### PR TITLE
fix(shell): stabilize multiline prompt input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+* **Shell Prompt Session**: Reuse a single `sqly-shell` prompt across interactive commands so multiline SQL, history preload, and completion state no longer depend on per-command prompt teardown workarounds.
+
 ### Refactoring
 * **Session Usecase Boundaries**: Split the monolithic database usecase into focused `QueryUsecase`, `ImportUsecase`, and `MetadataUsecase` interfaces so each shell command depends only on the capability it uses. Behavior is unchanged.
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/nao1215/filesql v0.12.2
-	github.com/nao1215/prompt v0.0.4
+	github.com/nao1215/prompt v0.0.5
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,6 @@ github.com/nao1215/fileparser v0.5.1 h1:cbig0/kfl0HoPsrdK7VGvfj15iMnwknKWv3u/4i0
 github.com/nao1215/fileparser v0.5.1/go.mod h1:u/OKOYKZ2VJ+PHyQ9lNP3FuCTelJjP3YRlQEoKsFBJ4=
 github.com/nao1215/filesql v0.12.2 h1:+Us9bArJZ00L7gKLVeeGZhgomYRxRlQA9O97po4F9hI=
 github.com/nao1215/filesql v0.12.2/go.mod h1:T4HUV3foansrZFV/uQAoKisWPgv3W3LBSGjJg9PMGP0=
-github.com/nao1215/prompt v0.0.4 h1:NnqExDcQ+oyc1OlPcGmcKiCLNsTPhMKaP/zUaJPstk8=
-github.com/nao1215/prompt v0.0.4/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/nao1215/prompt v0.0.5 h1:W3B7rgrotlpxheJW9IMYTbfNZCXNm1lEHx1Gu8rpMzw=
 github.com/nao1215/prompt v0.0.5/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/nao1215/filesql v0.12.2 h1:+Us9bArJZ00L7gKLVeeGZhgomYRxRlQA9O97po4F9h
 github.com/nao1215/filesql v0.12.2/go.mod h1:T4HUV3foansrZFV/uQAoKisWPgv3W3LBSGjJg9PMGP0=
 github.com/nao1215/prompt v0.0.4 h1:NnqExDcQ+oyc1OlPcGmcKiCLNsTPhMKaP/zUaJPstk8=
 github.com/nao1215/prompt v0.0.4/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
