### PR TITLE
refactor(shell): replace OS-dependent .ls/.clear/.cd with in-process implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### Bug Fixes
 * **Shell Prompt Session**: Reuse a single `sqly-shell` prompt across interactive commands so multiline SQL, history preload, and completion state no longer depend on per-command prompt teardown workarounds.
+* **`.cd` Prompt Path**: Store the normalized absolute path after a directory change so the prompt stays correct after relative moves such as `.cd ..`.
 
 ### Refactoring
 * **Session Usecase Boundaries**: Split the monolithic database usecase into focused `QueryUsecase`, `ImportUsecase`, and `MetadataUsecase` interfaces so each shell command depends only on the capability it uses. Behavior is unchanged.
+* **In-Process Shell Helpers**: `.ls` and `.clear` no longer shell out to `ls`/`dir`/`clear`/`cls`. `.ls` lists entries sorted with a trailing `/` on directories for output stable across operating systems; `.clear` uses ANSI escapes. This avoids stalls in headless environments.
 
 ## [v0.15.0](https://github.com/nao1215/sqly/compare/v0.14.2...v0.15.0) (2026-03-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 * **Shell Prompt Session**: Reuse a single `sqly-shell` prompt across interactive commands so multiline SQL, history preload, and completion state no longer depend on per-command prompt teardown workarounds.
-* **`.cd` Prompt Path**: Store the normalized absolute path after a directory change so the prompt stays correct after relative moves such as `.cd ..`.
+* **`.cd` Prompt Path**: Store the normalized absolute path after a directory change so the prompt stays correct after relative moves such as `.cd ..`. Argument-less `.cd` now resolves the home directory via `os.UserHomeDir`, fixing it on Windows where `$HOME` is usually unset.
 
 ### Refactoring
 * **Session Usecase Boundaries**: Split the monolithic database usecase into focused `QueryUsecase`, `ImportUsecase`, and `MetadataUsecase` interfaces so each shell command depends only on the capability it uses. Behavior is unchanged.

--- a/shell/cd.go
+++ b/shell/cd.go
@@ -11,21 +11,24 @@ import (
 // If there is one argument, change to the specified directory.
 // If there are multiple arguments, return an error.
 func (c CommandList) cdCommand(_ context.Context, s *Shell, argv []string) error {
-	if len(argv) == 0 {
-		home := os.Getenv("HOME")
-		if err := os.Chdir(home); err != nil {
-			return err
-		}
-		s.state.cwd = home
-		return nil
-	}
 	if len(argv) > 1 {
 		return errors.New("too many arguments")
 	}
 
-	if err := os.Chdir(argv[0]); err != nil {
+	target := os.Getenv("HOME")
+	if len(argv) == 1 {
+		target = argv[0]
+	}
+
+	if err := os.Chdir(target); err != nil {
 		return err
 	}
-	s.state.cwd = argv[0]
+	// Store the normalized absolute path (via os.Getwd), not the raw argument,
+	// so the prompt stays correct after relative moves (e.g. ".." or "sub").
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	s.state.cwd = cwd
 	return nil
 }

--- a/shell/cd.go
+++ b/shell/cd.go
@@ -15,9 +15,17 @@ func (c CommandList) cdCommand(_ context.Context, s *Shell, argv []string) error
 		return errors.New("too many arguments")
 	}
 
-	target := os.Getenv("HOME")
+	var target string
 	if len(argv) == 1 {
 		target = argv[0]
+	} else {
+		// Resolve the home directory cross-platform. os.UserHomeDir reads
+		// %USERPROFILE% on Windows, where $HOME is usually unset.
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		target = home
 	}
 
 	if err := os.Chdir(target); err != nil {

--- a/shell/clear.go
+++ b/shell/clear.go
@@ -3,29 +3,18 @@ package shell
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
 
 	"github.com/nao1215/sqly/config"
 )
 
-// clearCommand clears the terminal screen.
-func (c CommandList) clearCommand(ctx context.Context, _ *Shell, _ []string) error {
-	var cmd *exec.Cmd
-
-	switch runtime.GOOS {
-	case config.Windows:
-		cmd = exec.CommandContext(ctx, "cmd", "/c", "cls")
-	default:
-		cmd = exec.CommandContext(ctx, "clear")
-	}
-
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to clear screen: %w", err)
-	}
-
+// clearCommand clears the terminal screen in-process.
+//
+// It writes ANSI escapes (clear screen, clear scrollback, cursor home) instead
+// of shelling out to clear/cls. Why: spawning an external process can stall in
+// headless CI and ties behavior to platform binaries. config.Stdout is a
+// go-colorable writer, which translates these escapes to the Windows console
+// API, so a single sequence works across supported operating systems.
+func (c CommandList) clearCommand(_ context.Context, _ *Shell, _ []string) error {
+	fmt.Fprint(config.Stdout, "\x1b[H\x1b[2J\x1b[3J")
 	return nil
 }

--- a/shell/clear_test.go
+++ b/shell/clear_test.go
@@ -1,9 +1,13 @@
 package shell
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/nao1215/sqly/config"
 )
 
 // Test_clearCommand tests the clearCommand registration and metadata.
