### PR TITLE
test: add shellspec binary e2e tests and wire into CI

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,40 @@
+name: E2E
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  shellspec:
+    name: shellspec (binary e2e)
+
+    strategy:
+      matrix:
+        os:
+          - "ubuntu-latest"
+          - "macos-latest"
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Install shellspec
+        run: |
+          curl -fsSL https://git.io/shellspec | sh -s -- --yes
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Build sqly
+        run: make build
+
+      - name: Run shellspec end-to-end tests
+        run: shellspec --shell sh

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install shellspec
         run: |
-          curl -fsSL https://git.io/shellspec | sh -s -- --yes
+          curl -fsSL https://git.io/shellspec | sh -s 0.28.1 --yes
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Build sqly

--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,2 @@
+--shell sh
+--format documentation

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean vet fmt chkfmt
+.PHONY: build test test-e2e clean vet fmt chkfmt
 
 APP         = sqly
 VERSION     = $(shell git describe --tags --abbrev=0)
@@ -27,6 +27,9 @@ clean: ## Clean project
 test: ## Start test
 	env GOOS=$(GOOS) $(GO_TEST) -cover $(GO_PKGROOT) -coverpkg=./... -coverprofile=cover.out
 	$(GO_TOOL) cover -html=cover.out -o cover.html
+
+test-e2e: build ## Run shellspec end-to-end tests against the built binary
+	shellspec --shell sh
 
 bench: ## Start benchmark
 	env GOOS=$(GOOS) go test -bench=BenchmarkImport100000Records -benchmem