+github.com/nao1215/prompt v0.0.5 h1:W3B7rgrotlpxheJW9IMYTbfNZCXNm1lEHx1Gu8rpMzw=
+github.com/nao1215/prompt v0.0.5/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -127,7 +127,11 @@ func (s *Shell) communicate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = p.Close() }()
+	defer func() {
+		if err := p.Close(); err != nil {
+			fmt.Fprintf(config.Stderr, "failed to close prompt session: %v\n", err)
+		}
+	}()
 
 	for {
 		input, err := s.prompt(p)
@@ -154,7 +158,9 @@ func (s *Shell) newPromptSession(ctx context.Context) (promptSession, error) {
 
 	histories, err := s.usecases.history.List(ctx)
 	if err != nil {
-		_ = p.Close()
+		if errClose := p.Close(); errClose != nil {
+			return nil, errors.Join(err, fmt.Errorf("failed to close prompt session: %w", errClose))
+		}
 		return nil, err
 	}
 	for _, h := range histories.ToStringList() {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -45,12 +45,22 @@ const (
 // Shell is main class of the sqly command.
 // Shell is the interface to the user and requests processing from the usecase layer.
 type Shell struct {
-	argument *config.Arg
-	config   *config.Config
-	commands CommandList
-	usecases Usecases
-	state    *state
+	argument  *config.Arg
+	config    *config.Config
+	commands  CommandList
+	usecases  Usecases
+	state     *state
+	newPrompt promptFactory
 }
+
+type promptSession interface {
+	AddHistory(string)
+	Close() error
+	Run() (string, error)
+	SetPrefix(string)
+}
+
+type promptFactory func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error)
 
 // NewShell return *Shell.
 func NewShell(
@@ -69,6 +79,17 @@ func NewShell(
 		commands: cmds,
 		usecases: usecases,
 		state:    state,
+		newPrompt: func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+			const historySize = 100
+
+			return prompt.New(
+				prefix,
+				prompt.WithCompleter(completer),
+				prompt.WithMemoryHistory(historySize),
+				prompt.WithTheme(prompt.ThemeNightOwl),
+				prompt.WithMultiline(true),
+			)
+		},
 	}, nil
 }
 
@@ -102,8 +123,14 @@ func (s *Shell) Run(ctx context.Context) error {
 // This function receive user input (it's SQL query or helper command) and
 // request the usecase layer to process it.
 func (s *Shell) communicate(ctx context.Context) error {
+	p, err := s.newPromptSession(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Close() }()
+
 	for {
-		input, err := s.prompt(ctx)
+		input, err := s.prompt(p)
 		if err != nil {
 			return err
 		}
@@ -115,6 +142,26 @@ func (s *Shell) communicate(ctx context.Context) error {
 			continue
 		}
 	}
+}
+
+func (s *Shell) newPromptSession(ctx context.Context) (promptSession, error) {
+	p, err := s.newPrompt(s.promptPrefix(), func(d prompt.Document) []prompt.Suggestion {
+		return s.completerNew(ctx, d.Text)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	histories, err := s.usecases.history.List(ctx)
+	if err != nil {
+		_ = p.Close()
+		return nil, err
+	}
+	for _, h := range histories.ToStringList() {
+		p.AddHistory(h)
+	}
+
+	return p, nil
 }
 
 // init store CSV data to in-memory DB and create table for sqly history.
@@ -139,43 +186,13 @@ func (s *Shell) printWelcomeMessage() {
 }
 
 // printPrompt print "sqly>" prompt and getting user input
-func (s *Shell) prompt(ctx context.Context) (string, error) {
-	histories, err := s.usecases.history.List(ctx)
-	if err != nil {
-		return "", err
-	}
+func (s *Shell) prompt(p promptSession) (string, error) {
+	p.SetPrefix(s.promptPrefix())
+	return p.Run()
+}
 
-	const historySize = 100
-	p, err := prompt.New(
-		fmt.Sprintf("sqly:%s(%s)$ ", s.state.shortCWD(), s.state.mode.String()),
-		prompt.WithCompleter(func(d prompt.Document) []prompt.Suggestion {
-			return s.completerNew(ctx, d.Text)
-		}),
-		prompt.WithMemoryHistory(historySize),
-		prompt.WithTheme(prompt.ThemeNightOwl),
-		prompt.WithMultiline(true),
-	)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = p.Close() }()
-
-	// Add existing history entries to the prompt
-	for _, h := range histories.ToStringList() {
-		p.AddHistory(h)
-	}
-
-	result, err := p.Run()
-	if err != nil {
-		return "", err
-	}
-
-	// The new prompt library seems to output an extra newline after input.
-	// We need to move the cursor up one line to eliminate this extra space.
-	fmt.Print("\033[1A") // Move cursor up one line
-
-	// Trim any trailing newlines or whitespace that might be added by the prompt library
-	return strings.TrimSpace(result), nil
+func (s *Shell) promptPrefix() string {
+	return fmt.Sprintf("sqly:%s(%s)$ ", s.state.shortCWD(), s.state.mode.String())
 }
 
 // Suggest is a local struct to maintain compatibility with old code structure

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/nao1215/prompt"
 	"github.com/nao1215/sqly/config"
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/golden"
@@ -1164,6 +1166,203 @@ func getExecStdOutput(t *testing.T, f func(context.Context, string) error, arg s
 
 	execErr := f(context.Background(), arg)
 	return buffer.Bytes(), execErr
+}
+
+type fakePromptSession struct {
+	results         []string
+	addedHistories  []string
+	prefixes        []string
+	closeCalls      int
+	runCalls        int
+	initialPrefix   string
+	capturedSuggest []prompt.Suggestion
+}
+
+func (f *fakePromptSession) AddHistory(history string) {
+	f.addedHistories = append(f.addedHistories, history)
+}
+
+func (f *fakePromptSession) Close() error {
+	f.closeCalls++
+	return nil
+}
+
+func (f *fakePromptSession) Run() (string, error) {
+	if f.runCalls >= len(f.results) {
+		return "", io.EOF
+	}
+
+	result := f.results[f.runCalls]
+	f.runCalls++
+	return result, nil
+}
+
+func (f *fakePromptSession) SetPrefix(prefix string) {
+	f.prefixes = append(f.prefixes, prefix)
+}
+
+func captureOSStdout(t *testing.T, f func()) string {
+	t.Helper()
+
+	backupStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.Stdout = backupStdout
+	}()
+
+	os.Stdout = writer
+	f()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func hasPromptSuggestion(suggestions []prompt.Suggestion, text string) bool {
+	for _, suggestion := range suggestions {
+		if suggestion.Text == text {
+			return true
+		}
+	}
+	return false
+}
+
+func TestShellCommunicate_ReusesPromptSessionForMultilineSQL(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if err := shell.recordUserRequest(context.Background(), "SELECT 0 AS n"); err != nil {
+		t.Fatal(err)
+	}
+
+	fakePrompt := &fakePromptSession{
+		results: []string{
+			"SELECT 1 AS n\nUNION ALL\nSELECT 2 AS n",
+			".exit",
+		},
+	}
+	factoryCalls := 0
+	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+		factoryCalls++
+		fakePrompt.initialPrefix = prefix
+		return fakePrompt, nil
+	}
+
+	backupStdout := config.Stdout
+	defer func() {
+		config.Stdout = backupStdout
+	}()
+
+	var queryOutput bytes.Buffer
+	config.Stdout = &queryOutput
+
+	terminalOutput := captureOSStdout(t, func() {
+		if err := shell.communicate(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if factoryCalls != 1 {
+		t.Fatalf("prompt factory called %d times, want 1", factoryCalls)
+	}
+	if fakePrompt.closeCalls != 1 {
+		t.Fatalf("prompt close calls = %d, want 1", fakePrompt.closeCalls)
+	}
+	if fakePrompt.runCalls != 2 {
+		t.Fatalf("prompt run calls = %d, want 2", fakePrompt.runCalls)
+	}
+	if len(fakePrompt.addedHistories) != 1 || fakePrompt.addedHistories[0] != "SELECT 0 AS n" {
+		t.Fatalf("preloaded histories = %#v, want only persisted history", fakePrompt.addedHistories)
+	}
+	if strings.Contains(terminalOutput, "\x1b[1A") {
+		t.Fatalf("terminal output contains removed cursor workaround: %q", terminalOutput)
+	}
+	if !strings.Contains(queryOutput.String(), "1") || !strings.Contains(queryOutput.String(), "2") {
+		t.Fatalf("multiline SQL output missing expected rows: %q", queryOutput.String())
+	}
+}
+
+func TestShellCommunicate_PreloadsHistoryAndCompletion(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if err := shell.recordUserRequest(context.Background(), "SELECT 9 AS n"); err != nil {
+		t.Fatal(err)
+	}
+
+	fakePrompt := &fakePromptSession{results: []string{".exit"}}
+	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+		fakePrompt.initialPrefix = prefix
+		fakePrompt.capturedSuggest = completer(prompt.Document{
+			Text:           "SEL",
+			CursorPosition: 3,
+		})
+		return fakePrompt, nil
+	}
+
+	if err := shell.communicate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(fakePrompt.initialPrefix, "(table)") {
+		t.Fatalf("initial prefix = %q, want table mode prompt", fakePrompt.initialPrefix)
+	}
+	if len(fakePrompt.addedHistories) != 1 || fakePrompt.addedHistories[0] != "SELECT 9 AS n" {
+		t.Fatalf("preloaded histories = %#v, want persisted command", fakePrompt.addedHistories)
+	}
+	if !hasPromptSuggestion(fakePrompt.capturedSuggest, "SELECT") {
+		t.Fatalf("captured suggestions = %#v, want SELECT completion", fakePrompt.capturedSuggest)
+	}
+}
+
+func TestShellCommunicate_RefreshesPromptPrefixBetweenRuns(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	fakePrompt := &fakePromptSession{
+		results: []string{
+			".mode csv",
+			".exit",
+		},
+	}
+	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+		fakePrompt.initialPrefix = prefix
+		return fakePrompt, nil
+	}
+
+	if err := shell.communicate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fakePrompt.prefixes) != 2 {
+		t.Fatalf("prompt prefixes = %#v, want 2 prompt updates", fakePrompt.prefixes)
+	}
+	if !strings.Contains(fakePrompt.prefixes[0], "(table)") {
+		t.Fatalf("first prefix = %q, want table mode", fakePrompt.prefixes[0])
+	}
+	if !strings.Contains(fakePrompt.prefixes[1], "(csv)") {
+		t.Fatalf("second prefix = %q, want csv mode", fakePrompt.prefixes[1])
+	}
 }
 
 func TestTrimGaps(t *testing.T) {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1364,7 +1364,7 @@ func TestShellCommunicate_RefreshesPromptPrefixBetweenRuns(t *testing.T) {
 			".exit",
 		},
 	}
-	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+	shell.newPrompt = func(prefix string, _ func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
 		fakePrompt.initialPrefix = prefix
 		return fakePrompt, nil
 	}
@@ -1395,7 +1395,7 @@ func TestShellCommunicate_LogsPromptCloseError(t *testing.T) {
 		results:  []string{".exit"},
 		closeErr: errors.New("prompt close failed"),
 	}
-	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+	shell.newPrompt = func(_ string, _ func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
 		return fakePrompt, nil
 	}
 
@@ -1429,7 +1429,7 @@ func TestShellNewPromptSession_JoinsCloseErrorOnHistoryFailure(t *testing.T) {
 	listErr := errors.New("history list failed")
 	closeErr := errors.New("prompt close failed")
 	fakePrompt := &fakePromptSession{closeErr: closeErr}
-	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+	shell.newPrompt = func(_ string, _ func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
 		return fakePrompt, nil
 	}
 	shell.usecases.history = historyUsecaseStub{listErr: listErr}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -1173,6 +1174,7 @@ type fakePromptSession struct {
 	addedHistories  []string
 	prefixes        []string
 	closeCalls      int
+	closeErr        error
 	runCalls        int
 	initialPrefix   string
 	capturedSuggest []prompt.Suggestion
@@ -1184,7 +1186,7 @@ func (f *fakePromptSession) AddHistory(history string) {
 
 func (f *fakePromptSession) Close() error {
 	f.closeCalls++
-	return nil
+	return f.closeErr
 }
 
 func (f *fakePromptSession) Run() (string, error) {
@@ -1236,6 +1238,23 @@ func hasPromptSuggestion(suggestions []prompt.Suggestion, text string) bool {
 		}
 	}
 	return false
+}
+
+type historyUsecaseStub struct {
+	histories model.Histories
+	listErr   error
+}
+
+func (h historyUsecaseStub) CreateTable(context.Context) error {
+	return nil
+}
+
+func (h historyUsecaseStub) Create(context.Context, model.History) error {
+	return nil
+}
+
+func (h historyUsecaseStub) List(context.Context) (model.Histories, error) {
+	return h.histories, h.listErr
 }
 
 func TestShellCommunicate_ReusesPromptSessionForMultilineSQL(t *testing.T) {
@@ -1362,6 +1381,71 @@ func TestShellCommunicate_RefreshesPromptPrefixBetweenRuns(t *testing.T) {
 	}
 	if !strings.Contains(fakePrompt.prefixes[1], "(csv)") {
 		t.Fatalf("second prefix = %q, want csv mode", fakePrompt.prefixes[1])
+	}
+}
+
+func TestShellCommunicate_LogsPromptCloseError(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	fakePrompt := &fakePromptSession{
+		results:  []string{".exit"},
+		closeErr: errors.New("prompt close failed"),
+	}
+	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+		return fakePrompt, nil
+	}
+
+	backupStderr := config.Stderr
+	defer func() {
+		config.Stderr = backupStderr
+	}()
+
+	var stderr bytes.Buffer
+	config.Stderr = &stderr
+
+	if err := shell.communicate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if fakePrompt.closeCalls != 1 {
+		t.Fatalf("prompt close calls = %d, want 1", fakePrompt.closeCalls)
+	}
+	if !strings.Contains(stderr.String(), "failed to close prompt session: prompt close failed") {
+		t.Fatalf("stderr = %q, want prompt close warning", stderr.String())
+	}
+}
+
+func TestShellNewPromptSession_JoinsCloseErrorOnHistoryFailure(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	listErr := errors.New("history list failed")
+	closeErr := errors.New("prompt close failed")
+	fakePrompt := &fakePromptSession{closeErr: closeErr}
+	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+		return fakePrompt, nil
+	}
+	shell.usecases.history = historyUsecaseStub{listErr: listErr}
+
+	_, err = shell.newPromptSession(context.Background())
+	if err == nil {
+		t.Fatal("newPromptSession returned nil error")
+	}
+	if !errors.Is(err, listErr) {
+		t.Fatalf("error %v does not include history list failure", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("error %v does not include prompt close failure", err)
+	}
+	if fakePrompt.closeCalls != 1 {
+		t.Fatalf("prompt close calls = %d, want 1", fakePrompt.closeCalls)
 	}
 }
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1275,7 +1275,7 @@ func TestShellCommunicate_ReusesPromptSessionForMultilineSQL(t *testing.T) {
 		},
 	}
 	factoryCalls := 0
-	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+	shell.newPrompt = func(prefix string, _ func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
 		factoryCalls++
 		fakePrompt.initialPrefix = prefix
 		return fakePrompt, nil


### PR DESCRIPTION
## Summary
Stabilize interactive shell input by reusing a single prompt session across commands and by updating `github.com/nao1215/prompt` to `v0.0.5`.
This removes the per-command prompt teardown workaround and keeps multiline pasted SQL, history preload, and completion behavior consistent.

## Changes
- reuse one prompt session for the lifetime of the interactive shell loop
- preload shell history once when the prompt session starts instead of rebuilding prompt state every command
- refresh the prompt prefix before each run so `.mode` changes still update the prompt label
- remove the cursor-up and `TrimSpace` workarounds that depended on prompt recreation
- add regression tests for prompt reuse, history preload, completion wiring, and prefix refresh
- upgrade `github.com/nao1215/prompt` from `v0.0.4` to `v0.0.5`

## Design Decisions
- keep the shell-side prompt lifecycle fix even after the upstream `prompt` release because it removes redundant setup and avoids reloading history on every command
- depend on the released `prompt v0.0.5` tag instead of a local replace so the fix is reproducible in CI and downstream builds

## Limitations
- this PR does not change other shell input flows outside the interactive prompt loop

Closes #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive shell now reuses a single prompt session across commands, fixing multiline SQL input, preserving history, and keeping completion state consistent.

* **Tests**
  * Added tests for prompt-session reuse, history preload, completion suggestions, prompt prefix refresh between modes, and prompt-session lifecycle/error handling.

* **Chores**
  * Updated dependency: github.com/nao1215/prompt → v0.0.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqly/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->