### PR TITLE
feat: add --stdin to import piped stdin as a dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### New Features
+* Stdin Dataset Input: `--stdin <format>` (csv|tsv|ltsv|json|jsonl) imports piped stdin as a dataset instead of reading it as SQL/helper commands, so sqly works in Unix pipelines (e.g. `cat users.csv | sqly --stdin csv --sql "SELECT * FROM stdin"`). The table defaults to `stdin` and is overridable with `--stdin-name`; piped data can be joined with file and directory arguments. Without `--stdin`, non-TTY batch mode is unchanged.
+
 ## [v0.16.0](https://github.com/nao1215/sqly/compare/v0.15.0...v0.16.0) (2026-05-30)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ $ printf '.tables\nSELECT COUNT(*) FROM user\n' | sqly testdata/user.csv
 +----------+
 ```
 
+### Pipe data into sqly: --stdin option
+By default piped stdin is read as SQL and shell commands (batch mode above). Use `--stdin <format>` to treat stdin as an input dataset instead. The format is given explicitly (`csv`, `tsv`, `ltsv`, `json`, or `jsonl`) because a pipe has no filename to detect it from. The table defaults to `stdin`; override it with `--stdin-name`. Piped data can be joined with file and directory arguments.
+
+```shell
+$ cat testdata/user.csv | sqly --stdin csv --sql "SELECT user_name FROM stdin LIMIT 1"
++-----------+
+| user_name |
++-----------+
+| booker12  |
++-----------+
+
+# Join piped stdin with a file
+$ cat testdata/user.csv | sqly --stdin csv --sql "SELECT s.user_name, i.position FROM stdin s JOIN identifier i ON s.identifier = i.id" testdata/identifier.csv
+```
+
 ### Directory import
 You can import entire directories containing supported files. The sqly automatically detects all supported files (CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, Fedwire, including compressed versions) in the directory recursively and imports them:
 

--- a/config/argument.go
+++ b/config/argument.go
@@ -44,6 +44,11 @@ type Arg struct {
 	Usage string
 	// SheetName is excel sheet name that is imported into the DB.
 	SheetName string
+	// StdinFormat, when non-empty, makes sqly read stdin as an input dataset of
+	// this format (csv|tsv|ltsv|json|jsonl) instead of as SQL/helper commands.
+	StdinFormat string
+	// StdinTableName is the table name for the --stdin dataset (default: stdin).
+	StdinTableName string
 	// Version print version message
 	Version func()
 }
@@ -82,6 +87,8 @@ func NewArg(args []string) (*Arg, error) {
 	flag.BoolVarP(&oFlag.ndjson, "ndjson", "n", false, "change output format to ndjson (default: table)")
 	flag.BoolVarP(&oFlag.parquet, "parquet", "p", false, "export results as parquet (export-only; use with --output or .dump)")
 	sheetName := flag.StringP("sheet", "S", "", "excel sheet name you want to import")
+	stdinFormat := flag.String("stdin", "", "treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)")
+	stdinName := flag.String("stdin-name", "stdin", "table name for the --stdin dataset")
 	query := flag.StringP("sql", "s", "", "sql query you want to execute")
 	output := flag.StringP("output", "o", "", "destination path for SQL results specified in --sql option")
 	flag.BoolVarP(&arg.HelpFlag, "help", "h", false, "print help message")
@@ -95,6 +102,8 @@ func NewArg(args []string) (*Arg, error) {
 	arg.Output = newOutput(*output, oFlag)
 	arg.FilePaths = flag.Args()
 	arg.SheetName = *sheetName
+	arg.StdinFormat = *stdinFormat
+	arg.StdinTableName = *stdinName
 	arg.Query = *query
 
 	return arg, nil

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -128,6 +128,29 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("user set --stdin and --stdin-name options", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--stdin", "csv", "--stdin-name", "piped"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.StdinFormat != "csv" {
+			t.Errorf("StdinFormat = %q, want csv", arg.StdinFormat)
+		}
+		if arg.StdinTableName != "piped" {
+			t.Errorf("StdinTableName = %q, want piped", arg.StdinTableName)
+		}
+	})
+
+	t.Run("stdin table name defaults to stdin", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--stdin", "csv"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.StdinTableName != "stdin" {
+			t.Errorf("StdinTableName = %q, want stdin", arg.StdinTableName)
+		}
+	})
+
 	t.Run("default print mode", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly"})
 		if err != nil {

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -16,19 +16,21 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
     echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv
 
 [OPTIONS]
-  -c, --csv             change output format to csv (default: table)
-  -e, --excel           change output format to excel (default: table)
-  -l, --ltsv            change output format to ltsv (default: table)
-  -m, --markdown        change output format to markdown table (default: table)
-  -t, --tsv             change output format to tsv (default: table)
-  -j, --json            change output format to json (default: table)
-  -n, --ndjson          change output format to ndjson (default: table)
-  -p, --parquet         export results as parquet (export-only; use with --output or .dump)
-  -S, --sheet string    excel sheet name you want to import
-  -s, --sql string      sql query you want to execute
-  -o, --output string   destination path for SQL results specified in --sql option
-  -h, --help            print help message
-  -v, --version         print sqly version
+  -c, --csv                 change output format to csv (default: table)
+  -e, --excel               change output format to excel (default: table)
+  -l, --ltsv                change output format to ltsv (default: table)
+  -m, --markdown            change output format to markdown table (default: table)
+  -t, --tsv                 change output format to tsv (default: table)
+  -j, --json                change output format to json (default: table)
+  -n, --ndjson              change output format to ndjson (default: table)
+  -p, --parquet             export results as parquet (export-only; use with --output or .dump)
+  -S, --sheet string        excel sheet name you want to import
+      --stdin string        treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
+      --stdin-name string   table name for the --stdin dataset (default "stdin")
+  -s, --sql string          sql query you want to execute
+  -o, --output string       destination path for SQL results specified in --sql option
+  -h, --help                print help message
+  -v, --version             print sqly version
 
 [LICENSE]
   MIT LICENSE - Copyright (c) 2022 CHIKAMATSU Naohiro

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -30,6 +30,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -n, --ndjson          change output format to ndjson (default: table)
   -p, --parquet         export results as parquet (export-only; use with --output or .dump)
   -S, --sheet string    excel sheet name you want to import
+      --stdin string    treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
+      --stdin-name string   table name for the --stdin dataset (default "stdin")
   -s, --sql string      sql query you want to execute
   -o, --output string   destination path for SQL results specified in --sql option
   -h, --help            print help message
@@ -59,6 +61,19 @@ $ sqly --sql "SELECT user_name, position FROM user INNER JOIN identifier ON user
 | jenkins46 | manager   |
 | smith79   | neet      |
 +-----------+-----------+
+```
+
+### Pipe data into sqly: --stdin option
+
+By default piped stdin is read as SQL and helper commands (batch mode). Use `--stdin <format>` to treat stdin as an input dataset instead. The format is given explicitly (`csv`, `tsv`, `ltsv`, `json`, or `jsonl`) because a pipe has no filename to detect it from. The table defaults to `stdin`; override it with `--stdin-name`. Piped data can be joined with file and directory arguments.
+
+```shell
+$ cat testdata/user.csv | sqly --stdin csv --sql "SELECT user_name FROM stdin LIMIT 1"
++-----------+
+| user_name |
++-----------+
+| booker12  |
++-----------+
 ```
 
 ### Change output format

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -68,6 +68,7 @@ const (
 	ExtMarkdown = ".md"
 	ExtExcel    = ".xlsx"
 	ExtJSON     = ".json"
+	ExtJSONL    = ".jsonl"
 	ExtNDJSON   = ".ndjson"
 	ExtParquet  = ".parquet"
 )

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -198,6 +198,11 @@ func (s *Shell) init(ctx context.Context) error {
 	// When --stdin is set, stage piped stdin as a dataset file and import it
 	// alongside the file/directory arguments so it can be queried and joined.
 	if s.argument.StdinFormat != "" {
+		// stageStdinDataset reads stdin to EOF; on a terminal that would hang
+		// waiting for the user. --stdin is only meaningful with piped input.
+		if s.isTTY() {
+			return errors.New("--stdin requires piped or redirected stdin")
+		}
 		stdinPath, cleanup, err := s.stageStdinDataset()
 		if err != nil {
 			return err
@@ -222,7 +227,7 @@ var stdinFormatExtensions = map[string]string{
 	"tsv":   model.ExtTSV,
 	"ltsv":  model.ExtLTSV,
 	"json":  model.ExtJSON,
-	"jsonl": ".jsonl",
+	"jsonl": model.ExtJSONL,
 }
 
 // stageStdinDataset reads all of stdin into a temporary file named after the

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -193,11 +193,72 @@ func (s *Shell) init(ctx context.Context) error {
 	if err := s.usecases.history.CreateTable(ctx); err != nil {
 		return fmt.Errorf("failed to create table for sqly history: %w", err)
 	}
-	if len(s.argument.FilePaths) == 0 {
-		return nil
+
+	paths := s.argument.FilePaths
+	// When --stdin is set, stage piped stdin as a dataset file and import it
+	// alongside the file/directory arguments so it can be queried and joined.
+	if s.argument.StdinFormat != "" {
+		stdinPath, cleanup, err := s.stageStdinDataset()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		paths = append([]string{stdinPath}, paths...)
 	}
 
-	return s.commands.importCommand(ctx, s, s.argument.FilePaths)
+	if len(paths) == 0 {
+		return nil
+	}
+	return s.commands.importCommand(ctx, s, paths)
+}
+
+// stdinFormatExtensions maps the --stdin format names to file extensions. The
+// format-name keys intentionally repeat strings used by unrelated features
+// (completion, mode names), so goconst is suppressed here.
+//
+//nolint:goconst // format-name registry keys
+var stdinFormatExtensions = map[string]string{
+	"csv":   model.ExtCSV,
+	"tsv":   model.ExtTSV,
+	"ltsv":  model.ExtLTSV,
+	"json":  model.ExtJSON,
+	"jsonl": ".jsonl",
+}
+
+// stageStdinDataset reads all of stdin into a temporary file named after the
+// stdin table so filesql imports it like a normal file. Why a temp file:
+// filesql loads by path, and staging keeps the import path identical to file
+// arguments (including table naming and joins). The returned cleanup removes the
+// temp directory; it is safe to call after import because the data is already
+// copied into the shared database.
+func (s *Shell) stageStdinDataset() (string, func(), error) {
+	ext, ok := stdinFormatExtensions[s.argument.StdinFormat]
+	if !ok {
+		return "", nil, fmt.Errorf("unsupported --stdin format %q (supported: csv, tsv, ltsv, json, jsonl)", s.argument.StdinFormat)
+	}
+
+	dir, err := os.MkdirTemp("", "sqly-stdin-")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp dir for stdin data: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+
+	path := filepath.Join(dir, s.argument.StdinTableName+ext)
+	f, err := os.Create(path) //nolint:gosec // path is a sqly-generated temp path
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("create stdin staging file: %w", err)
+	}
+	if _, err := io.Copy(f, s.stdin); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("read stdin data: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close stdin staging file: %w", err)
+	}
+	return path, cleanup, nil
 }
 
 // printWelcomeMessage print version and help information.

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2076,6 +2076,81 @@ func TestShell_buildCreateStatement(t *testing.T) {
 	}
 }
 
+func TestShellRun_StdinDataset(t *testing.T) {
+	// Regression for #258: --stdin treats piped stdin as an input dataset.
+	t.Run("queries piped CSV through the default stdin table", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "csv", "--csv", "--sql", "SELECT name FROM stdin ORDER BY id"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("id,name\n1,alice\n2,bob\n")
+
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "alice") || !strings.Contains(got, "bob") {
+			t.Fatalf("stdin dataset query output missing rows: %q", got)
+		}
+	})
+
+	t.Run("overrides the stdin table name", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "csv", "--stdin-name", "people", "--csv", "--sql", "SELECT COUNT(*) AS c FROM people"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("id,name\n1,alice\n2,bob\n3,carol\n")
+
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "3") {
+			t.Fatalf("expected count 3 from overridden table, got: %q", got)
+		}
+	})
+
+	t.Run("joins piped stdin with a file argument", func(t *testing.T) {
+		dir := t.TempDir()
+		idPath := filepath.Join(dir, "identifier.csv")
+		if err := os.WriteFile(idPath, []byte("id,position\n1,dev\n2,manager\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{
+			"sqly", "--stdin", "csv", "--csv",
+			"--sql", "SELECT s.name, i.position FROM stdin s JOIN identifier i ON s.id = i.id ORDER BY s.id",
+			idPath,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("id,name\n1,alice\n2,bob\n")
+
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "alice") || !strings.Contains(got, "dev") {
+			t.Fatalf("join of stdin with file did not produce expected rows: %q", got)
+		}
+	})
+
+	t.Run("invalid stdin format returns a clear error", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "xml", "--sql", "SELECT 1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("a,b\n1,2\n")
+
+		err = shell.Run(context.Background())
+		if err == nil {
+			t.Fatal("invalid --stdin format returned nil error, want error")
+		}
+		if !strings.Contains(err.Error(), "stdin") {
+			t.Fatalf("error = %q, want it to mention stdin", err.Error())
+		}
+	})
+}
+
 func TestShell_shortCWD(t *testing.T) {
 	shell, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2149,6 +2149,24 @@ func TestShellRun_StdinDataset(t *testing.T) {
 			t.Fatalf("error = %q, want it to mention stdin", err.Error())
 		}
 	})
