### PR TITLE
Implement missing Dump functionality for filesql migration

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -108,6 +108,7 @@ deps:
   memory-infra:
     canUse:
       - filesql
+      - excelize
     mayDependOn:
       - model
       - repository

--- a/infrastructure/filesql/file_interactor.go
+++ b/infrastructure/filesql/file_interactor.go
@@ -2,10 +2,20 @@ package filesql
 
 import (
 	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/usecase"
+	"github.com/xuri/excelize/v2"
+)
+
+const (
+	defaultExcelSheetName = "Sheet1"
 )
 
 // fileInteractor implements file format use cases using filesql
@@ -50,13 +60,114 @@ func (fi *fileInteractor) List(filePath string) (*model.Table, error) {
 	return fi.adapter.Query(ctx, query)
 }
 
-// Dump writes contents of DB table to file
-// For now, this maintains the same interface but will need to be implemented
-// based on the specific format requirements
-func (fi *fileInteractor) Dump(_ string, _ *model.Table) error {
-	// TODO: Implement dump functionality
-	// This would need to use filesql's save capabilities or fall back to existing logic
-	return &FileSQLError{Op: "dump", Err: "dump functionality not yet implemented with filesql"}
+// Dump writes contents of DB table to file in the format determined by file extension
+// Supports CSV, TSV, LTSV, and Markdown formats with automatic format detection
+func (fi *fileInteractor) Dump(filePath string, table *model.Table) error {
+	// Check for nil table
+	if table == nil {
+		return &FileSQLError{Op: "dump", Err: "table cannot be nil"}
+	}
+
+	// Validate and clean the file path
+	cleanPath, err := validateFilePath(filePath)
+	if err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("invalid file path: %v", err)}
+	}
+
+	// Create or open the output file
+	file, err := os.Create(cleanPath) // #nosec G304 - path is validated above
+	if err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to create file %s: %v", filePath, err)}
+	}
+	defer func() {
+		logCloseError("dump", file.Close())
+	}()
+
+	// Determine format from file extension and write accordingly
+	ext := strings.ToLower(filepath.Ext(cleanPath))
+	switch ext {
+	case ".csv":
+		return fi.dumpCSV(file, table)
+	case ".tsv":
+		return fi.dumpTSV(file, table)
+	case ".ltsv":
+		return fi.dumpLTSV(file, table)
+	case ".md", ".markdown":
+		return fi.dumpMarkdown(file, table)
+	default:
+		// Default to CSV format
+		return fi.dumpCSV(file, table)
+	}
+}
+
+// dumpCSV writes table data to file in CSV format
+func (fi *fileInteractor) dumpCSV(f *os.File, table *model.Table) error {
+	w := csv.NewWriter(f)
+
+	records := [][]string{
+		table.Header(),
+	}
+	for _, v := range table.Records() {
+		records = append(records, v)
+	}
+	//nolint:errcheck // WriteAll doesn't return errors, check w.Error() instead
+	_ = w.WriteAll(records)
+	if err := w.Error(); err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to write CSV: %v", err)}
+	}
+	return nil
+}
+
+// dumpTSV writes table data to file in TSV format
+func (fi *fileInteractor) dumpTSV(f *os.File, table *model.Table) error {
+	w := csv.NewWriter(f)
+	w.Comma = '\t'
+	records := make([][]string, 0, 1+len(table.Records()))
+	records = append(records, table.Header())
+	for _, v := range table.Records() {
+		records = append(records, v)
+	}
+	//nolint:errcheck // WriteAll doesn't return errors, check w.Error() instead
+	_ = w.WriteAll(records)
+	if err := w.Error(); err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to write TSV: %v", err)}
+	}
+	return nil
+}
+
+// dumpLTSV writes table data to file in LTSV format
+func (fi *fileInteractor) dumpLTSV(f *os.File, table *model.Table) error {
+	w := csv.NewWriter(f)
+	w.Comma = '\t'
+	records := make([][]string, 0, len(table.Records()))
+	hdr := table.Header()
+	for _, v := range table.Records() {
+		// Add bounds checking to prevent panic
+		maxLen := len(v)
+		if len(hdr) < maxLen {
+			maxLen = len(hdr)
+		}
+
+		r := make([]string, 0, maxLen)
+		for i := range maxLen {
+			r = append(r, hdr[i]+":"+v[i])
+		}
+		records = append(records, r)
+	}
+	//nolint:errcheck // WriteAll doesn't return errors, check w.Error() instead
+	_ = w.WriteAll(records)
+	if err := w.Error(); err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to write LTSV: %v", err)}
+	}
+	return nil
+}
+
+// dumpMarkdown writes table data to file in Markdown table format
+func (fi *fileInteractor) dumpMarkdown(f *os.File, table *model.Table) error {
+	// Use the existing printMarkdownTable method from the domain model
+	// Note: table.Print doesn't return errors, it writes directly to the writer
+	table.Print(f, model.PrintModeMarkdownTable)
+	return nil
 }
 
 // excelInteractor implements Excel-specific use cases using filesql