@@ -30,6 +34,24 @@ func Test_clearCommand(t *testing.T) {
 		}
 		if cmd.execute == nil {
 			t.Error("Expected execute function to be set")
+		}
+	})
+
+	t.Run("writes ANSI clear sequence to stdout in-process", func(t *testing.T) {
+		// Regression for #236: .clear must clear the screen in-process via ANSI
+		// escapes instead of shelling out to clear/cls.
+		c := NewCommands()
+
+		backup := config.Stdout
+		defer func() { config.Stdout = backup }()
+		var buf bytes.Buffer
+		config.Stdout = &buf
+
+		if err := c[".clear"].execute(context.Background(), &Shell{}, []string{}); err != nil {
+			t.Fatalf("clear command returned error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "\x1b[2J") {
+			t.Fatalf("clear output = %q, want it to contain the ANSI clear-screen escape", buf.String())
 		}
 	})
 

--- a/shell/commands_test.go
+++ b/shell/commands_test.go
@@ -221,6 +221,71 @@ func TestCommandList_lsCommand(t *testing.T) {
 	}
 }
 
+func TestCommandList_lsCommand_Output(t *testing.T) {
+	// Regression for #236: .ls must list directory contents in-process with
+	// deterministic, OS-independent output instead of shelling out to ls/dir.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "b.csv"), []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.csv"), []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	commandList := NewCommands()
+
+	backup := config.Stdout
+	defer func() { config.Stdout = backup }()
+	var buf bytes.Buffer
+	config.Stdout = &buf
+
+	if err := commandList.lsCommand(context.Background(), &Shell{}, []string{dir}); err != nil {
+		t.Fatalf("lsCommand returned error: %v", err)
+	}
+
+	got := buf.String()
+	want := "a.csv\nb.csv\nsub/\n"
+	if got != want {
+		t.Fatalf("lsCommand output = %q, want %q", got, want)
+	}
+}
+
+func TestCommandList_cdCommand_StoresAbsolutePath(t *testing.T) {
+	// Regression for #236: .cd must store a normalized absolute path so the
+	// prompt stays correct after a relative move.
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	shell := newBoundaryTestShell(t, Usecases{})
+	commandList := NewCommands()
+
+	if err := commandList.cdCommand(context.Background(), shell, []string{"sub"}); err != nil {
+		t.Fatalf("cdCommand returned error: %v", err)
+	}
+
+	if !filepath.IsAbs(shell.state.cwd) {
+		t.Fatalf("state.cwd = %q, want an absolute path", shell.state.cwd)
+	}
+	wantResolved, err := filepath.EvalSymlinks(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotResolved, err := filepath.EvalSymlinks(shell.state.cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotResolved != wantResolved {
+		t.Fatalf("state.cwd resolved = %q, want %q", gotResolved, wantResolved)
+	}
+}
+
 func TestShell_getFilePathCompletions_errorHandling(t *testing.T) {
 	shell, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {

--- a/shell/ls.go
+++ b/shell/ls.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"runtime"
+	"path/filepath"
+	"sort"
 
 	"github.com/nao1215/sqly/config"
 )
@@ -15,36 +15,49 @@ import (
 // If there is no argument, list the files and directories in the current directory.
 // If there is one argument, list the files and directories in the specified directory.
 // If there are multiple arguments, return an error.
+//
+// Listing is done in-process rather than shelling out to ls/dir. Why: external
+// binaries differ per platform (ls -l vs dir /q) and produce inconsistent
+// output. Entries are sorted by name and directories carry a trailing "/" so
+// the result is deterministic across supported operating systems.
 func (c CommandList) lsCommand(_ context.Context, _ *Shell, argv []string) error {
-	path, err := func() (string, error) {
-		if len(argv) == 0 {
-			return ".", nil
-		}
-		if len(argv) > 1 {
-			return "", errors.New("too many arguments")
-		}
-		return argv[0], nil
-	}()
+	if len(argv) > 1 {
+		return errors.New("too many arguments")
+	}
+	path := "."
+	if len(argv) == 1 {
+		path = argv[0]
+	}
+
+	info, err := os.Stat(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no such file or directory: %s", path)
+		}
 		return err
 	}
 
-	if err := func() error {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			return fmt.Errorf("no such file or directory: %s", path)
-		}
+	// A non-directory argument lists just that entry, mirroring `ls FILE`.
+	if !info.IsDir() {
+		fmt.Fprintln(config.Stdout, filepath.Base(path))
+		return nil
+	}
 
-		var cmd *exec.Cmd
-		if runtime.GOOS == config.Windows {
-			cmd = exec.CommandContext(context.Background(), "cmd", "/c", "dir", "/q", path) // #nosec G204
-		} else {
-			cmd = exec.CommandContext(context.Background(), "ls", "-l", path) // #nosec G204
-		}
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		return cmd.Run()
-	}(); err != nil {
+	entries, err := os.ReadDir(path)
+	if err != nil {
 		return err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			name += "/"
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Fprintln(config.Stdout, name)
 	}
 	return nil
 }

--- a/shell/state.go
+++ b/shell/state.go
@@ -31,7 +31,12 @@ func newState(arg *config.Arg) (*state, error) {
 // shortCWD return short current working directory.
 // If current working directory is home directory, return "~".
 func (s *state) shortCWD() string {
-	home := os.Getenv("HOME")
+	// Resolve home cross-platform (os.UserHomeDir uses %USERPROFILE% on Windows,
+	// where $HOME is usually unset). Skip abbreviation if it cannot be resolved.
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return s.cwd
+	}
 	if s.cwd == home {
 		return "~"
 	}


### PR DESCRIPTION
## Summary
Removes external-binary dependencies from the shell helper commands. `.ls` and `.clear` no longer spawn `ls`/`dir`/`clear`/`cls`, and `.cd` now records a normalized absolute path. This makes the helpers behave consistently across operating systems and avoids subprocess stalls in headless environments.

Closes #236

## Changes
- `shell/ls.go`: list directory entries in-process with `os.ReadDir`, sorted by name with a trailing `/` on directories. A non-directory argument prints just its base name. Output goes to `config.Stdout`.
- `shell/clear.go`: clear the screen with ANSI escapes (`\x1b[H\x1b[2J\x1b[3J`) written to `config.Stdout`. `config.Stdout` is a go-colorable writer, which translates the escapes to the Windows console API.
- `shell/cd.go`: after `os.Chdir`, store `os.Getwd()` instead of the raw argument so the prompt stays correct after relative moves like `.cd ..`.
- Tests: `TestCommandList_lsCommand_Output` asserts the deterministic listing, `TestCommandList_cdCommand_StoresAbsolutePath` asserts the stored path is absolute and resolves to the target, and a new `Test_clearCommand` case asserts the ANSI sequence is written in-process.

## Design Decisions
`.ls` output format is intentionally simplified from `ls -l`/`dir /q` to a sorted name list, since the previous per-platform formats were not stable and could not be tested cross-platform. Directories are marked with a trailing `/` so the type is still visible.

ANSI escapes were chosen over a platform switch because `config.Stdout` already handles the Windows translation, so one code path covers all supported operating systems and runs without a subprocess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `.cd` helper to correctly update shell prompt path after relative directory changes (e.g., `.cd ..`).

* **Improvements**
  * `.ls` command now provides consistently sorted directory listings with directories marked by a trailing `/`.
  * `.clear` command now operates in-process for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqly/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->