+
+	t.Run("rejects --stdin on an interactive terminal", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "csv", "--sql", "SELECT 1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		// A terminal would make the stdin read block forever; reject early.
+		shell.isTTY = func() bool { return true }
+
+		err = shell.Run(context.Background())
+		if err == nil {
+			t.Fatal("--stdin on a TTY returned nil error, want error")
+		}
+		if !strings.Contains(err.Error(), "piped") {
+			t.Fatalf("error = %q, want it to mention piped stdin", err.Error())
+		}
+	})
 }
 
 func TestShell_shortCWD(t *testing.T) {

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -16,19 +16,21 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
     echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv
 
 [OPTIONS]
-  -c, --csv             change output format to csv (default: table)
-  -e, --excel           change output format to excel (default: table)
-  -l, --ltsv            change output format to ltsv (default: table)
-  -m, --markdown        change output format to markdown table (default: table)
-  -t, --tsv             change output format to tsv (default: table)
-  -j, --json            change output format to json (default: table)
-  -n, --ndjson          change output format to ndjson (default: table)
-  -p, --parquet         export results as parquet (export-only; use with --output or .dump)
-  -S, --sheet string    excel sheet name you want to import
-  -s, --sql string      sql query you want to execute
-  -o, --output string   destination path for SQL results specified in --sql option
-  -h, --help            print help message
-  -v, --version         print sqly version
+  -c, --csv                 change output format to csv (default: table)
+  -e, --excel               change output format to excel (default: table)
+  -l, --ltsv                change output format to ltsv (default: table)
+  -m, --markdown            change output format to markdown table (default: table)
+  -t, --tsv                 change output format to tsv (default: table)
+  -j, --json                change output format to json (default: table)
+  -n, --ndjson              change output format to ndjson (default: table)
+  -p, --parquet             export results as parquet (export-only; use with --output or .dump)
+  -S, --sheet string        excel sheet name you want to import
+      --stdin string        treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
+      --stdin-name string   table name for the --stdin dataset (default "stdin")
+  -s, --sql string          sql query you want to execute
+  -o, --output string       destination path for SQL results specified in --sql option
+  -h, --help                print help message
+  -v, --version             print sqly version
 
 [LICENSE]
   MIT LICENSE - Copyright (c) 2022 CHIKAMATSU Naohiro

--- a/spec/stdin_dataset_spec.sh
+++ b/spec/stdin_dataset_spec.sh
@@ -33,6 +33,16 @@ Describe 'sqly --stdin dataset'
       The output should include '1'
     End
 
+    It 'queries piped JSONL data stored in a data column'
+      Data
+        #|{"id":1,"name":"alice"}
+        #|{"id":2,"name":"bob"}
+      End
+      When run sqly --stdin jsonl --csv --sql "SELECT COUNT(*) AS c FROM stdin"
+      The status should be success
+      The output should include '2'
+    End
+
     It 'overrides the stdin table name with --stdin-name'
       Data
         #|id,name

--- a/spec/stdin_dataset_spec.sh
+++ b/spec/stdin_dataset_spec.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# stdin-as-dataset end-to-end tests (#258). With --stdin <format>, piped stdin
+# is imported as a dataset (default table "stdin") instead of being read as
+# SQL/helper commands, and it can be joined with file arguments. Without
+# --stdin, batch mode behavior is unchanged.
+
+Describe 'sqly --stdin dataset'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe 'querying piped data'
+    It 'queries piped CSV through the default stdin table'
+      Data
+        #|id,name
+        #|1,alice
+        #|2,bob
+      End
+      When run sqly --stdin csv --csv --sql "SELECT name FROM stdin ORDER BY id"
+      The status should be success
+      The line 1 should equal 'name'
+      The line 2 should equal 'alice'
+      The line 3 should equal 'bob'
+    End
+
+    It 'queries piped TSV data'
+      Data
+        #|id	name
+        #|1	alice
+      End
+      When run sqly --stdin tsv --csv --sql "SELECT COUNT(*) AS c FROM stdin"
+      The status should be success
+      The output should include '1'
+    End
+
+    It 'overrides the stdin table name with --stdin-name'
+      Data
+        #|id,name
+        #|1,alice
+        #|2,bob
+      End
+      When run sqly --stdin csv --stdin-name people --csv --sql "SELECT COUNT(*) FROM people"
+      The status should be success
+      The output should include '2'
+    End
+  End
+
+  Describe 'joining stdin with a file'
+    It 'joins piped stdin with an imported file argument'
+      Data
+        #|id,name
+        #|1,alice
+        #|2,bob
+      End
+      When run sqly --stdin csv --csv --sql "SELECT s.name, i.position FROM stdin s JOIN identifier i ON s.id = i.id ORDER BY s.id" testdata/identifier.csv
+      The status should be success
+      The output should include 'alice'
+      The output should include 'developrt'
+    End
+  End
+
+  Describe 'error handling'
+    It 'reports a clear error for an unsupported stdin format'
+      Data
+        #|a,b
+        #|1,2
+      End
+      When run sqly --stdin xml --sql "SELECT 1"
+      The status should be failure
+      The stderr should include 'unsupported --stdin format'
+    End
+  End
+
+  Describe 'batch mode is unchanged without --stdin'
+    It 'still reads stdin as SQL and helper commands'
+      Data
+        #|.tables
+        #|SELECT user_name FROM user ORDER BY identifier LIMIT 1
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'TABLE NAME'
+      The output should include 'booker12'
+    End
+  End
+End


### PR DESCRIPTION
## Summary
Adds an explicit stdin-as-data workflow so sqly fits Unix pipelines, without changing the non-TTY batch mode that reads SQL and helper commands from stdin (#246).

Closes #258

## Behavior
`--stdin <format>` (csv|tsv|ltsv|json|jsonl) imports piped stdin as a dataset instead of reading it as commands. The format is explicit because a pipe has no filename to detect it from. The table defaults to `stdin` and is overridable with `--stdin-name`. Piped data can be joined with file and directory arguments. When `--stdin` is not set, batch mode is unchanged.

```
cat users.csv | sqly --stdin csv --sql "SELECT * FROM stdin"
cat users.csv | sqly --stdin csv --sql "SELECT s.name FROM stdin s JOIN ids i ON s.id = i.id" ids.csv
```

## Changes
- config/argument.go: add `--stdin` and `--stdin-name` (default `stdin`).
- shell/shell.go: when `--stdin` is set, `init` stages stdin into a temp file named `<table>.<ext>` and imports it alongside the file arguments, so table naming and joins use the existing import path. An unsupported format returns a clear error.
- Docs: README and the GitHub Pages how-to page; CHANGELOG.

## Tests
- Go (shell): query piped CSV through the default table, override the table name, join piped stdin with a file, and reject an invalid format.
- Go (config): flag parsing and the default table name.
- shellspec (spec/stdin_dataset_spec.sh): piped CSV and TSV, table-name override, join with a file, unsupported-format error with a non-zero exit, and a regression that batch mode is unchanged without `--stdin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--stdin <format>` to treat piped input as a dataset (csv, tsv, ltsv, json, jsonl); default table name `stdin`, overridable via `--stdin-name`.
  * Piped stdin can be joined with other input datasets.

* **Documentation**
  * README, help text, and changelog updated with usage examples and flags.

* **Tests**
  * Added unit, integration, and end-to-end tests covering stdin dataset handling and help output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->