@@ -83,9 +194,139 @@ func (ei *excelInteractor) List(excelFilePath, sheetName string) (*model.Table, 
 }
 
 // Dump writes contents of DB table to Excel file
-func (ei *excelInteractor) Dump(_ string, _ *model.Table) error {
-	// TODO: Implement Excel dump functionality
-	return &FileSQLError{Op: "dump", Err: "Excel dump functionality not yet implemented with filesql"}
+func (ei *excelInteractor) Dump(filePath string, table *model.Table) error {
+	// Check for nil table
+	if table == nil {
+		return &FileSQLError{Op: "dump", Err: "table cannot be nil"}
+	}
+
+	// Validate and clean the file path
+	cleanPath, err := validateFilePath(filePath)
+	if err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("invalid file path: %v", err)}
+	}
+
+	// Use excelize library to create Excel file
+	f := excelize.NewFile()
+	defer func() {
+		logCloseError("excel dump", f.Close())
+	}()
+
+	// Sanitize the table name for Excel sheet name
+	sheetName := sanitizeExcelSheetName(table.Name())
+
+	// Handle Sheet1 collision by using alternative name
+	if sheetName == defaultExcelSheetName {
+		sheetName = defaultExcelSheetName + "_1"
+	}
+
+	// Create a new sheet with the sanitized name
+	idx, err := f.NewSheet(sheetName)
+	if err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to create sheet: %v", err)}
+	}
+
+	// Delete default sheet
+	if err := f.DeleteSheet(defaultExcelSheetName); err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to delete default sheet: %v", err)}
+	}
+
+	// Set the newly created sheet as active
+	f.SetActiveSheet(idx)
+
+	// Write header - optimize by directly converting slice
+	headerSlice := table.Header()
+	header := make([]any, len(headerSlice))
+	for i, h := range headerSlice {
+		header[i] = h
+	}
+	if err := f.SetSheetRow(sheetName, "A1", &header); err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to write header: %v", err)}
+	}
+
+	// Write records - optimize by directly converting each record
+	for i, record := range table.Records() {
+		row := make([]any, len(record))
+		for j, c := range record {
+			row[j] = c
+		}
+		if err := f.SetSheetRow(sheetName, fmt.Sprintf("A%d", i+2), &row); err != nil {
+			return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to write record %d: %v", i, err)}
+		}
+	}
+
+	// Save the file using validated path
+	if err := f.SaveAs(cleanPath); err != nil {
+		return &FileSQLError{Op: "dump", Err: fmt.Sprintf("failed to save Excel file: %v", err)}
+	}
+
+	return nil
+}
+
+// sanitizeExcelSheetName sanitizes a table name for use as an Excel sheet name
+// Excel sheet names have restrictions:
+// - Max 31 characters
+// - Cannot contain: / \ ? * [ ] :
+// - Cannot be empty
+func sanitizeExcelSheetName(name string) string {
+	if name == "" {
+		return defaultExcelSheetName
+	}
+
+	// Replace invalid characters with underscores
+	invalidChars := []string{"/", "\\", "?", "*", "[", "]", ":"}
+	sanitized := name
+	for _, char := range invalidChars {
+		sanitized = strings.ReplaceAll(sanitized, char, "_")
+	}
+
+	// Trim to max length (31 characters)
+	if len(sanitized) > 31 {
+		sanitized = sanitized[:31]
+	}
+
+	// Ensure it's not empty after sanitization
+	if strings.TrimSpace(sanitized) == "" {
+		sanitized = defaultExcelSheetName
+	}
+
+	return sanitized
+}
+
+// validateFilePath validates and cleans the file path to prevent directory traversal attacks
+func validateFilePath(filePath string) (string, error) {
+	// Clean the path
+	cleanPath := filepath.Clean(filePath)
+
+	// Check for directory traversal attempts by inspecting path segments
+	for _, seg := range strings.Split(cleanPath, string(filepath.Separator)) {
+		if seg == ".." {
+			return "", errors.New("invalid file path: directory traversal not allowed")
+		}
+	}
+
+	// Check if path is absolute and potentially dangerous
+	if filepath.IsAbs(cleanPath) {
+		// For absolute paths, ensure they don't point to system directories
+		systemDirs := []string{"/etc", "/bin", "/sbin", "/usr/bin", "/usr/sbin", "/sys", "/proc"}
+		for _, sysDir := range systemDirs {
+			if strings.HasPrefix(cleanPath, sysDir) {
+				return "", errors.New("invalid file path: access to system directories not allowed")
+			}
+		}
+	}
+
+	return cleanPath, nil
+}
+
+// logCloseError logs file close errors that occur in defer statements
+// Following project guideline to never omit error handling
+func logCloseError(op string, err error) {
+	if err != nil {
+		// In a production environment, this would use a proper logger
+		// For now, we use fmt.Fprintf to stderr as per project conventions
+		fmt.Fprintf(os.Stderr, "Warning: failed to close file during %s: %v\n", op, err)
+	}
 }
 
 // GetSheetNames returns all sheet names in an Excel file

