### PR TITLE
feat: add JSON and NDJSON output modes for CLI and shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### New Features
+* **JSON and NDJSON Output**: Render query results as JSON or newline-delimited JSON via `--json`/`--ndjson`, `.mode json`/`.mode ndjson` in the shell, and `.dump`/`--output` for files. Values are emitted as strings like the other text formats; an empty result is `[]` for JSON and an empty stream for NDJSON.
 * **Non-TTY Batch Mode**: When stdin is piped or redirected, sqly reads SQL and helper commands from stdin line by line. A failed command exits non-zero, so batch runs are scriptable (e.g. `echo 'SELECT * FROM sample' | sqly sample.csv`).
 * **Quoted Helper-Command Arguments**: Helper commands honor single quotes, double quotes, and backslash-escaped whitespace, so file paths and `--sheet` values can contain spaces (e.g. `.import "my data.csv"`, `.import --sheet "Q1 Sales" report.xlsx`). The separated `--sheet NAME` form is now accepted alongside `--sheet=NAME`.
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ The sqly output sql query results in following formats:
 - CSV format (--csv option)
 - TSV format (--tsv option)
 - LTSV format (--ltsv option)
+- JSON format (--json option)
+- NDJSON format (--ndjson option)
 
 ```shell
 $ sqly --sql "SELECT * FROM user LIMIT 2" --csv testdata/user.csv 
@@ -172,6 +174,22 @@ user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
 ```
+
+JSON and NDJSON are easy to consume from scripts and tools. Values are emitted as strings.
+
+```shell
+$ sqly --sql "SELECT user_name, identifier FROM user LIMIT 2" --json testdata/user.csv
+[
+  {"user_name":"booker12","identifier":"1"},
+  {"user_name":"jenkins46","identifier":"2"}
+]
+
+$ sqly --sql "SELECT user_name, identifier FROM user LIMIT 2" --ndjson testdata/user.csv
+{"user_name":"booker12","identifier":"1"}
+{"user_name":"jenkins46","identifier":"2"}
+```
+
+In the shell, switch with `.mode json` or `.mode ndjson`. `.dump` writes the current mode to a file (`.json`/`.ndjson`).
 
 ### Run sqly shell
 The sqly shell starts when you run the sqly command without the --sql option. When you execute sqly command with file path, the sqly-shell starts after importing the file into the SQLite3 in-memory database.  

--- a/config/argument.go
+++ b/config/argument.go
@@ -55,6 +55,8 @@ type outputFlag struct {
 	ltsv     bool
 	excel    bool
 	markdown bool
+	json     bool
+	ndjson   bool
 }
 
 // NewArg return *Arg that is assigned the result of parsing os.Args.
