### PR TITLE
Add go 1.23 in unit test coverage

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -19,6 +19,7 @@ jobs:
           - "macos-latest"
         go:
           - "1"
+          - "1.23"
           - "1.22"
           - "1.21"
       fail-fast: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced testing compatibility by adding support for Go version 1.23 in the workflow, ensuring better validation of the codebase with the latest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->