### PR TITLE
feat: add Parquet as an export target

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -113,6 +113,7 @@ deps:
       - filesql
       - fileparser
       - excelize
+      - sqlite
     mayDependOn:
       - model
       - repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### New Features
-* Parquet Export: Export query results to Apache Parquet via `--parquet`, `.mode parquet`, `.dump`, and `--output`. Like Excel, it is export-only: on screen it renders as CSV, and writes the file through filesql. Exporting an empty result errors because Parquet needs at least one row to infer its schema.
+* Parquet Export: Export query results to Apache Parquet via `--parquet`, `.mode parquet`, `.dump`, and `--output`. Like Excel, it is export-only: on-screen it renders as CSV, and writes the file through filesql. Exporting an empty result errors because Parquet needs at least one row to infer its schema.
 * Schema Inspection Commands: `.schema TABLE_NAME` prints the `CREATE TABLE` statement and `.describe TABLE_NAME` lists each column's position, name, type, nullability, default, and primary-key flag. Both work for CSV/TSV/LTSV/JSON, Excel, ACH, and Fedwire tables, and emit structured output in `.mode json`/`.mode ndjson`.
 * JSON and NDJSON Output: Render query results as JSON or newline-delimited JSON via `--json`/`--ndjson`, `.mode json`/`.mode ndjson` in the shell, and `.dump`/`--output` for files. Values are emitted as strings like the other text formats; an empty result is `[]` for JSON and an empty stream for NDJSON.
 * Non-TTY Batch Mode: When stdin is piped or redirected, sqly reads SQL and helper commands from stdin line by line. A failed command exits non-zero, so batch runs are scriptable (e.g. `echo 'SELECT * FROM sample' | sqly sample.csv`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### New Features
+* Parquet Export: Export query results to Apache Parquet via `--parquet`, `.mode parquet`, `.dump`, and `--output`. Like Excel, it is export-only: on screen it renders as CSV, and writes the file through filesql. Exporting an empty result errors because Parquet needs at least one row to infer its schema.
 * Schema Inspection Commands: `.schema TABLE_NAME` prints the `CREATE TABLE` statement and `.describe TABLE_NAME` lists each column's position, name, type, nullability, default, and primary-key flag. Both work for CSV/TSV/LTSV/JSON, Excel, ACH, and Fedwire tables, and emit structured output in `.mode json`/`.mode ndjson`.
 * JSON and NDJSON Output: Render query results as JSON or newline-delimited JSON via `--json`/`--ndjson`, `.mode json`/`.mode ndjson` in the shell, and `.dump`/`--output` for files. Values are emitted as strings like the other text formats; an empty result is `[]` for JSON and an empty stream for NDJSON.
 * Non-TTY Batch Mode: When stdin is piped or redirected, sqly reads SQL and helper commands from stdin line by line. A failed command exits non-zero, so batch runs are scriptable (e.g. `echo 'SELECT * FROM sample' | sqly sample.csv`).

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The sqly output sql query results in following formats:
 - LTSV format (--ltsv option)
 - JSON format (--json option)
 - NDJSON format (--ndjson option)
+- Parquet export (--parquet option, export-only)
 
 ```shell
 $ sqly --sql "SELECT * FROM user LIMIT 2" --csv testdata/user.csv 
@@ -188,6 +189,13 @@ $ sqly --sql "SELECT user_name, identifier FROM user LIMIT 2" --ndjson testdata/
 ```
 
 In the shell, switch with `.mode json` or `.mode ndjson`. `.dump` writes the current mode to a file (`.json`/`.ndjson`).
+
+Parquet is export-only, like Excel: `.mode parquet` (or `--parquet`) renders as CSV on screen and writes a `.parquet` file through `.dump` or `--output`. sqly can re-import the file. An empty result cannot be exported because Parquet needs at least one row to infer its schema.
+
+```shell
+$ sqly --parquet --output result.parquet --sql "SELECT * FROM user" testdata/user.csv
+Output sql result to result.parquet (output mode=parquet)
+```
 
 ### Run sqly shell
 The sqly shell starts when you run the sqly command without the --sql option. When you execute sqly command with file path, the sqly-shell starts after importing the file into the SQLite3 in-memory database.  

--- a/config/argument.go
+++ b/config/argument.go
@@ -57,6 +57,7 @@ type outputFlag struct {
 	markdown bool
 	json     bool
 	ndjson   bool
+	parquet  bool
 }
 
 // NewArg return *Arg that is assigned the result of parsing os.Args.
@@ -79,6 +80,7 @@ func NewArg(args []string) (*Arg, error) {
 	flag.BoolVarP(&oFlag.tsv, "tsv", "t", false, "change output format to tsv (default: table)")
 	flag.BoolVarP(&oFlag.json, "json", "j", false, "change output format to json (default: table)")
 	flag.BoolVarP(&oFlag.ndjson, "ndjson", "n", false, "change output format to ndjson (default: table)")
+	flag.BoolVarP(&oFlag.parquet, "parquet", "p", false, "export results as parquet (export-only; use with --output or .dump)")
 	sheetName := flag.StringP("sheet", "S", "", "excel sheet name you want to import")
 	query := flag.StringP("sql", "s", "", "sql query you want to execute")
 	output := flag.StringP("output", "o", "", "destination path for SQL results specified in --sql option")
@@ -118,6 +120,8 @@ func newOutput(filePath string, of outputFlag) *Output {
 		output.Mode = model.PrintModeJSON
 	case of.ndjson:
 		output.Mode = model.PrintModeNDJSON
+	case of.parquet:
+		output.Mode = model.PrintModeParquet
 	default:
 		output.Mode = model.PrintModeTable
 	}

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -117,6 +117,17 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("user set --parquet option", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--parquet"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if arg.Output.Mode != model.PrintModeParquet {
+			t.Errorf("mismatch got=%v, want=%v", arg.Output.Mode, model.PrintModeParquet)
+		}
+	})
+
 	t.Run("default print mode", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly"})
 		if err != nil {

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -23,6 +23,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -t, --tsv             change output format to tsv (default: table)
   -j, --json            change output format to json (default: table)
   -n, --ndjson          change output format to ndjson (default: table)
+  -p, --parquet         export results as parquet (export-only; use with --output or .dump)
   -S, --sheet string    excel sheet name you want to import
   -s, --sql string      sql query you want to execute
   -o, --output string   destination path for SQL results specified in --sql option

--- a/doc/pages/markdown/sqly_helper_command.md
+++ b/doc/pages/markdown/sqly_helper_command.md
@@ -121,6 +121,7 @@ sqly:~/github/github.com/nao1215/sqly(table)$ .mode
   json
   ndjson
   excel ※ active only when executing .dump, otherwise same as csv mode
+  parquet ※ active only when executing .dump, otherwise same as csv mode
 ```
 
 ### pwd command

--- a/domain/model/export.go
+++ b/domain/model/export.go
@@ -20,6 +20,8 @@ const (
 	ExportJSON
 	// ExportNDJSON exports data as newline-delimited JSON
 	ExportNDJSON
+	// ExportParquet exports data as Apache Parquet
+	ExportParquet
 )
 
 // String returns the string representation of the ExportFormat.
@@ -39,6 +41,8 @@ func (e ExportFormat) String() string {
 		return formatJSON
 	case ExportNDJSON:
 		return formatNDJSON
+	case ExportParquet:
+		return formatParquet
 	}
 	return formatCSV
 }
@@ -60,6 +64,8 @@ func (e ExportFormat) Extension() string {
 		return ExtJSON
 	case ExportNDJSON:
 		return ExtNDJSON
+	case ExportParquet:
+		return ExtParquet
 	}
 	return ExtCSV
 }
@@ -82,6 +88,8 @@ func ExportFormatFromPrintMode(m PrintMode) ExportFormat {
 		return ExportJSON
 	case PrintModeNDJSON:
 		return ExportNDJSON
+	case PrintModeParquet:
+		return ExportParquet
 	default:
 		return ExportCSV
 	}

--- a/domain/model/export_test.go
+++ b/domain/model/export_test.go
@@ -17,6 +17,7 @@ func TestExportFormat_String(t *testing.T) {
 		{name: "excel", ef: ExportExcel, want: "excel"},
 		{name: "json", ef: ExportJSON, want: "json"},
 		{name: "ndjson", ef: ExportNDJSON, want: "ndjson"},
+		{name: "parquet", ef: ExportParquet, want: "parquet"},
 		{name: "unknown defaults to csv", ef: ExportFormat(99), want: "csv"},
 	}
 	for _, tt := range tests {
@@ -44,6 +45,7 @@ func TestExportFormat_Extension(t *testing.T) {
 		{name: "excel", ef: ExportExcel, want: ".xlsx"},
 		{name: "json", ef: ExportJSON, want: ".json"},
 		{name: "ndjson", ef: ExportNDJSON, want: ".ndjson"},
+		{name: "parquet", ef: ExportParquet, want: ".parquet"},
 		{name: "unknown defaults to .csv", ef: ExportFormat(99), want: ".csv"},
 	}
 	for _, tt := range tests {
@@ -72,6 +74,7 @@ func TestExportFormatFromPrintMode(t *testing.T) {
 		{name: "excel", mode: PrintModeExcel, want: ExportExcel},
 		{name: "json", mode: PrintModeJSON, want: ExportJSON},
 		{name: "ndjson", mode: PrintModeNDJSON, want: ExportNDJSON},
+		{name: "parquet", mode: PrintModeParquet, want: ExportParquet},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -57,6 +57,7 @@ const (
 	formatExcel    = "excel"
 	formatJSON     = "json"
 	formatNDJSON   = "ndjson"
+	formatParquet  = "parquet"
 )
 
 // Extension name constants.
@@ -68,6 +69,7 @@ const (
 	ExtExcel    = ".xlsx"
 	ExtJSON     = ".json"
 	ExtNDJSON   = ".ndjson"
+	ExtParquet  = ".parquet"
 )
 
 const (
@@ -87,6 +89,9 @@ const (
 	PrintModeJSON
 	// PrintModeNDJSON print data as newline-delimited JSON (one object per line)
 	PrintModeNDJSON
+	// PrintModeParquet is an export-only mode; on screen it renders like CSV and
+	// only writes a Parquet file via .dump or --output (same pattern as Excel).
+	PrintModeParquet
 )
 
 // String return string of PrintMode.
@@ -108,6 +113,8 @@ func (p PrintMode) String() string {
 		return formatJSON
 	case PrintModeNDJSON:
 		return formatNDJSON
+	case PrintModeParquet:
+		return formatParquet
 	}
 	return "unknown"
 }
@@ -242,6 +249,11 @@ func (t *Table) Print(out io.Writer, mode PrintMode) error {
 		return t.printJSON(out)
 	case PrintModeNDJSON:
 		return t.printNDJSON(out)
+	case PrintModeParquet:
+		// Export-only: on screen, render like CSV. The Parquet file is written
+		// by the export path (.dump / --output), not here.
+		t.printCSV(out)
+		return nil
 	default:
 		return t.printTable(out)
 	}

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -111,6 +111,11 @@ func TestPrintModeString(t *testing.T) {
 			want: "ndjson",
 		},
 		{
+			name: "parquet mode",
+			p:    PrintModeParquet,
+			want: "parquet",
+		},
+		{
 			name: "unknown mode",
 			p:    100, // not defined
 			want: "unknown",

--- a/infrastructure/filesql/parquet.go
+++ b/infrastructure/filesql/parquet.go
@@ -11,6 +11,7 @@ import (
 	libfilesql "github.com/nao1215/filesql"
 	"github.com/nao1215/sqly/domain/model"
 	infra "github.com/nao1215/sqly/infrastructure"
+	_ "modernc.org/sqlite" // register the "sqlite" driver used for the staging DB
 )
 
 // DumpTableToParquet writes a single table to a Parquet file at filePath.
@@ -49,10 +50,20 @@ func DumpTableToParquet(filePath string, table *model.Table) (err error) {
 	if _, err = db.ExecContext(ctx, infra.GenerateCreateTableStatement(table)); err != nil {
 		return fmt.Errorf("create staging table: %w", err)
 	}
+	// Insert in a single transaction; one implicit transaction per row is slow
+	// for large exports.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin staging transaction: %w", err)
+	}
 	for _, record := range table.Records() {
-		if _, err = db.ExecContext(ctx, infra.GenerateInsertStatement(table.Name(), record)); err != nil {
+		if _, err = tx.ExecContext(ctx, infra.GenerateInsertStatement(table.Name(), record)); err != nil {
+			_ = tx.Rollback()
 			return fmt.Errorf("insert into staging table: %w", err)
 		}
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit staging transaction: %w", err)
 	}
 
 	outDir := filepath.Join(tmpDir, "out")

--- a/infrastructure/filesql/parquet.go
+++ b/infrastructure/filesql/parquet.go
@@ -1,0 +1,90 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	libfilesql "github.com/nao1215/filesql"
+	"github.com/nao1215/sqly/domain/model"
+	infra "github.com/nao1215/sqly/infrastructure"
+)
+
+// DumpTableToParquet writes a single table to a Parquet file at filePath.
+//
+// filesql can read Parquet but only exposes a whole-database dump
+// (DumpDatabase writes one file per table into a directory), so sqly stages the
+// table in a temporary single-table SQLite database, dumps it to Parquet, and
+// moves the one produced file to filePath. A file-backed temporary database is
+// used because filesql's dumper opens a second connection, which would deadlock
+// a single-connection in-memory database and would not be shared otherwise.
+func DumpTableToParquet(filePath string, table *model.Table) (err error) {
+	// filesql's Parquet writer needs at least one row to infer the column
+	// schema and rejects an empty source. Surface that limitation with a clear
+	// message instead of filesql's internal error.
+	if len(table.Records()) == 0 {
+		return errors.New("cannot export an empty result to parquet: parquet export requires at least one row")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "sqly-parquet-")
+	if err != nil {
+		return fmt.Errorf("create temp dir for parquet dump: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	db, err := sql.Open("sqlite", filepath.Join(tmpDir, "stage.db"))
+	if err != nil {
+		return fmt.Errorf("open staging database: %w", err)
+	}
+	defer func() {
+		if cerr := db.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close staging database: %w", cerr)
+		}
+	}()
+
+	ctx := context.Background()
+	if _, err = db.ExecContext(ctx, infra.GenerateCreateTableStatement(table)); err != nil {
+		return fmt.Errorf("create staging table: %w", err)
+	}
+	for _, record := range table.Records() {
+		if _, err = db.ExecContext(ctx, infra.GenerateInsertStatement(table.Name(), record)); err != nil {
+			return fmt.Errorf("insert into staging table: %w", err)
+		}
+	}
+
+	outDir := filepath.Join(tmpDir, "out")
+	opts := libfilesql.NewDumpOptions().WithFormat(libfilesql.OutputFormatParquet)
+	if err = libfilesql.DumpDatabase(db, outDir, opts); err != nil {
+		return fmt.Errorf("dump table to parquet: %w", err)
+	}
+
+	produced, err := filepath.Glob(filepath.Join(outDir, "*.parquet"))
+	if err != nil {
+		return fmt.Errorf("locate parquet output: %w", err)
+	}
+	if len(produced) != 1 {
+		return fmt.Errorf("expected 1 parquet file, got %d", len(produced))
+	}
+	if err = copyFile(produced[0], filePath); err != nil {
+		return fmt.Errorf("write parquet to %q: %w", filePath, err)
+	}
+	return nil
+}
+
+// copyFile copies src to dst. A copy (not rename) is used because the temporary
+// directory and the destination may live on different filesystems.
+func copyFile(src, dst string) (err error) {
+	data, err := os.ReadFile(src) //nolint:gosec // src is a sqly-generated temp path
+	if err != nil {
+		return err
+	}
+	// dst is the user-chosen output path (already filepath.Clean'd by the caller);
+	// writing there is the intended behavior of an export command.
+	if err = os.WriteFile(dst, data, 0o600); err != nil { //nolint:gosec // user-specified output path
+		return err
+	}
+	return nil
+}

--- a/infrastructure/filesql/parquet_test.go
+++ b/infrastructure/filesql/parquet_test.go
@@ -1,0 +1,96 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	libfilesql "github.com/nao1215/filesql"
+	"github.com/nao1215/sqly/domain/model"
+	_ "modernc.org/sqlite"
+)
+
+// reimportRowCount writes the parquet file back into a fresh database via
+// filesql and returns the row count of the given table.
+func reimportRowCount(t *testing.T, parquetPath, tableName string) int {
+	t.Helper()
+	db, err := libfilesql.OpenContext(context.Background(), parquetPath)
+	if err != nil {
+		t.Fatalf("reimport parquet: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	var n int
+	if err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM "+tableName).Scan(&n); err != nil {
+		t.Fatalf("count after reimport: %v", err)
+	}
+	return n
+}
+
+// TestDumpTableToParquet_RoundTrip locks the #241 export target: a table
+// written to Parquet must re-import into sqly with the same rows and columns.
+func TestDumpTableToParquet_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	table := model.NewTable("people", model.Header{"id", "name"}, []model.Record{
+		{"1", "alice"},
+		{"2", "bob"},
+		{"3", "carol"},
+	})
+	out := filepath.Join(t.TempDir(), "people.parquet")
+
+	if err := DumpTableToParquet(out, table); err != nil {
+		t.Fatalf("DumpTableToParquet: %v", err)
+	}
+
+	if got := reimportRowCount(t, out, "people"); got != 3 {
+		t.Errorf("reimported rows = %d, want 3", got)
+	}
+
+	// Schema fidelity: the reimported table exposes the same columns.
+	db, err := libfilesql.OpenContext(context.Background(), out)
+	if err != nil {
+		t.Fatalf("reimport: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	rows, err := db.QueryContext(context.Background(), "PRAGMA table_info('people')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	var cols []string
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, typ string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+			t.Fatal(err)
+		}
+		cols = append(cols, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(cols) != 2 || cols[0] != "id" || cols[1] != "name" {
+		t.Errorf("reimported columns = %v, want [id name]", cols)
+	}
+}
+
+// TestDumpTableToParquet_EmptyResult covers the empty-result behavior required
+// by #241. Parquet needs at least one row to infer its schema, so exporting an
+// empty result returns a clear error rather than writing an unreadable file.
+func TestDumpTableToParquet_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	table := model.NewTable("empty", model.Header{"a", "b"}, []model.Record{})
+	out := filepath.Join(t.TempDir(), "empty.parquet")
+
+	err := DumpTableToParquet(out, table)
+	if err == nil {
+		t.Fatal("DumpTableToParquet on empty result = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "empty result") {
+		t.Errorf("error = %q, want it to mention the empty result", err.Error())
+	}
+}

--- a/interactor/export.go
+++ b/interactor/export.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/domain/repository"
+	"github.com/nao1215/sqly/infrastructure/filesql"
 	"github.com/nao1215/sqly/usecase"
 )
 
@@ -58,6 +59,8 @@ func (e *exportInteractor) DumpTable(filePath string, table *model.Table, format
 		return e.dumpViaPrint(filePath, table, model.PrintModeJSON)
 	case model.ExportNDJSON:
 		return e.dumpViaPrint(filePath, table, model.PrintModeNDJSON)
+	case model.ExportParquet:
+		return filesql.DumpTableToParquet(filepath.Clean(filePath), table)
 	default:
 		return e.dumpWithFile(filePath, table, e.csvRepo.Dump)
 	}

--- a/shell/mode.go
+++ b/shell/mode.go
@@ -21,6 +21,7 @@ func (c CommandList) modeCommand(_ context.Context, s *Shell, argv []string) err
 		fmt.Fprintln(config.Stdout, "  json")
 		fmt.Fprintln(config.Stdout, "  ndjson")
 		fmt.Fprintln(config.Stdout, "  excel ※ active only when executing .dump, otherwise same as csv mode")
+		fmt.Fprintln(config.Stdout, "  parquet ※ active only when executing .dump, otherwise same as csv mode")
 		return nil
 	}
 	return s.state.mode.changeOutputModeIfNeeded(argv[0])

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -364,6 +364,7 @@ func (s *Shell) getRegularCompletions(ctx context.Context, input string) []Sugge
 		{Text: "json", Description: "sqly command argument: json output format"},
 		{Text: "ndjson", Description: "sqly command argument: ndjson output format"},
 		{Text: "excel", Description: "sqly command argument: excel output format"},
+		{Text: "parquet", Description: "sqly command argument: parquet export format"},
 	}
 
 	for _, v := range s.commands {

--- a/shell/state.go
+++ b/shell/state.go
@@ -90,6 +90,10 @@ func (m *mode) changeOutputModeIfNeeded(modeName string) error {
 		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
 			m.String(), model.PrintModeExcel.String())
 		m.PrintMode = model.PrintModeExcel
+	case model.PrintModeParquet.String():
+		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
+			m.String(), model.PrintModeParquet.String())
+		m.PrintMode = model.PrintModeParquet
 	default:
 		return fmt.Errorf("invalid output mode: %s", modeName)
 	}

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -23,6 +23,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -t, --tsv             change output format to tsv (default: table)
   -j, --json            change output format to json (default: table)
   -n, --ndjson          change output format to ndjson (default: table)
+  -p, --parquet         export results as parquet (export-only; use with --output or .dump)
   -S, --sheet string    excel sheet name you want to import
   -s, --sql string      sql query you want to execute
   -o, --output string   destination path for SQL results specified in --sql option

--- a/shell/testdata/golden/mode_without_arg.golden
+++ b/shell/testdata/golden/mode_without_arg.golden
@@ -9,3 +9,4 @@
   json
   ndjson
   excel ※ active only when executing .dump, otherwise same as csv mode
+  parquet ※ active only when executing .dump, otherwise same as csv mode

--- a/spec/parquet_export_spec.sh
+++ b/spec/parquet_export_spec.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Parquet export end-to-end tests (#241). Parquet is export-only, like Excel:
+# it is written by .dump and --output, re-imports cleanly, normalizes the file
+# extension, and reports a clear error for an empty result.
+
+Describe 'sqly parquet export'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe '.dump and round-trip'
+    check_dump_roundtrip() {
+      dir=$(mktemp -d)
+      out="$dir/user.parquet"
+      printf '.mode parquet\n.dump user %s\n' "$out" | sqly testdata/user.csv >/dev/null
+      [ -f "$out" ] || { rm -rf "$dir"; return 1; }
+      # A fresh import of the parquet file must have the same row count.
+      count=$(printf 'SELECT COUNT(*) FROM user\n' | sqly "$out" | tail -n +2 | grep -o '[0-9]\+' | head -1)
+      rm -rf "$dir"
+      [ "$count" = "3" ]
+    }
+    It 'writes a parquet file that re-imports with the same rows'
+      When call check_dump_roundtrip
+      The status should be success
+    End
+  End
+
+  Describe 'extension normalization'
+    check_extension() {
+      dir=$(mktemp -d)
+      # No extension given; parquet mode must produce a .parquet file.
+      printf '.mode parquet\n.dump user %s/result\n' "$dir" | sqly testdata/user.csv >/dev/null
+      ok=1
+      [ -f "$dir/result.parquet" ] || ok=0
+      rm -rf "$dir"
+      [ "$ok" = "1" ]
+    }
+    It 'appends the .parquet extension'
+      When call check_extension
+      The status should be success
+    End
+  End
+
+  Describe '--output to a parquet file'
+    It 'writes query results to the given parquet path'
+      out_dir=$(mktemp -d)
+      export out_dir
+      When run sqly --parquet --output "$out_dir/q.parquet" --sql "SELECT user_name FROM user LIMIT 2" testdata/user.csv
+      The status should be success
+      The output should include 'q.parquet'
+      The path "$out_dir/q.parquet" should be file
+      rm -rf "$out_dir"
+    End
+  End
+
+  Describe 'empty result'
+    It 'reports a clear error when exporting an empty result'
+      out_dir=$(mktemp -d)
+      export out_dir
+      When run sqly --parquet --output "$out_dir/empty.parquet" --sql "SELECT user_name FROM user WHERE 1=0" testdata/user.csv
+      The status should be failure
+      The stderr should include 'empty result'
+      rm -rf "$out_dir"
+    End
+  End
+End


### PR DESCRIPTION
## Summary
Adds Apache Parquet as an export-only output format, the same way Excel works. Results can be written to `.parquet` via `--parquet`, `.mode parquet`, `.dump`, and `--output`, and re-imported into sqly.

Closes #241

## Changes
- domain/model: add `PrintModeParquet` and `ExportParquet` with the `.parquet` extension and `PrintMode` mapping. In display, Parquet renders as CSV (export-only, same as Excel).
- config/argument.go: add `--parquet`/`-p`.
- shell: accept `.mode parquet`, list it in the mode usage with the export-only note, and add a completion entry.
- interactor/export.go: route `ExportParquet` in `DumpTable` to the new writer.
- infrastructure/filesql/parquet.go: `DumpTableToParquet` stages the table in a temporary file-backed SQLite database and uses filesql's `DumpDatabase` to write Parquet, then moves the single produced file to the target path. filesql can read Parquet but only dumps a whole database to a directory, so a single-table staging database is used; it is file-backed because filesql's dumper opens a second connection that would deadlock or not share an in-memory database.
- Docs: README output-format section, GitHub Pages mode list, CHANGELOG.

## Design Decisions
Parquet is export-only because it is a binary columnar format with no useful terminal rendering, mirroring the existing Excel mode. Writing reuses filesql rather than adding a separate Parquet writer, keeping sqly aligned with the formats filesql already supports.

Exporting an empty result returns a clear error rather than writing an unreadable file: filesql's Parquet writer needs at least one row to infer the column schema. This is surfaced with a descriptive message instead of filesql's internal error.

## Tests
- infrastructure/filesql/parquet_test.go: round-trip (export then re-import, asserting rows and columns) and the empty-result error.
- spec/parquet_export_spec.sh: `.dump` round-trip, extension normalization, `--output` to a Parquet path, and the empty-result error with a non-zero exit code.
- Enum/flag tests for the new mode and flag; goldens for help, usage, and the mode list regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Parquet export: export results to .parquet via CLI flag or .dump; on-screen output remains CSV
  * Exporting an empty result now fails with a clear "empty result" message

* **Documentation**
  * Updated README, help text, and mode help to document Parquet export workflow and limitations

* **Tests**
  * Added unit and end-to-end tests validating Parquet round-trip and empty-result behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqly/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->