@@ -75,6 +77,8 @@ func NewArg(args []string) (*Arg, error) {
 	flag.BoolVarP(&oFlag.ltsv, "ltsv", "l", false, "change output format to ltsv (default: table)")
 	flag.BoolVarP(&oFlag.markdown, "markdown", "m", false, "change output format to markdown table (default: table)")
 	flag.BoolVarP(&oFlag.tsv, "tsv", "t", false, "change output format to tsv (default: table)")
+	flag.BoolVarP(&oFlag.json, "json", "j", false, "change output format to json (default: table)")
+	flag.BoolVarP(&oFlag.ndjson, "ndjson", "n", false, "change output format to ndjson (default: table)")
 	sheetName := flag.StringP("sheet", "S", "", "excel sheet name you want to import")
 	query := flag.StringP("sql", "s", "", "sql query you want to execute")
 	output := flag.StringP("output", "o", "", "destination path for SQL results specified in --sql option")
@@ -110,6 +114,10 @@ func newOutput(filePath string, of outputFlag) *Output {
 		output.Mode = model.PrintModeLTSV
 	case of.markdown:
 		output.Mode = model.PrintModeMarkdownTable
+	case of.json:
+		output.Mode = model.PrintModeJSON
+	case of.ndjson:
+		output.Mode = model.PrintModeNDJSON
 	default:
 		output.Mode = model.PrintModeTable
 	}

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -95,6 +95,28 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("user set --json option", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--json"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if arg.Output.Mode != model.PrintModeJSON {
+			t.Errorf("mismatch got=%v, want=%v", arg.Output.Mode, model.PrintModeJSON)
+		}
+	})
+
+	t.Run("user set --ndjson option", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--ndjson"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if arg.Output.Mode != model.PrintModeNDJSON {
+			t.Errorf("mismatch got=%v, want=%v", arg.Output.Mode, model.PrintModeNDJSON)
+		}
+	})
+
 	t.Run("default print mode", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly"})
 		if err != nil {

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -21,6 +21,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -l, --ltsv            change output format to ltsv (default: table)
   -m, --markdown        change output format to markdown table (default: table)
   -t, --tsv             change output format to tsv (default: table)
+  -j, --json            change output format to json (default: table)
+  -n, --ndjson          change output format to ndjson (default: table)
   -S, --sheet string    excel sheet name you want to import
   -s, --sql string      sql query you want to execute
   -o, --output string   destination path for SQL results specified in --sql option

--- a/domain/model/export.go
+++ b/domain/model/export.go
@@ -16,6 +16,10 @@ const (
 	ExportMarkdown
 	// ExportExcel exports data as XLSX
 	ExportExcel
+	// ExportJSON exports data as a JSON array of objects
+	ExportJSON
+	// ExportNDJSON exports data as newline-delimited JSON
+	ExportNDJSON
 )
 
 // String returns the string representation of the ExportFormat.
@@ -31,6 +35,10 @@ func (e ExportFormat) String() string {
 		return formatMarkdown
 	case ExportExcel:
 		return formatExcel
+	case ExportJSON:
+		return formatJSON
+	case ExportNDJSON:
+		return formatNDJSON
 	}
 	return formatCSV
 }
@@ -48,6 +56,10 @@ func (e ExportFormat) Extension() string {
 		return ExtMarkdown
 	case ExportExcel:
 		return ExtExcel
+	case ExportJSON:
+		return ExtJSON
+	case ExportNDJSON:
+		return ExtNDJSON
 	}
 	return ExtCSV
 }
@@ -66,6 +78,10 @@ func ExportFormatFromPrintMode(m PrintMode) ExportFormat {
 		return ExportMarkdown
 	case PrintModeExcel:
 		return ExportExcel
+	case PrintModeJSON:
+		return ExportJSON
+	case PrintModeNDJSON:
+		return ExportNDJSON
 	default:
 		return ExportCSV
 	}