--- a/spec/batch_spec.sh
+++ b/spec/batch_spec.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Non-TTY batch-mode end-to-end tests (#246). Piping into sqly (no terminal)
+# runs commands from stdin; failures must surface a non-zero exit code.
+
+Describe 'sqly batch mode (piped stdin)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'runs SQL read from stdin'
+    Data
+      #|SELECT user_name FROM user ORDER BY identifier LIMIT 1
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+    The output should include 'booker12'
+  End
+
+  It 'switches output mode and runs the following query'
+    Data
+      #|.mode ndjson
+      #|SELECT user_name FROM user ORDER BY identifier LIMIT 1
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+    The output should include '{"user_name":"booker12"}'
+  End
+
+  It 'exits non-zero and names the failing line on error'
+    Data
+      #|SELECT user_name FROM user ORDER BY identifier LIMIT 1
+      #|SELECT * FROM no_such_table
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The output should include 'booker12'
+    The stderr should include 'batch line 2 failed'
+    The stderr should include 'no_such_table'
+  End
+
+  It 'stops at .exit with a success status'
+    Data
+      #|.exit
+      #|SELECT * FROM no_such_table
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+  End
+End

--- a/spec/helpers_spec.sh
+++ b/spec/helpers_spec.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Shell helper-command end-to-end tests: in-process .ls/.clear/.cd (#236),
+# quoted .import arguments (#246), and the .mode listing (#237). Driven through
+# piped stdin so the real binary is exercised.
+
+Describe 'sqly shell helper commands'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe '.cd and .pwd'
+    It 'changes directory with a relative path and reports it'
+      Data
+        #|.cd testdata
+        #|.pwd
+      End
+      When run sqly
+      The status should be success
+      The output should include 'testdata'
+    End
+  End
+
+  Describe '.clear'
+    It 'clears the screen in-process without an external command'
+      clear_seq=$(printf '\033[H\033[2J\033[3J')
+      Data
+        #|.clear
+      End
+      When run sqly
+      The status should be success
+      The output should equal "$clear_seq"
+    End
+  End
+
+  Describe '.import with a quoted path containing a space'
+    setup() { printf 'id,name\n1,foo\n' > '/tmp/sqly_e2e space.csv'; }
+    cleanup() { rm -f '/tmp/sqly_e2e space.csv'; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'imports the file as a single argument'
+      Data
+        #|.import "/tmp/sqly_e2e space.csv"
+        #|.tables
+      End
+      When run sqly
+      The status should be success
+      The output should include 'sqly_e2e_space'
+    End
+  End
+
+  Describe '.mode'
+    It 'lists json and ndjson modes'
+      Data
+        #|.mode
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'json'
+      The output should include 'ndjson'
+    End
+  End
+End

--- a/spec/helpers_spec.sh
+++ b/spec/helpers_spec.sh
@@ -33,14 +33,20 @@ Describe 'sqly shell helper commands'
   End
 
   Describe '.import with a quoted path containing a space'
-    setup() { printf 'id,name\n1,foo\n' > '/tmp/sqly_e2e space.csv'; }
-    cleanup() { rm -f '/tmp/sqly_e2e space.csv'; }
+    # Use a unique directory so concurrent runs cannot collide; the spaced
+    # filename inside it is what the quoting must handle.
+    setup() {
+      IMPORT_DIR="$(mktemp -d)"
+      export IMPORT_DIR
+      printf 'id,name\n1,foo\n' > "$IMPORT_DIR/sqly_e2e space.csv"
+    }
+    cleanup() { rm -rf "${IMPORT_DIR:-}"; }
     Before 'setup'
     After 'cleanup'
 
     It 'imports the file as a single argument'
-      Data
-        #|.import "/tmp/sqly_e2e space.csv"
+      Data:expand
+        #|.import "$IMPORT_DIR/sqly_e2e space.csv"
         #|.tables
       End
       When run sqly

--- a/spec/output_format_spec.sh
+++ b/spec/output_format_spec.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Output-format end-to-end tests (#237 and existing formats). Runs the binary
+# with --json/--ndjson/--csv and checks the rendered query results.
+
+Describe 'sqly output formats'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe '--json'
+    It 'renders results as a JSON array'
+      When run sqly --json --sql "SELECT user_name, identifier FROM user ORDER BY identifier LIMIT 2" testdata/user.csv
+      The status should be success
+      The line 1 should equal '['
+      The output should include '{"user_name":"booker12","identifier":"1"}'
+      The output should include '{"user_name":"jenkins46","identifier":"2"}'
+    End
+
+    It 'prints [] for an empty result'
+      When run sqly --json --sql "SELECT user_name FROM user WHERE user_name = 'nobody'" testdata/user.csv
+      The status should be success
+      The output should equal '[]'
+    End
+  End
+
+  Describe '--ndjson'
+    It 'renders one JSON object per line'
+      When run sqly --ndjson --sql "SELECT user_name, identifier FROM user ORDER BY identifier LIMIT 2" testdata/user.csv
+      The status should be success
+      The line 1 should equal '{"user_name":"booker12","identifier":"1"}'
+      The line 2 should equal '{"user_name":"jenkins46","identifier":"2"}'
+    End
+
+    It 'prints nothing for an empty result'
+      When run sqly --ndjson --sql "SELECT user_name FROM user WHERE user_name = 'nobody'" testdata/user.csv
+      The status should be success
+      The output should equal ''
+    End
+  End
+
+  Describe '--csv'
+    It 'renders header and rows as CSV'
+      When run sqly --csv --sql "SELECT user_name, identifier FROM user ORDER BY identifier LIMIT 1" testdata/user.csv
+      The status should be success
+      The line 1 should equal 'user_name,identifier'
+      The line 2 should equal 'booker12,1'
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# shellspec helper for sqly end-to-end tests. These exercise the built binary
+# the way a user does (flags, piped stdin, exit codes) rather than internal Go
+# paths, so they catch regressions unit tests cannot.
+
+set -eu
+
+PROJECT_ROOT="$(cd "$SHELLSPEC_SPECDIR/.." && pwd)"
+export PROJECT_ROOT
+
+# SQLY_BIN points at the binary built by `make build`. Override to test another
+# build. The specs fail loudly (below) if it is missing.
+SQLY_BIN="${SQLY_BIN:-$PROJECT_ROOT/sqly}"
+export SQLY_BIN
+
+# sqly runs the built binary from the project root so that testdata/ relative
+# paths resolve regardless of where shellspec was invoked.
+sqly() {
+  cd "$PROJECT_ROOT" && "$SQLY_BIN" "$@"
+}


### PR DESCRIPTION
## Summary
Adds end-to-end tests that exercise the built sqly binary the way a user does — through CLI flags, piped stdin, and exit codes — using [shellspec](https://github.com/shellspec/shellspec), and runs them in CI. Until now, CLI/shell behavior was only covered by Go tests that swap internal writers, which do not prove the real binary works. This locks down recently shipped behavior (batch mode, in-process helpers, JSON/NDJSON output) at the binary level.

The setup mirrors the shellspec conventions already used in nao1215/sqlode.

## Changes
- `.shellspec`: run specs with `sh` and documentation format.
- `spec/spec_helper.sh`: resolves the project root and runs the `make build` binary so `testdata/` relative paths work.
- `spec/output_format_spec.sh`: `--json` array, `--ndjson` lines, `--csv`, and empty-result behavior (`[]` and empty stream).
- `spec/batch_spec.sh`: piped stdin runs SQL, `.mode` switching, non-zero exit with the failing line on error, and `.exit` early stop.
- `spec/helpers_spec.sh`: `.cd` relative move + `.pwd`, in-process `.clear` ANSI output, quoted `.import` of a spaced path, and the `.mode` listing.
- `Makefile`: `make test-e2e` builds the binary and runs shellspec.
- `.github/workflows/e2e_test.yml`: installs shellspec, builds, and runs the specs on Linux and macOS.

## Notes
Binary e2e runs on Linux and macOS; cross-platform behavior on Windows stays covered by the Go tests, since shellspec depends on a POSIX shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for batch mode operations, shell helper commands (directory navigation, screen clearing, file imports, output modes), and output format rendering (JSON, NDJSON, CSV).

* **Chores**
  * Configured automated end-to-end testing via GitHub Actions across Ubuntu and macOS platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqly/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->