### PR TITLE
feat(shell): add non-TTY batch mode and quoted helper-command parsing

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -19,6 +19,7 @@ vendors:
   excelize: { in: github.com/xuri/excelize/v2 }
   gomock: { in: go.uber.org/mock/gomock }
   prompt: { in: github.com/nao1215/prompt }
+  term: { in: golang.org/x/term }
   filesql: { in: github.com/nao1215/filesql }
   fileparser: { in: github.com/nao1215/fileparser }
 
@@ -73,6 +74,7 @@ deps:
       - env
       - sqlite
       - wire
+      - term
   model:
     canUse:
       - tablewriter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### New Features
+* **Non-TTY Batch Mode**: When stdin is piped or redirected, sqly reads SQL and helper commands from stdin line by line. A failed command exits non-zero, so batch runs are scriptable (e.g. `echo 'SELECT * FROM sample' | sqly sample.csv`).
+* **Quoted Helper-Command Arguments**: Helper commands honor single quotes, double quotes, and backslash-escaped whitespace, so file paths and `--sheet` values can contain spaces (e.g. `.import "my data.csv"`, `.import --sheet "Q1 Sales" report.xlsx`). The separated `--sheet NAME` form is now accepted alongside `--sheet=NAME`.
+
 ### Bug Fixes
 * **Shell Prompt Session**: Reuse a single `sqly-shell` prompt across interactive commands so multiline SQL, history preload, and completion state no longer depend on per-command prompt teardown workarounds.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ $ sqly --sql "SELECT user_name, position FROM user INNER JOIN identifier ON user
 +-----------+-----------+
 ```
 
+### Batch mode: pipe commands via stdin
+When standard input is not a terminal (piped or redirected), sqly reads SQL queries and shell commands from stdin, one per line, instead of starting the interactive shell. A failed command makes sqly exit non-zero, so batch runs are scriptable.
+
+```shell
+$ echo "SELECT * FROM user LIMIT 1" | sqly testdata/user.csv
+
+$ printf '.tables\nSELECT COUNT(*) FROM user\n' | sqly testdata/user.csv
+```
+
 ### Directory import
 You can import entire directories containing supported files. The sqly automatically detects all supported files (CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, Fedwire, including compressed versions) in the directory recursively and imports them:
 
@@ -124,6 +133,10 @@ Successfully imported 3 tables from directory ./csv_files: [users products order
 
 sqly:~/data$ .import file1.csv ./directory file2.tsv
 # Imports file1.csv, all files from directory, and file2.tsv
+
+# Quote arguments that contain spaces
+sqly:~/data$ .import "my data.csv"
+sqly:~/data$ .import --sheet "Q1 Sales" report.xlsx
 
 sqly:~/data$ .tables
 orders

--- a/config/argument.go
+++ b/config/argument.go
@@ -137,6 +137,8 @@ func usage(flag pflag.FlagSet) string {
 	s += "    sqly ./path/to/data/directory\n"
 	s += fmt.Sprintf("  - %s\n", color.HiYellowString("Mix files and directories"))
 	s += "    sqly file1.csv ./data_dir file2.tsv\n"
+	s += fmt.Sprintf("  - %s\n", color.HiYellowString("Batch mode: pipe SQL/commands via stdin (no TTY)"))
+	s += "    echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv\n"
 	s += "\n"
 	s += "[OPTIONS]\n"
 	s += flag.FlagUsages()

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -12,6 +12,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
     sqly ./path/to/data/directory
   - Mix files and directories
     sqly file1.csv ./data_dir file2.tsv
+  - Batch mode: pipe SQL/commands via stdin (no TTY)
+    echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv
 
 [OPTIONS]
   -c, --csv             change output format to csv (default: table)

--- a/config/tty.go
+++ b/config/tty.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// IsInputFromTTY reports whether standard input is connected to an interactive
+// terminal. The shell uses this to choose non-TTY batch mode: when stdin is
+// piped or redirected, commands are read from stdin instead of the prompt.
+func IsInputFromTTY() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/xuri/excelize/v2 v2.10.1
 	go.uber.org/mock v0.6.0
+	golang.org/x/term v0.42.0
 	modernc.org/sqlite v1.51.0
 )
 
@@ -72,7 +73,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260428171046-76f71b9afea0 // indirect
-	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -1,0 +1,47 @@
+package shell
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nao1215/sqly/config"
+)
+
+// maxBatchLineBytes caps a single batch input line, preventing unbounded memory
+// growth on input without newlines.
+const maxBatchLineBytes = 10 * 1024 * 1024
+
+// runBatch executes SQL queries and helper commands read from stdin, one per
+// line, until EOF. It is used when sqly runs without a TTY (piped stdin), where
+// the interactive prompt cannot start.
+//
+// Each non-empty line is executed via exec, so quoting rules match the
+// interactive shell. Errors are reported to stderr but do not stop processing;
+// if any line failed, runBatch returns an error so the process exits non-zero.
+// A line of ".exit" stops processing early with a success status, mirroring the
+// interactive shell.
+func (s *Shell) runBatch(ctx context.Context) error {
+	scanner := bufio.NewScanner(s.stdin)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxBatchLineBytes)
+
+	failed := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if err := s.exec(ctx, line); err != nil {
+			if errors.Is(err, ErrExitSqly) {
+				return nil // user input ".exit"
+			}
+			fmt.Fprintf(config.Stderr, "%v\n", err)
+			failed = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read batch input: %w", err)
+	}
+	if failed {
+		return errors.New("one or more batch commands failed")
+	}
+	return nil
+}

--- a/shell/import.go
+++ b/shell/import.go
@@ -15,6 +15,11 @@ import (
 const (
 	// maxDirectoryDepth is the maximum directory depth to prevent deep traversal.
 	maxDirectoryDepth = 10
+	// sheetFlag is the .import flag selecting a single Excel sheet. It accepts
+	// both the separated form "--sheet NAME" and the joined form "--sheet=NAME".
+	sheetFlag = "--sheet"
+	// sheetFlagAssign is the joined form prefix of sheetFlag.
+	sheetFlagAssign = sheetFlag + "="
 )
 
 // importCommand imports files into the in-memory database.
@@ -35,8 +40,13 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 	var errorMessages []string
 	var successCount int
 
-	for _, path := range argv {
-		if strings.HasPrefix(path, "--sheet=") {
+	for i := 0; i < len(argv); i++ {
+		path := argv[i]
+		if path == sheetFlag {
+			i++ // skip the separated value (e.g. --sheet "Q1 Sales")
+			continue
+		}
+		if strings.HasPrefix(path, sheetFlagAssign) {
 			continue
 		}
 
@@ -309,12 +319,18 @@ func validatePath(path string) (string, error) {
 }
 
 // extractSheetNameFromArgs extracts the sheet name from command line arguments.
-// It looks for arguments in the format "--sheet=SHEET_NAME" and returns the sheet name.
-// If no sheet name is found, it returns an empty string.
+// It accepts both the joined form "--sheet=SHEET_NAME" and the separated form
+// "--sheet SHEET_NAME", returning the first match. The separated form lets the
+// value carry spaces once splitArgs has tokenized the quoted input. If no sheet
+// name is found, it returns an empty string.
 func extractSheetNameFromArgs(argv []string) string {
-	for _, arg := range argv {
-		if value, found := strings.CutPrefix(arg, "--sheet="); found {
+	for i := range argv {
+		arg := argv[i]
+		if value, found := strings.CutPrefix(arg, sheetFlagAssign); found {
 			return value
+		}
+		if arg == sheetFlag && i+1 < len(argv) {
+			return argv[i+1]
 		}
 	}
 	return ""
@@ -323,7 +339,9 @@ func extractSheetNameFromArgs(argv []string) string {
 // printImportUsage print import command usage.
 func printImportUsage() {
 	fmt.Fprintln(config.Stdout, "[Usage]")
-	fmt.Fprintln(config.Stdout, "  .import FILE_PATH(S)|DIRECTORY_PATH(S) [--sheet=SHEET_NAME]")
+	fmt.Fprintln(config.Stdout, "  .import FILE_PATH(S)|DIRECTORY_PATH(S) [--sheet SHEET_NAME]")
+	fmt.Fprintln(config.Stdout, "")
+	fmt.Fprintln(config.Stdout, "  - Quote arguments that contain spaces: .import \"my data.csv\" or --sheet \"Q1 Sales\"")
 	fmt.Fprintln(config.Stdout, "")
 	fmt.Fprintln(config.Stdout, "  - Supported file format: csv, tsv, ltsv, json, jsonl, parquet, xlsx [+compressed], ach, fed")
 	fmt.Fprintln(config.Stdout, "  - Compression (csv/tsv/ltsv/json/jsonl/parquet/xlsx only): .gz, .bz2, .xz, .zst, .z, .snappy, .s2, .lz4")

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -572,6 +572,8 @@ func TestImportCommand_SheetArgExtraction(t *testing.T) {
 		{"no sheet", []string{"file.csv"}, ""},
 		{"sheet flag", []string{"file.xlsx", "--sheet=Summary"}, "Summary"},
 		{"sheet flag first", []string{"--sheet=Data", "file.xlsx"}, "Data"},
+		{"separated sheet flag", []string{"file.xlsx", "--sheet", "Summary"}, "Summary"},
+		{"separated sheet flag with space value", []string{"--sheet", "Q1 Sales", "file.xlsx"}, "Q1 Sales"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shell/parse.go
+++ b/shell/parse.go
@@ -1,0 +1,90 @@
+package shell
+
+import (
+	"errors"
+	"strings"
+)
+
+// splitArgs splits a helper-command line into arguments while honoring single
+// quotes, double quotes, and backslash-escaped whitespace. This lets helper
+// commands accept file paths and --sheet values that contain spaces, e.g.
+//
+//	.import "my data.csv"
+//	.import --sheet "Q1 Sales" report.xlsx
+//	.import --sheet='Q1 Sales' report.xlsx
+//	.import my\ data.csv
+//
+// Adjacent quoted and unquoted segments are concatenated into a single argument
+// (so --sheet="Q1 Sales" yields one token --sheet=Q1 Sales).
+//
+// A bare backslash is kept literally (e.g. Windows paths like C:\data\x.csv) and
+// only escapes the next character when it is whitespace, a quote, or a backslash.
+func splitArgs(input string) ([]string, error) {
+	var (
+		args    []string
+		current strings.Builder
+		inWord  bool // true once a token has started, so "" yields an empty arg
+	)
+
+	runes := []rune(input)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			if inWord {
+				args = append(args, current.String())
+				current.Reset()
+				inWord = false
+			}
+		case '\'':
+			inWord = true
+			for i++; ; i++ {
+				if i >= len(runes) {
+					return nil, errors.New("unterminated single quote in command")
+				}
+				if runes[i] == '\'' {
+					break
+				}
+				current.WriteRune(runes[i])
+			}
+		case '"':
+			inWord = true
+			for i++; ; i++ {
+				if i >= len(runes) {
+					return nil, errors.New("unterminated double quote in command")
+				}
+				if runes[i] == '\\' && i+1 < len(runes) {
+					if next := runes[i+1]; next == '"' || next == '\\' {
+						current.WriteRune(next)
+						i++
+						continue
+					}
+				}
+				if runes[i] == '"' {
+					break
+				}
+				current.WriteRune(runes[i])
+			}
+		case '\\':
+			inWord = true
+			if i+1 < len(runes) {
+				switch next := runes[i+1]; next {
+				case ' ', '\t', '\\', '\'', '"':
+					current.WriteRune(next)
+					i++
+				default:
+					current.WriteRune('\\') // keep literal (e.g. Windows path separator)
+				}
+			} else {
+				current.WriteRune('\\')
+			}
+		default:
+			inWord = true
+			current.WriteRune(c)
+		}
+	}
+	if inWord {
+		args = append(args, current.String())
+	}
+	return args, nil
+}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -51,6 +53,12 @@ type Shell struct {
 	usecases  Usecases
 	state     *state
 	newPrompt promptFactory
+	// stdin is the source for non-TTY batch mode. It defaults to os.Stdin and
+	// is overridable in tests so piped input can be simulated without a terminal.
+	stdin io.Reader
+	// isTTY reports whether stdin is an interactive terminal. When false, Run
+	// reads commands from stdin in batch mode instead of starting the prompt.
+	isTTY func() bool
 }
 
 type promptSession interface {
@@ -90,6 +98,8 @@ func NewShell(
 				prompt.WithMultiline(true),
 			)
 		},
+		stdin: os.Stdin,
+		isTTY: config.IsInputFromTTY,
 	}, nil
 }
 
@@ -112,6 +122,12 @@ func (s *Shell) Run(ctx context.Context) error {
 
 	if s.argument.Query != "" {
 		return s.execSQL(ctx, s.argument.Query)
+	}
+
+	// Without a terminal (e.g. piped stdin) the interactive prompt cannot
+	// initialize, so read SQL and helper commands from stdin in batch mode.
+	if !s.isTTY() {
+		return s.runBatch(ctx)
 	}
 
 	// Start shell
@@ -404,8 +420,11 @@ func (s *Shell) getRegularCompletions(ctx context.Context, input string) []Sugge
 // exec execute sqly helper command or sql query.
 func (s *Shell) exec(ctx context.Context, request string) error {
 	req := strings.TrimSpace(request)
-	argv := strings.Split(trimGaps(req), " ")
-	if argv[0] == "" {
+	argv, err := splitArgs(req)
+	if err != nil {
+		return err
+	}
+	if len(argv) == 0 || argv[0] == "" {
 		return nil // user only input enter, space tab
 	}
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1710,6 +1710,140 @@ func TestShell_init(t *testing.T) {
 	}
 }
 
+func TestSplitArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{"plain words split on spaces", ".import a.csv b.csv", []string{".import", "a.csv", "b.csv"}, false},
+		{"collapses repeated whitespace", ".import\ta.csv   b.csv", []string{".import", "a.csv", "b.csv"}, false},
+		{"double-quoted path with space stays one arg", `.import "my data.csv"`, []string{".import", "my data.csv"}, false},
+		{"single-quoted path with space stays one arg", `.import 'my data.csv'`, []string{".import", "my data.csv"}, false},
+		{"joined --sheet= with quoted value", `.import --sheet="Q1 Sales" r.xlsx`, []string{".import", "--sheet=Q1 Sales", "r.xlsx"}, false},
+		{"separated --sheet with quoted value", `.import --sheet "Q1 Sales" r.xlsx`, []string{".import", "--sheet", "Q1 Sales", "r.xlsx"}, false},
+		{"backslash escapes a space", `.import my\ data.csv`, []string{".import", "my data.csv"}, false},
+		{"windows path keeps backslashes", `.import C:\data\file.csv`, []string{".import", `C:\data\file.csv`}, false},
+		{"empty input yields no args", "   ", nil, false},
+		{"unterminated double quote errors", `.import "oops`, nil, true},
+		{"unterminated single quote errors", `.import 'oops`, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := splitArgs(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("splitArgs(%q) error = nil, want error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("splitArgs(%q) unexpected error: %v", tt.input, err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitArgs(%q) = %#v, want %#v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("splitArgs(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestShellRun_BatchModeReadsStdin(t *testing.T) {
+	// Regression for issue #246: without a TTY, sqly reads SQL and helper
+	// commands from stdin instead of failing on prompt initialization.
+	shell, cleanup, err := newShell(t, []string{"sqly", filepath.Join("testdata", "actor.csv")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	promptCalled := false
+	shell.newPrompt = func(_ string, _ func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+		promptCalled = true
+		return nil, errors.New("prompt must not be created in batch mode")
+	}
+	shell.isTTY = func() bool { return false }
+	shell.stdin = strings.NewReader(".tables\nSELECT actor FROM actor ORDER BY actor ASC LIMIT 1\n")
+
+	got := getStdoutForRunFunc(t, shell.Run)
+
+	if promptCalled {
+		t.Fatal("interactive prompt was started in batch mode")
+	}
+	if !strings.Contains(string(got), "actor") {
+		t.Fatalf("batch output missing query result: %q", string(got))
+	}
+}
+
+func TestShellRunBatch_ReturnsErrorOnCommandFailure(t *testing.T) {
+	// Batch execution must surface failures so the process can exit non-zero.
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	shell.isTTY = func() bool { return false }
+	shell.stdin = strings.NewReader("SELECT * FROM no_such_table\n")
+
+	backupStderr := config.Stderr
+	defer func() { config.Stderr = backupStderr }()
+	config.Stderr = &bytes.Buffer{}
+
+	if err := shell.Run(context.Background()); err == nil {
+		t.Fatal("batch Run returned nil error for failing command, want non-nil")
+	}
+}
+
+func TestShellRunBatch_ExitStopsEarly(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	shell.isTTY = func() bool { return false }
+	shell.stdin = strings.NewReader(".exit\nSELECT * FROM no_such_table\n")
+
+	if err := shell.Run(context.Background()); err != nil {
+		t.Fatalf("batch Run returned error after .exit: %v", err)
+	}
+}
+
+func TestShellRunBatch_QuotedSheetArgument(t *testing.T) {
+	// End-to-end: a quoted --sheet value with a space is parsed as one argument.
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	dir := t.TempDir()
+	spaced := filepath.Join(dir, "my data.csv")
+	if err := os.WriteFile(spaced, []byte("id,name\n1,foo\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	shell.isTTY = func() bool { return false }
+	shell.stdin = strings.NewReader(".import \"" + filepath.ToSlash(spaced) + "\"\n.tables\n")
+
+	got := getStdoutForRunFunc(t, shell.Run)
+	if strings.Contains(string(got), "does not exist") {
+		t.Fatalf("spaced path was split into multiple args: %q", string(got))
+	}
+	if !strings.Contains(string(got), "my_data") {
+		t.Fatalf("batch output missing imported table from spaced path: %q", string(got))
+	}
+}
+
 func TestShell_shortCWD(t *testing.T) {
 	shell, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -12,6 +12,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
     sqly ./path/to/data/directory
   - Mix files and directories
     sqly file1.csv ./data_dir file2.tsv
+  - Batch mode: pipe SQL/commands via stdin (no TTY)
+    echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv
 
 [OPTIONS]
   -c, --csv             change output format to csv (default: table)

--- a/shell/testdata/golden/import_without_arg.golden
+++ b/shell/testdata/golden/import_without_arg.golden
@@ -1,5 +1,7 @@
 [Usage]
-  .import FILE_PATH(S)|DIRECTORY_PATH(S) [--sheet=SHEET_NAME]
+  .import FILE_PATH(S)|DIRECTORY_PATH(S) [--sheet SHEET_NAME]
+
+  - Quote arguments that contain spaces: .import "my data.csv" or --sheet "Q1 Sales"
 
   - Supported file format: csv, tsv, ltsv, json, jsonl, parquet, xlsx [+compressed], ach, fed
   - Compression (csv/tsv/ltsv/json/jsonl/parquet/xlsx only): .gz, .bz2, .xz, .zst, .z, .snappy, .s2, .lz4


### PR DESCRIPTION
## Summary
Makes sqly scriptable without a TTY and lets helper-command arguments contain spaces. When stdin is not a terminal, sqly now reads SQL and helper commands from stdin instead of failing on prompt initialization, and helper commands honor quotes and escaped whitespace.

Closes #246

## Changes
- `shell/parse.go`: new `splitArgs` tokenizer that honors single quotes, double quotes, and backslash-escaped whitespace; adjacent quoted/unquoted segments concatenate into one argument. `exec` now uses it instead of naive whitespace splitting.
- `shell/batch.go`: new `runBatch` that reads stdin line by line when there is no TTY, executing each line through the same `exec` path. Failed lines are reported to stderr and make `Run` return an error so the process exits non-zero; a `.exit` line stops early with success.
- `shell/shell.go`: `Shell` gains injectable `stdin` and `isTTY`; `Run` dispatches to batch mode when stdin is not a terminal.
- `config/tty.go`: new `IsInputFromTTY` (uses `golang.org/x/term`) so TTY detection lives in the config layer rather than the shell component.
- `shell/import.go`: `--sheet` now accepts the separated form `--sheet NAME` in addition to `--sheet=NAME`, and the path loop skips the separated value.
- Help text: global usage gains a batch-mode example, and `.import` usage documents quoting; `.go-arch-lint.yml` allows config to use the `term` vendor.
- Docs: CHANGELOG and README (English) describe batch mode and quoted arguments.
- Tests: `TestSplitArgs`, batch-mode integration tests (piped stdin, non-zero exit on failure, `.exit` early stop, quoted spaced path), and separated `--sheet` cases added to existing test functions.

## Design Decisions
TTY detection is checked once up front and routes to batch mode, rather than catching a prompt-initialization failure, because the no-TTY case is expected (pipes, CI) and should not surface as an error.

A bare backslash is kept literally instead of being stripped POSIX-style, so Windows paths like `C:\data\x.csv` typed into helper commands survive; backslash only escapes the following character when it is whitespace, a quote, or another backslash.

Batch input is executed line by line through the existing `exec` path so quoting and command dispatch match the interactive shell exactly.

## Limitations
Batch mode executes one statement per line, so a single SQL statement split across multiple input lines is not joined. Multi-statement scripts should place one statement per line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch mode: pipe SQL and commands via stdin with line-by-line execution and non-zero exit on command failures for scriptability.
  * Helper commands now support quoted arguments (single/double quotes and escaped whitespace) and `--sheet NAME` syntax in addition to `--sheet=NAME`.

* **Documentation**
  * Updated usage text and README with batch mode examples and argument quoting guidance.

* **Tests**
  * Added comprehensive test coverage for batch mode execution and argument parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqly/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->