### PR TITLE
fix(shell): address review feedback on batch mode and --sheet parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,23 @@ When standard input is not a terminal (piped or redirected), sqly reads SQL quer
 
 ```shell
 $ echo "SELECT * FROM user LIMIT 1" | sqly testdata/user.csv
++-----------+------------+------------+-----------+
+| user_name | identifier | first_name | last_name |
++-----------+------------+------------+-----------+
+| booker12  |          1 | Rachel     | Booker    |
++-----------+------------+------------+-----------+
 
 $ printf '.tables\nSELECT COUNT(*) FROM user\n' | sqly testdata/user.csv
++------------+
+| TABLE NAME |
++------------+
+| user       |
++------------+
++----------+
+| COUNT(*) |
++----------+
+|        3 |
++----------+
 ```
 
 ### Directory import

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -27,13 +27,17 @@ func (s *Shell) runBatch(ctx context.Context) error {
 	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxBatchLineBytes)
 
 	failed := false
+	lineNo := 0
 	for scanner.Scan() {
+		lineNo++
 		line := scanner.Text()
 		if err := s.exec(ctx, line); err != nil {
 			if errors.Is(err, ErrExitSqly) {
 				return nil // user input ".exit"
 			}
-			fmt.Fprintf(config.Stderr, "%v\n", err)
+			// Report the line number and content so a failing command is
+			// identifiable when many lines are piped in.
+			fmt.Fprintf(config.Stderr, "batch line %d failed: %q: %v\n", lineNo, line, err)
 			failed = true
 		}
 	}

--- a/shell/import.go
+++ b/shell/import.go
@@ -43,8 +43,14 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 	for i := 0; i < len(argv); i++ {
 		path := argv[i]
 		if path == sheetFlag {
-			i++ // skip the separated value (e.g. --sheet "Q1 Sales")
-			continue
+			// Require a value (e.g. --sheet "Q1 Sales"). A trailing --sheet or
+			// one followed by another flag is rejected instead of silently
+			// importing nothing, which would hide the mistake in scripts.
+			if i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "--") {
+				i++ // consume the separated value
+				continue
+			}
+			return fmt.Errorf("%s requires a value", sheetFlag)
 		}
 		if strings.HasPrefix(path, sheetFlagAssign) {
 			continue
@@ -329,7 +335,7 @@ func extractSheetNameFromArgs(argv []string) string {
 		if value, found := strings.CutPrefix(arg, sheetFlagAssign); found {
 			return value
 		}
-		if arg == sheetFlag && i+1 < len(argv) {
+		if arg == sheetFlag && i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "--") {
 			return argv[i+1]
 		}
 	}
@@ -339,7 +345,7 @@ func extractSheetNameFromArgs(argv []string) string {
 // printImportUsage print import command usage.
 func printImportUsage() {
 	fmt.Fprintln(config.Stdout, "[Usage]")
-	fmt.Fprintln(config.Stdout, "  .import FILE_PATH(S)|DIRECTORY_PATH(S) [--sheet SHEET_NAME]")
+	fmt.Fprintln(config.Stdout, "  .import FILE_PATH(S)|DIRECTORY_PATH(S) [--sheet NAME | --sheet=NAME]")
 	fmt.Fprintln(config.Stdout, "")
 	fmt.Fprintln(config.Stdout, "  - Quote arguments that contain spaces: .import \"my data.csv\" or --sheet \"Q1 Sales\"")
 	fmt.Fprintln(config.Stdout, "")

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -586,6 +586,30 @@ func TestImportCommand_SheetArgExtraction(t *testing.T) {
 	}
 }
 
+func TestImportCommand_MissingSheetValueErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+	}{
+		{"sheet flag alone", []string{"--sheet"}},
+		{"sheet flag at end after file", []string{"file.xlsx", "--sheet"}},
+		{"sheet flag followed by another flag", []string{"--sheet", "--sheet=Data"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, cleanup, err := newShell(t, []string{"sqly"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+
+			if err := s.commands.importCommand(context.Background(), s, tt.argv); err == nil {
+				t.Errorf("importCommand(%v) = nil error, want missing-value error", tt.argv)
+			}
+		})
+	}
+}
+
 func TestValidatePath_Import(t *testing.T) {
 	t.Parallel()
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1792,14 +1792,22 @@ func TestShellRunBatch_ReturnsErrorOnCommandFailure(t *testing.T) {
 	defer cleanup()
 
 	shell.isTTY = func() bool { return false }
-	shell.stdin = strings.NewReader("SELECT * FROM no_such_table\n")
+	shell.stdin = strings.NewReader("SELECT 1\nSELECT * FROM no_such_table\n")
 
 	backupStderr := config.Stderr
 	defer func() { config.Stderr = backupStderr }()
-	config.Stderr = &bytes.Buffer{}
+	var stderr bytes.Buffer
+	config.Stderr = &stderr
 
 	if err := shell.Run(context.Background()); err == nil {
 		t.Fatal("batch Run returned nil error for failing command, want non-nil")
+	}
+	// The failing line is the second input line; stderr must identify it.
+	if !strings.Contains(stderr.String(), "batch line 2 failed") {
+		t.Fatalf("stderr = %q, want it to name the failing line number", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "no_such_table") {
+		t.Fatalf("stderr = %q, want it to include the failing line content", stderr.String())
 	}
 }
 

--- a/shell/testdata/golden/import_without_arg.golden
+++ b/shell/testdata/golden/import_without_arg.golden
@@ -1,5 +1,5 @@
 [Usage]
-  .import FILE_PATH(S)|DIRECTORY_PATH(S) [--sheet SHEET_NAME]
+  .import FILE_PATH(S)|DIRECTORY_PATH(S) [--sheet NAME | --sheet=NAME]
 
   - Quote arguments that contain spaces: .import "my data.csv" or --sheet "Q1 Sales"
 


### PR DESCRIPTION
## Summary
Follow-up to #249, addressing CodeRabbit review comments that were left unresolved when that PR merged. No behavior from #249 is reverted; these are refinements and one functional-bug fix.

Refs #246

## Changes
- `shell/import.go`: `.import --sheet` with no following value (trailing, or followed by another flag) now returns `--sheet requires a value` instead of silently importing nothing. `extractSheetNameFromArgs` ignores a flag-like token after `--sheet` for the same reason.
- `shell/batch.go`: batch errors now name the failing input line and its content (`batch line N failed: "<line>": <err>`), so a failing command is identifiable when many lines are piped in.
- `shell/import.go`: `.import` usage now documents both `--sheet NAME` and `--sheet=NAME`.
- `README.md`: batch-mode examples include their output, fixing markdownlint MD014 (dollar-prefixed commands without output).
- Tests: `TestImportCommand_MissingSheetValueErrors` covers the missing-value cases; the batch failure test now asserts the line number and content appear on stderr; the `.import` usage golden is regenerated.

## Design Decisions
A missing `--sheet` value is treated as a hard error rather than a no-op so scripted imports fail loudly. A token starting with `--` is not accepted as the value, since that almost always means the value was forgotten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting in batch mode to include line numbers and command content when operations fail
  * Fixed validation for the `--sheet` flag to require a value and reject incomplete usage

* **Documentation**
  * Updated batch mode documentation with example output
  * Clarified accepted formats for the `--sheet` flag in help text

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqly/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->