### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v0.16.0](https://github.com/nao1215/sqly/compare/v0.15.0...v0.16.0) (2026-05-30)
 
 ### New Features
 * Parquet Export: Export query results to Apache Parquet via `--parquet`, `.mode parquet`, `.dump`, and `--output`. Like Excel, it is export-only: on-screen it renders as CSV, and writes the file through filesql. Exporting an empty result errors because Parquet needs at least one row to infer its schema.

--- a/doc/pages/markdown/design_overview.md
+++ b/doc/pages/markdown/design_overview.md
@@ -1,6 +1,6 @@
 **sqly: A Design Overview**  
 
-sqly operates by reading CSV, TSV, LTSV, and JSON files, inserting the loaded data into an in-memory SQLite3 database, and then executing SQL queries against it.  
+sqly operates by reading CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedwire files, inserting the loaded data into an in-memory SQLite3 database, and then executing SQL queries against it.  
 
 The main advantage of this design is that there is no need to implement a custom SQL parser, making development significantly easier (which is crucial). Even if additional file formats are supported in the future, as long as the data insertion process is implemented, no modifications to the SQL parsing logic will be necessary.  
 

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -2,17 +2,17 @@
 
 If no SQL query is specified with the `--sql` option, sqly will start the sqly shell. sqly determines the file type to be loaded from the extension when the shell starts and automatically begins importing it into the SQLite3 in-memory database. Multiple files can be loaded simultaneously. The table names will be the file names (without extensions) or the Excel sheet names. If an SQL query is specified with the `--sql` option, the SQL query result will be displayed in the terminal and sqly will exit without starting the sqly shell.
 
-sqly allows you to change the display mode of SQL results with options. By default, the output is in table format. The output format can be changed to csv (`--csv`), excel (`--excel`), json (`--json`), ltsv (`--ltsv`), markdown (`--markdown`), or tsv (`--tsv`). Since the output mode can be changed while the sqly shell is running, it is easy to execute `sqly sample.csv` and then change settings or execute SQL queries within the sqly shell.
+sqly allows you to change the display mode of SQL results with options. By default, the output is in table format. The output format can be changed to csv (`--csv`), tsv (`--tsv`), ltsv (`--ltsv`), markdown (`--markdown`), json (`--json`), or ndjson (`--ndjson`). Excel (`--excel`) and Parquet (`--parquet`) are export-only: they render as csv on screen and write a file only through `.dump` or `--output`. Since the output mode can be changed while the sqly shell is running, it is easy to execute `sqly sample.csv` and then change settings or execute SQL queries within the sqly shell.
 
 
 ### sqly options
 
 ```shell
 $ sqly --help
-sqly - execute SQL against CSV/TSV/LTSV/JSON with shell (v0.10.0)
+sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire with shell
 
 [Usage]
-  sqly [OPTIONS] [FILE_PATH]
+  sqly [OPTIONS] [FILE_PATH(S)|DIRECTORY_PATH(S)]
 
 [Example]
   - run sqly shell
@@ -23,10 +23,12 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON with shell (v0.10.0)
 [OPTIONS]
   -c, --csv             change output format to csv (default: table)
   -e, --excel           change output format to excel (default: table)
-  -j, --json            change output format to json (default: table)
   -l, --ltsv            change output format to ltsv (default: table)
   -m, --markdown        change output format to markdown table (default: table)
   -t, --tsv             change output format to tsv (default: table)
+  -j, --json            change output format to json (default: table)
+  -n, --ndjson          change output format to ndjson (default: table)
+  -p, --parquet         export results as parquet (export-only; use with --output or .dump)
   -S, --sheet string    excel sheet name you want to import
   -s, --sql string      sql query you want to execute
   -o, --output string   destination path for SQL results specified in --sql option

--- a/doc/pages/markdown/index.md
+++ b/doc/pages/markdown/index.md
@@ -1,6 +1,6 @@
 ## What is sqly?
 
-The `sqly` command is a command-line tool for executing SQL queries on CSV/TSV/LTSV/JSON files and Microsoft Excel™. `sqly` is written in Golang and supports cross-platform usage. Similar tools include [harelba/q](https://github.com/harelba/q), [dinedal/textql](https://github.com/dinedal/textql), [noborus/trdsql](https://github.com/noborus/trdsql), and [mithrandie/csvq](https://github.com/mithrandie/csvq).
+The `sqly` command is a command-line tool for executing SQL queries on CSV, TSV, LTSV, JSON, JSONL, Parquet, Microsoft Excel, ACH, and Fedwire files, including their compressed variants. `sqly` is written in Golang and supports cross-platform usage. Similar tools include [harelba/q](https://github.com/harelba/q), [dinedal/textql](https://github.com/dinedal/textql), [noborus/trdsql](https://github.com/noborus/trdsql), and [mithrandie/csvq](https://github.com/mithrandie/csvq).
 
 One of the unique strengths of `sqly` is that it allows you to interactively build SQL queries using the `sqly shell`. You can interactively execute SQL with SQL completion and command history. Of course, you can also execute SQL without running the `sqly-shell`. Since `sqly` uses SQLite3 to execute SQL, the SQL syntax is equivalent to SQLite3.
 

--- a/doc/pages/markdown/installation.md
+++ b/doc/pages/markdown/installation.md
@@ -5,7 +5,7 @@ The following OS and Go versions are supported. The sqly is likely to work on BS
 - Windows
 - macOS
 - Linux
-- go1.22 or later
+- go1.25.0 or later
 
 ### Use "go install"
 


### PR DESCRIPTION
## Summary
Release preparation for v0.16.0. This is a minor release: every change since v0.15.0 is backward compatible (new features, fixes, refactors, docs, and tests).

This PR finalizes the CHANGELOG (sets the v0.16.0 heading, date, and compare link) and refreshes the GitHub Pages docs that had drifted.

## Highlights since v0.15.0
- JSON and NDJSON output modes (`--json`/`--ndjson`, `.mode`, `.dump`/`--output`).
- Non-TTY batch mode with scriptable exit codes, and quoted helper-command arguments.
- Schema inspection commands `.schema` and `.describe`.
- Parquet as an export target (`--parquet`, `.mode parquet`).
- In-process `.ls`/`.clear`/`.cd` (no external commands), plus a `.cd` Windows fix.
- shellspec binary e2e tests, property-based and metamorphic tests, and documented filesql session integration.

## Documentation checks
- README: feature coverage is current (all formats, batch mode, JSON/NDJSON, Parquet, schema inspection). The coverage badge resolves and reads 87.0%, kept current by the Coverage workflow on every main push.
- GitHub Pages: refreshed `how_to_use.md` (output formats and option list now include ndjson and parquet, usage header updated), `index.md` and `design_overview.md` (supported formats), and `installation.md` (Go 1.25.0).

## Release steps
Merge this PR, then push the `v0.16.0` tag. GoReleaser publishes the release and updates the Homebrew tap on tag push.