--- a/domain/model/export_test.go
+++ b/domain/model/export_test.go
@@ -15,6 +15,8 @@ func TestExportFormat_String(t *testing.T) {
 		{name: "ltsv", ef: ExportLTSV, want: "ltsv"},
 		{name: "markdown", ef: ExportMarkdown, want: "markdown"},
 		{name: "excel", ef: ExportExcel, want: "excel"},
+		{name: "json", ef: ExportJSON, want: "json"},
+		{name: "ndjson", ef: ExportNDJSON, want: "ndjson"},
 		{name: "unknown defaults to csv", ef: ExportFormat(99), want: "csv"},
 	}
 	for _, tt := range tests {
@@ -40,6 +42,8 @@ func TestExportFormat_Extension(t *testing.T) {
 		{name: "ltsv", ef: ExportLTSV, want: ".ltsv"},
 		{name: "markdown", ef: ExportMarkdown, want: ".md"},
 		{name: "excel", ef: ExportExcel, want: ".xlsx"},
+		{name: "json", ef: ExportJSON, want: ".json"},
+		{name: "ndjson", ef: ExportNDJSON, want: ".ndjson"},
 		{name: "unknown defaults to .csv", ef: ExportFormat(99), want: ".csv"},
 	}
 	for _, tt := range tests {
@@ -66,6 +70,8 @@ func TestExportFormatFromPrintMode(t *testing.T) {
 		{name: "ltsv", mode: PrintModeLTSV, want: ExportLTSV},
 		{name: "markdown", mode: PrintModeMarkdownTable, want: ExportMarkdown},
 		{name: "excel", mode: PrintModeExcel, want: ExportExcel},
+		{name: "json", mode: PrintModeJSON, want: ExportJSON},
+		{name: "ndjson", mode: PrintModeNDJSON, want: ExportNDJSON},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -53,6 +55,8 @@ const (
 	formatLTSV     = "ltsv"
 	formatMarkdown = "markdown"
 	formatExcel    = "excel"
+	formatJSON     = "json"
+	formatNDJSON   = "ndjson"
 )
 
 // Extension name constants.
@@ -62,6 +66,8 @@ const (
 	ExtLTSV     = ".ltsv"
 	ExtMarkdown = ".md"
 	ExtExcel    = ".xlsx"
+	ExtJSON     = ".json"
+	ExtNDJSON   = ".ndjson"
 )
 
 const (
@@ -77,6 +83,10 @@ const (
 	PrintModeLTSV
 	// PrintModeExcel print data in excel format
 	PrintModeExcel
+	// PrintModeJSON print data as a JSON array of objects
+	PrintModeJSON
+	// PrintModeNDJSON print data as newline-delimited JSON (one object per line)
+	PrintModeNDJSON
 )
 
 // String return string of PrintMode.
@@ -94,6 +104,10 @@ func (p PrintMode) String() string {
 		return formatLTSV
 	case PrintModeExcel:
 		return formatExcel
+	case PrintModeJSON:
+		return formatJSON
+	case PrintModeNDJSON:
+		return formatNDJSON
 	}
 	return "unknown"
 }
@@ -224,6 +238,10 @@ func (t *Table) Print(out io.Writer, mode PrintMode) error {
 	case PrintModeExcel:
 		t.printExcel(out)
 		return nil
+	case PrintModeJSON:
+		return t.printJSON(out)
+	case PrintModeNDJSON:
+		return t.printNDJSON(out)
 	default:
 		return t.printTable(out)
 	}
@@ -350,4 +368,79 @@ func (t *Table) printLTSV(out io.Writer) {
 // This is the same as printCSV.
 func (t *Table) printExcel(out io.Writer) {
 	t.printCSV(out)
+}
+
+// rowToJSONObject builds a JSON object for one record, preserving the header
+// column order. Why string values: the table model stores every cell as a
+// string, so emitting strings keeps output lossless (e.g. "007" stays "007")
+// and consistent with the other text formats. Why a manual builder: encoding's
+// map marshaling sorts keys alphabetically, which would drop column order.
+func (t *Table) rowToJSONObject(record Record) ([]byte, error) {
+	var b bytes.Buffer
+	b.WriteByte('{')
+	for i, h := range t.Header() {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		key, err := json.Marshal(h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode column name %q: %w", h, err)
+		}
+		b.Write(key)
+		b.WriteByte(':')
+
+		var val string
+		if i < len(record) {
+			val = record[i]
+		}
+		value, err := json.Marshal(val)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode value for column %q: %w", h, err)
+		}
+		b.Write(value)
+	}
+	b.WriteByte('}')
+	return b.Bytes(), nil
+}
+
+// printJSON prints all records as a JSON array of objects. An empty result set
+// prints "[]" so consumers always receive valid JSON.
+func (t *Table) printJSON(out io.Writer) error {
+	if len(t.Records()) == 0 {
+		_, err := fmt.Fprintln(out, "[]")
+		return err
+	}
+	if _, err := fmt.Fprintln(out, "["); err != nil {
+		return err
+	}
+	for i, record := range t.Records() {
+		obj, err := t.rowToJSONObject(record)
+		if err != nil {
+			return err
+		}
+		sep := ""
+		if i < len(t.Records())-1 {
+			sep = ","
+		}
+		if _, err := fmt.Fprintf(out, "  %s%s\n", obj, sep); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(out, "]")
+	return err
+}
+
+// printNDJSON prints one JSON object per line (newline-delimited JSON). An empty
+// result set prints nothing — the empty NDJSON stream.
+func (t *Table) printNDJSON(out io.Writer) error {
+	for _, record := range t.Records() {
+		obj, err := t.rowToJSONObject(record)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(out, "%s\n", obj); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -101,6 +101,16 @@ func TestPrintModeString(t *testing.T) {
 			want: "excel",
 		},
 		{
+			name: "json mode",
+			p:    PrintModeJSON,
+			want: "json",
+		},
+		{
+			name: "ndjson mode",
+			p:    PrintModeNDJSON,
+			want: "ndjson",
+		},
+		{
 			name: "unknown mode",
 			p:    100, // not defined
 			want: "unknown",
@@ -326,6 +336,71 @@ aaa:777	bbb:888	ccc:999
 111,222,333
 444,555,666
 777,888,999
+`,
+		},
+		{
+			name: "print json",
+			fields: fields{
+				Name:   "valid_table",
+				Header: Header{"aaa", "bbb", "ccc"},
+				Records: []Record{
+					{"111", "222", "333"},
+					{"444", "555", "666"},
+				},
+			},
+			args: args{PrintModeJSON},
+			wantOut: `[
+  {"aaa":"111","bbb":"222","ccc":"333"},
+  {"aaa":"444","bbb":"555","ccc":"666"}
+]
+`,
+		},
+		{
+			name: "print json with no records",
+			fields: fields{
+				Name:    "empty_table",
+				Header:  Header{"aaa", "bbb"},
+				Records: []Record{},
+			},
+			args:    args{PrintModeJSON},
+			wantOut: "[]\n",
+		},
+		{
+			name: "print ndjson",
+			fields: fields{
+				Name:   "valid_table",
+				Header: Header{"aaa", "bbb", "ccc"},
+				Records: []Record{
+					{"111", "222", "333"},
+					{"444", "555", "666"},
+				},
+			},
+			args: args{PrintModeNDJSON},
+			wantOut: `{"aaa":"111","bbb":"222","ccc":"333"}
+{"aaa":"444","bbb":"555","ccc":"666"}
+`,
+		},
+		{
+			name: "print ndjson with no records",
+			fields: fields{
+				Name:    "empty_table",
+				Header:  Header{"aaa", "bbb"},
+				Records: []Record{},
+			},
+			args:    args{PrintModeNDJSON},
+			wantOut: "",
+		},
+		{
+			name: "print json escapes special characters",
+			fields: fields{
+				Name:   "valid_table",
+				Header: Header{"name", "note"},
+				Records: []Record{
+					{`a"b`, "c\td"},
+				},
+			},
+			args: args{PrintModeNDJSON},
+			wantOut: `{"name":"a\"b","note":"c\td"}
 `,
 		},
 		{

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -391,7 +391,7 @@ aaa:777	bbb:888	ccc:999
 			wantOut: "",
 		},
 		{
-			name: "print json escapes special characters",
+			name: "print ndjson escapes special characters",
 			fields: fields{
 				Name:   "valid_table",
 				Header: Header{"name", "note"},

--- a/interactor/export.go
+++ b/interactor/export.go
@@ -53,7 +53,11 @@ func (e *exportInteractor) DumpTable(filePath string, table *model.Table, format
 	case model.ExportExcel:
 		return e.excelRepo.Dump(filepath.Clean(filePath), table)
 	case model.ExportMarkdown:
-		return e.dumpMarkdown(filePath, table)
+		return e.dumpViaPrint(filePath, table, model.PrintModeMarkdownTable)
+	case model.ExportJSON:
+		return e.dumpViaPrint(filePath, table, model.PrintModeJSON)
+	case model.ExportNDJSON:
+		return e.dumpViaPrint(filePath, table, model.PrintModeNDJSON)
 	default:
 		return e.dumpWithFile(filePath, table, e.csvRepo.Dump)
 	}
@@ -76,17 +80,19 @@ func (e *exportInteractor) dumpWithFile(filePath string, table *model.Table, dum
 	return nil
 }
 
-// dumpMarkdown writes table data to file in Markdown table format.
-func (e *exportInteractor) dumpMarkdown(filePath string, table *model.Table) (err error) {
+// dumpViaPrint writes table data to file using Table.Print for formats whose
+// file output matches their display rendering (Markdown, JSON, NDJSON). This
+// reuses the rendering implementation instead of a separate repository.
+func (e *exportInteractor) dumpViaPrint(filePath string, table *model.Table, mode model.PrintMode) (err error) {
 	f, err := e.fileRepo.Create(filepath.Clean(filePath))
 	if err != nil {
-		return fmt.Errorf("create markdown file %q: %w", filePath, err)
+		return fmt.Errorf("create output file %q: %w", filePath, err)
 	}
 	defer func() {
 		if cerr := f.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("close markdown file %q: %w", filePath, cerr)
+			err = fmt.Errorf("close output file %q: %w", filePath, cerr)
 		}
 	}()
 
-	return table.Print(f, model.PrintModeMarkdownTable)
+	return table.Print(f, mode)
 }

--- a/shell/mode.go
+++ b/shell/mode.go
@@ -18,6 +18,8 @@ func (c CommandList) modeCommand(_ context.Context, s *Shell, argv []string) err
 		fmt.Fprintln(config.Stdout, "  csv")
 		fmt.Fprintln(config.Stdout, "  tsv")
 		fmt.Fprintln(config.Stdout, "  ltsv")
+		fmt.Fprintln(config.Stdout, "  json")
+		fmt.Fprintln(config.Stdout, "  ndjson")
 		fmt.Fprintln(config.Stdout, "  excel ※ active only when executing .dump, otherwise same as csv mode")
 		return nil
 	}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -359,6 +359,8 @@ func (s *Shell) getRegularCompletions(ctx context.Context, input string) []Sugge
 		{Text: "csv", Description: "sqly command argument: csv output format"},
 		{Text: "tsv", Description: "sqly command argument: tsv output format"},
 		{Text: "ltsv", Description: "sqly command argument: ltsv output format"},
+		{Text: "json", Description: "sqly command argument: json output format"},
+		{Text: "ndjson", Description: "sqly command argument: ndjson output format"},
 		{Text: "excel", Description: "sqly command argument: excel output format"},
 	}
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -1849,6 +1850,68 @@ func TestShellRunBatch_QuotedSheetArgument(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "my_data") {
 		t.Fatalf("batch output missing imported table from spaced path: %q", string(got))
+	}
+}
+
+func TestShellRun_JSONOutputFromCLI(t *testing.T) {
+	// Regression for #237: --json renders query results as a JSON array that
+	// decodes with the expected column names and values.
+	shell, cleanup, err := newShell(t, []string{"sqly", "--json", "--sql", "SELECT actor FROM actor ORDER BY actor ASC LIMIT 2", filepath.Join("testdata", "actor.csv")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	got := getStdoutForRunFunc(t, shell.Run)
+
+	var rows []map[string]string
+	if err := json.Unmarshal(got, &rows); err != nil {
+		t.Fatalf("output is not valid JSON array: %v\noutput: %s", err, got)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2: %s", len(rows), got)
+	}
+	if _, ok := rows[0]["actor"]; !ok {
+		t.Fatalf("row missing 'actor' column: %#v", rows[0])
+	}
+	if rows[0]["actor"] != "Adam Sandler" {
+		t.Fatalf("rows[0].actor = %q, want %q", rows[0]["actor"], "Adam Sandler")
+	}
+}
+
+func TestShellExec_NDJSONModeSwitch(t *testing.T) {
+	// Regression for #237: .mode ndjson makes shell query output emit one JSON
+	// object per line.
+	shell, cleanup, err := newShell(t, []string{"sqly", filepath.Join("testdata", "actor.csv")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if err := shell.commands.importCommand(context.Background(), shell, []string{filepath.Join("testdata", "actor.csv")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getExecStdOutput(t, shell.exec, ".mode ndjson"); err != nil {
+		t.Fatalf(".mode ndjson failed: %v", err)
+	}
+
+	out, err := getExecStdOutput(t, shell.exec, "SELECT actor FROM actor ORDER BY actor ASC LIMIT 2")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d NDJSON lines, want 2: %s", len(lines), out)
+	}
+	for _, line := range lines {
+		var row map[string]string
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Fatalf("NDJSON line is not valid JSON: %v\nline: %s", err, line)
+		}
+		if _, ok := row["actor"]; !ok {
+			t.Fatalf("NDJSON line missing 'actor' column: %s", line)
+		}
 	}
 }
 

--- a/shell/state.go
+++ b/shell/state.go
@@ -80,6 +80,12 @@ func (m *mode) changeOutputModeIfNeeded(modeName string) error {
 	case model.PrintModeLTSV.String():
 		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeLTSV.String())
 		m.PrintMode = model.PrintModeLTSV
+	case model.PrintModeJSON.String():
+		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeJSON.String())
+		m.PrintMode = model.PrintModeJSON
+	case model.PrintModeNDJSON.String():
+		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeNDJSON.String())
+		m.PrintMode = model.PrintModeNDJSON
 	case model.PrintModeExcel.String():
 		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
 			m.String(), model.PrintModeExcel.String())

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -21,6 +21,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -l, --ltsv            change output format to ltsv (default: table)
   -m, --markdown        change output format to markdown table (default: table)
   -t, --tsv             change output format to tsv (default: table)
+  -j, --json            change output format to json (default: table)
+  -n, --ndjson          change output format to ndjson (default: table)
   -S, --sheet string    excel sheet name you want to import
   -s, --sql string      sql query you want to execute
   -o, --output string   destination path for SQL results specified in --sql option

--- a/shell/testdata/golden/mode_without_arg.golden
+++ b/shell/testdata/golden/mode_without_arg.golden
@@ -6,4 +6,6 @@
   csv
   tsv
   ltsv
+  json
+  ndjson
   excel ※ active only when executing .dump, otherwise same as csv mode


### PR DESCRIPTION
## Summary
Adds first-class machine-readable query output. Results can be rendered as a JSON array or as newline-delimited JSON (NDJSON) from the command line, the interactive shell, and file exports, making sqly easier to use from scripts and other tools.

Closes #237

## Changes
- `domain/model/table.go`: add `PrintModeJSON`/`PrintModeNDJSON` and render them via new `printJSON`/`printNDJSON`. A manual per-row JSON builder preserves header column order (map marshaling would sort keys) and emits values as strings to match the all-string table model.
- `domain/model/export.go`: add `ExportJSON`/`ExportNDJSON` with `.json`/`.ndjson` extensions and `PrintMode` mapping.
- `config/argument.go`: add `--json`/`-j` and `--ndjson`/`-n` flags.
- `shell/state.go`, `shell/mode.go`, `shell/shell.go`: accept `.mode json`/`.mode ndjson`, list them in usage, and add completion entries.
- `interactor/export.go`: dump JSON/NDJSON by reusing `Table.Print`, the same path Markdown already uses, so no new repository or DI wiring is needed.
- Docs: CHANGELOG entry and a README output-format example.
- Tests: decode JSON and NDJSON in `domain/model`, assert column names, row values, escaping, and empty-result behavior (`[]` for JSON, empty for NDJSON); cover `--json` CLI execution and `.mode ndjson` shell switching end to end; add flag-parsing and enum tests. Golden files for help/usage/mode regenerated.

## Design Decisions
Values are emitted as JSON strings rather than inferred types. The table model stores every cell as a string, so string output is lossless (e.g. "007" stays "007") and consistent with the existing CSV/TSV/LTSV formats; type inference would be ambiguous and could corrupt identifiers.

JSON/NDJSON file export reuses `Table.Print` instead of introducing dedicated repository interfaces, mirroring how Markdown export already works. This keeps a single rendering implementation and avoids touching the DI graph.

An empty result is `[]` for JSON (always valid JSON) and an empty stream for NDJSON (the natural empty form).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON and NDJSON output formats accessible via `--json`/`--ndjson` CLI flags
  * Added `.mode json` and `.mode ndjson` commands for interactive shell output mode switching
  * Added JSON/NDJSON file export via `.dump` command
  * Values are emitted as strings; empty results return `[]` for JSON and empty stream for NDJSON

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqly/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->