--- a/infrastructure/filesql/file_interactor_test.go
+++ b/infrastructure/filesql/file_interactor_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nao1215/sqly/domain/model"
+	"github.com/xuri/excelize/v2"
 	_ "modernc.org/sqlite"
 )
 
@@ -153,15 +155,162 @@ func TestFileInteractor_Dump(t *testing.T) {
 	adapter := NewFileSQLAdapter(sharedDB)
 	interactor := NewCSVInteractor(adapter)
 
-	// Test Dump - should return not implemented error
-	err = interactor.Dump("output.csv", nil)
-	if err == nil {
-		t.Fatal("Expected Dump to return error for not implemented functionality")
-	}
+	t.Run("nil table", func(t *testing.T) {
+		t.Parallel()
+		err = interactor.Dump("output.csv", nil)
+		if err == nil {
+			t.Fatal("Expected Dump to return error for nil table")
+		}
 
-	if !strings.Contains(err.Error(), "not yet implemented") {
-		t.Errorf("Expected 'not yet implemented' error, got: %v", err)
+		if !strings.Contains(err.Error(), "table cannot be nil") {
+			t.Errorf("Expected 'table cannot be nil' error, got: %v", err)
+		}
+	})
+
+	// Create test table for successful dump tests
+	header := model.NewHeader([]string{"name", "age", "city"})
+	records := []model.Record{
+		model.NewRecord([]string{"John", "25", "New York"}),
+		model.NewRecord([]string{"Jane", "30", "Los Angeles"}),
+		model.NewRecord([]string{"Bob", "35", "Chicago"}),
 	}
+	testTable := model.NewTable("test_table", header, records)
+
+	t.Run("CSV dump", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		csvFile := filepath.Join(tempDir, "test.csv")
+
+		err := interactor.Dump(csvFile, testTable)
+		if err != nil {
+			t.Fatalf("CSV dump failed: %v", err)
+		}
+
+		// Verify file contents
+		content, err := os.ReadFile(csvFile) // #nosec G304 - test file in temp dir
+		if err != nil {
+			t.Fatalf("Failed to read CSV file: %v", err)
+		}
+
+		expected := "name,age,city\nJohn,25,New York\nJane,30,Los Angeles\nBob,35,Chicago\n"
+		if string(content) != expected {
+			t.Errorf("CSV content mismatch.\nExpected: %q\nGot: %q", expected, string(content))
+		}
+	})
+
+	t.Run("TSV dump", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		tsvFile := filepath.Join(tempDir, "test.tsv")
+
+		err := interactor.Dump(tsvFile, testTable)
+		if err != nil {
+			t.Fatalf("TSV dump failed: %v", err)
+		}
+
+		// Verify file contents
+		content, err := os.ReadFile(tsvFile) // #nosec G304 - test file in temp dir
+		if err != nil {
+			t.Fatalf("Failed to read TSV file: %v", err)
+		}
+
+		expected := "name\tage\tcity\nJohn\t25\tNew York\nJane\t30\tLos Angeles\nBob\t35\tChicago\n"
+		if string(content) != expected {
+			t.Errorf("TSV content mismatch.\nExpected: %q\nGot: %q", expected, string(content))
+		}
+	})
+
+	t.Run("LTSV dump", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		ltsvFile := filepath.Join(tempDir, "test.ltsv")
+
+		err := interactor.Dump(ltsvFile, testTable)
+		if err != nil {
+			t.Fatalf("LTSV dump failed: %v", err)
+		}
+
+		// Verify file contents
+		content, err := os.ReadFile(ltsvFile) // #nosec G304 - test file in temp dir
+		if err != nil {
+			t.Fatalf("Failed to read LTSV file: %v", err)
+		}
+
+		lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+		if len(lines) != 3 {
+			t.Fatalf("Expected 3 lines, got %d", len(lines))
+		}
+
+		// Check first line format
+		expected := "name:John\tage:25\tcity:New York"
+		if lines[0] != expected {
+			t.Errorf("LTSV first line mismatch.\nExpected: %q\nGot: %q", expected, lines[0])
+		}
+	})
+
+	t.Run("Markdown dump", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		mdFile := filepath.Join(tempDir, "test.md")
+
+		err := interactor.Dump(mdFile, testTable)
+		if err != nil {
+			t.Fatalf("Markdown dump failed: %v", err)
+		}
+
+		// Verify file was created and has content
+		content, err := os.ReadFile(mdFile) // #nosec G304 - test file in temp dir
+		if err != nil {
+			t.Fatalf("Failed to read Markdown file: %v", err)
+		}
+
+		if len(content) == 0 {
+			t.Error("Markdown file is empty")
+		}
+
+		// Check for markdown table format
+		contentStr := string(content)
+		if !strings.Contains(contentStr, "|") {
+			t.Error("Markdown content doesn't contain table separators")
+		}
+	})
+
+	t.Run("default format (unknown extension)", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		unknownFile := filepath.Join(tempDir, "test.unknown")
+
+		err := interactor.Dump(unknownFile, testTable)
+		if err != nil {
+			t.Fatalf("Unknown format dump failed: %v", err)
+		}
+
+		// Should default to CSV format
+		content, err := os.ReadFile(unknownFile) // #nosec G304 - test file in temp dir
+		if err != nil {
+			t.Fatalf("Failed to read unknown format file: %v", err)
+		}
+
+		expected := "name,age,city\nJohn,25,New York\nJane,30,Los Angeles\nBob,35,Chicago\n"
+		if string(content) != expected {
+			t.Errorf("Default format content mismatch.\nExpected: %q\nGot: %q", expected, string(content))
+		}
+	})
+
+	t.Run("invalid file path", func(t *testing.T) {
+		t.Parallel()
+		// Try to write to a directory that doesn't exist (cross-platform)
+		invalidPath := filepath.Join(t.TempDir(), "no_such_dir", "test.csv")
+
+		err := interactor.Dump(invalidPath, testTable)
+		if err == nil {
+			t.Fatal("Expected error for invalid file path")
+		}
+
+		if !strings.Contains(err.Error(), "failed to create file") {
+			t.Errorf("Expected file creation error, got: %v", err)
+		}
+	})
 }
 
 func TestExcelInteractor_List(t *testing.T) {
@@ -196,9 +345,7 @@ func TestExcelInteractor_List(t *testing.T) {
 	}
 
 	// The error should be about file loading, not table querying
-	if !strings.Contains(err.Error(), "failed to load") && !strings.Contains(err.Error(), "stream") {
-		t.Logf("Got expected error for non-existent file: %v", err)
-	}
+	t.Logf("Got error for non-existent file (expected): %v", err)
 }
 
 func TestExcelInteractor_Dump(t *testing.T) {
@@ -213,15 +360,157 @@ func TestExcelInteractor_Dump(t *testing.T) {
 	adapter := NewFileSQLAdapter(sharedDB)
 	interactor := NewExcelInteractor(adapter)
 
-	// Test Dump - should return not implemented error
-	err = interactor.Dump("output.xlsx", nil)
-	if err == nil {
-		t.Fatal("Expected Dump to return error for not implemented functionality")
-	}
+	t.Run("nil table", func(t *testing.T) {
+		t.Parallel()
+		err = interactor.Dump("output.xlsx", nil)
+		if err == nil {
+			t.Fatal("Expected Dump to return error for nil table")
+		}
 
-	if !strings.Contains(err.Error(), "not yet implemented") {
-		t.Errorf("Expected 'not yet implemented' error, got: %v", err)
+		if !strings.Contains(err.Error(), "table cannot be nil") {
+			t.Errorf("Expected 'table cannot be nil' error, got: %v", err)
+		}
+	})
+
+	// Create test table for successful dump tests
+	header := model.NewHeader([]string{"name", "age", "city"})
+	records := []model.Record{
+		model.NewRecord([]string{"John", "25", "New York"}),
+		model.NewRecord([]string{"Jane", "30", "Los Angeles"}),
+		model.NewRecord([]string{"Bob", "35", "Chicago"}),
 	}
+	testTable := model.NewTable("test_data", header, records)
+
+	t.Run("successful Excel dump", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		excelFile := filepath.Join(tempDir, "test.xlsx")
+
+		err := interactor.Dump(excelFile, testTable)
+		if err != nil {
+			t.Fatalf("Excel dump failed: %v", err)
+		}
+
+		// Verify file was created
+		if _, err := os.Stat(excelFile); os.IsNotExist(err) {
+			t.Error("Excel file was not created")
+		}
+
+		// Try to open and read the Excel file to verify contents
+		f, err := excelize.OpenFile(excelFile)
+		if err != nil {
+			t.Fatalf("Failed to open Excel file: %v", err)
+		}
+		defer f.Close()
+
+		// Check sheet exists
+		sheets := f.GetSheetList()
+		if len(sheets) == 0 {
+			t.Fatal("No sheets found in Excel file")
+		}
+
+		sheetName := "test_data"
+		if !contains(sheets, sheetName) {
+			t.Errorf("Expected sheet %q not found. Available sheets: %v", sheetName, sheets)
+		}
+
+		// Check header row
+		headerRow, err := f.GetRows(sheetName)
+		if err != nil {
+			t.Fatalf("Failed to get rows from Excel file: %v", err)
+		}
+
+		if len(headerRow) < 1 {
+			t.Fatal("Excel file has no rows")
+		}
+
+		expectedHeader := []string{"name", "age", "city"}
+		if !equalSlices(headerRow[0], expectedHeader) {
+			t.Errorf("Header mismatch. Expected: %v, Got: %v", expectedHeader, headerRow[0])
+		}
+
+		// Check data rows
+		if len(headerRow) != 4 { // header + 3 data rows
+			t.Errorf("Expected 4 rows (header + 3 data), got %d", len(headerRow))
+		}
+	})
+
+	t.Run("Excel dump with special characters in table name", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		excelFile := filepath.Join(tempDir, "special.xlsx")
+
+		// Create table with problematic name
+		specialHeader := model.NewHeader([]string{"col1", "col2"})
+		specialRecords := []model.Record{model.NewRecord([]string{"val1", "val2"})}
+		specialTable := model.NewTable("test-table.with/special:chars", specialHeader, specialRecords)
+
+		err := interactor.Dump(excelFile, specialTable)
+		if err != nil {
+			t.Fatalf("Excel dump with special chars failed: %v", err)
+		}
+
+		// Verify file was created
+		if _, err := os.Stat(excelFile); os.IsNotExist(err) {
+			t.Error("Excel file with special chars was not created")
+		}
+	})
+
+	t.Run("Excel dump with empty table", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+		excelFile := filepath.Join(tempDir, "empty.xlsx")
+
+		emptyHeader := model.NewHeader([]string{"col1", "col2"})
+		emptyRecords := []model.Record{}
+		emptyTable := model.NewTable("empty_table", emptyHeader, emptyRecords)
+
+		err := interactor.Dump(excelFile, emptyTable)
+		if err != nil {
+			t.Fatalf("Excel dump with empty table failed: %v", err)
+		}
+
+		// Verify file was created
+		if _, err := os.Stat(excelFile); os.IsNotExist(err) {
+			t.Error("Excel file with empty table was not created")
+		}
+	})
+
+	t.Run("invalid file path", func(t *testing.T) {
+		t.Parallel()
+		invalidPath := filepath.Join(t.TempDir(), "no_such_dir", "test.xlsx")
+
+		err := interactor.Dump(invalidPath, testTable)
+		if err == nil {
+			t.Fatal("Expected error for invalid file path")
+		}
+
+		if !strings.Contains(err.Error(), "failed to save Excel file") {
+			t.Errorf("Expected save Excel file error, got: %v", err)
+		}
+	})
+}
+
+// Helper functions for tests
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestExcelInteractor_GetSheetNames(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Export tables to CSV, TSV, LTSV, Markdown, and Excel (.xlsx); format selected via file extension. Excel exports sanitize sheet names and preserve headers/rows.
- Bug Fixes
  - Clear error when dumping a nil table; invalid/unsafe file paths are rejected. Markdown output now handled consistently via the CSV-backed flow.
- Tests
  - Expanded coverage for all formats and Excel, including special-character names, empty tables, and invalid paths.
- Chores
  - Configuration updated to permit Excel library usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->