### PR TITLE
fix: tolerate unavailable history storage in non-interactive runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+* History Storage Tolerance: Non-interactive runs (`--sql` and batch mode) no longer fail when the history database cannot be created or written (for example, a read-only config directory in CI or containers). History is disabled for the session with a warning, and the requested command still runs. Point `SQLY_HISTORY_DB_PATH` at a writable path to re-enable it.
+
 ### New Features
 * Stdin Dataset Input: `--stdin <format>` (csv|tsv|ltsv|json|jsonl) imports piped stdin as a dataset instead of reading it as SQL/helper commands, so sqly works in Unix pipelines (e.g. `cat users.csv | sqly --stdin csv --sql "SELECT * FROM stdin"`). The table defaults to `stdin` and is overridable with `--stdin-name`; piped data can be joined with file and directory arguments. Without `--stdin`, non-TTY batch mode is unchanged.
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ sqly:~/github/github.com/nao1215/sqly(table)$
   
 The sqly shell functions similarly to a common SQL client (e.g., `sqlite3` command or `mysql` command). The sqly shell has helper commands that begin with a dot. The sqly-shell also supports command history, and input completion.  
 
+Command history is persisted to a SQLite database under the config directory. History is best-effort: if that database cannot be created or written (for example a read-only config directory in CI or a container), sqly disables history for the session with a warning and still runs the requested query or command. Set `SQLY_HISTORY_DB_PATH` to choose a writable location.
+
 The sqly-shell has the following helper commands:
 
 ```shell

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -76,6 +76,10 @@ $ cat testdata/user.csv | sqly --stdin csv --sql "SELECT user_name FROM stdin LI
 +-----------+
 ```
 
+### Command history
+
+The sqly shell persists command history to a SQLite database under the config directory. History is best-effort: if that database cannot be created or written (for example a read-only config directory in CI or a container), sqly disables history for the session with a warning and still runs the requested query or command. Set `SQLY_HISTORY_DB_PATH` to choose a writable location.
+
 ### Change output format
 
 ```shell

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -61,6 +61,10 @@ type Shell struct {
 	// isTTY reports whether stdin is an interactive terminal. When false, Run
 	// reads commands from stdin in batch mode instead of starting the prompt.
 	isTTY func() bool
+	// historyEnabled is true while command history can be persisted. It is
+	// disabled for the session if the history DB cannot be created or written,
+	// so automation does not fail on a read-only config location.
+	historyEnabled bool
 }
 
 type promptSession interface {
@@ -100,8 +104,9 @@ func NewShell(
 				prompt.WithMultiline(true),
 			)
 		},
-		stdin: os.Stdin,
-		isTTY: config.IsInputFromTTY,
+		stdin:          os.Stdin,
+		isTTY:          config.IsInputFromTTY,
+		historyEnabled: true,
 	}, nil
 }
 
@@ -174,15 +179,19 @@ func (s *Shell) newPromptSession(ctx context.Context) (promptSession, error) {
 		return nil, err
 	}
 
-	histories, err := s.usecases.history.List(ctx)
-	if err != nil {
-		if errClose := p.Close(); errClose != nil {
-			return nil, errors.Join(err, fmt.Errorf("failed to close prompt session: %w", errClose))
+	// Preload persisted history only when it is available; the prompt still
+	// keeps in-session history when persistence is disabled.
+	if s.historyEnabled {
+		histories, err := s.usecases.history.List(ctx)
+		if err != nil {
+			if errClose := p.Close(); errClose != nil {
+				return nil, errors.Join(err, fmt.Errorf("failed to close prompt session: %w", errClose))
+			}
+			return nil, err
 		}
-		return nil, err
-	}
-	for _, h := range histories.ToStringList() {
-		p.AddHistory(h)
+		for _, h := range histories.ToStringList() {
+			p.AddHistory(h)
+		}
 	}
 
 	return p, nil
@@ -190,8 +199,12 @@ func (s *Shell) newPromptSession(ctx context.Context) (promptSession, error) {
 
 // init store CSV data to in-memory DB and create table for sqly history.
 func (s *Shell) init(ctx context.Context) error {
+	// History is best-effort: a read-only or unwritable history DB (CI,
+	// sandboxes, containers) must not block the requested query or command.
+	// Disable history for the session and warn instead of failing.
 	if err := s.usecases.history.CreateTable(ctx); err != nil {
-		return fmt.Errorf("failed to create table for sqly history: %w", err)
+		s.historyEnabled = false
+		fmt.Fprintf(config.Stderr, "warning: command history disabled (%v). Set SQLY_HISTORY_DB_PATH to a writable path to enable it.\n", err)
 	}
 
 	paths := s.argument.FilePaths
@@ -499,8 +512,12 @@ func (s *Shell) exec(ctx context.Context, request string) error {
 		return nil // user only input enter, space tab
 	}
 
-	if err := s.recordUserRequest(ctx, req); err != nil {
-		return err
+	// Skip history persistence when it is disabled so a read-only history DB
+	// cannot fail the requested command.
+	if s.historyEnabled {
+		if err := s.recordUserRequest(ctx, req); err != nil {
+			return err
+		}
 	}
 
 	if s.commands.hasCmd(argv[0]) {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1242,16 +1242,18 @@ func hasPromptSuggestion(suggestions []prompt.Suggestion, text string) bool {
 }
 
 type historyUsecaseStub struct {
-	histories model.Histories
-	listErr   error
+	histories      model.Histories
+	listErr        error
+	createTableErr error
+	createErr      error
 }
 
 func (h historyUsecaseStub) CreateTable(context.Context) error {
-	return nil
+	return h.createTableErr
 }
 
 func (h historyUsecaseStub) Create(context.Context, model.History) error {
-	return nil
+	return h.createErr
 }
 
 func (h historyUsecaseStub) List(context.Context) (model.Histories, error) {
@@ -2165,6 +2167,50 @@ func TestShellRun_StdinDataset(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "piped") {
 			t.Fatalf("error = %q, want it to mention piped stdin", err.Error())
+		}
+	})
+}
+
+func TestShellRun_HistoryUnavailable(t *testing.T) {
+	// Regression for #262: non-interactive runs must succeed even when the
+	// history DB cannot be created or written (e.g. read-only config dir).
+	readonlyErr := errors.New("attempt to write a readonly database")
+
+	t.Run("--sql succeeds when history table cannot be created", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--csv", "--sql", "SELECT actor FROM actor ORDER BY actor LIMIT 1", filepath.Join("testdata", "actor.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.usecases.history = historyUsecaseStub{createTableErr: readonlyErr}
+
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "actor") {
+			t.Fatalf("--sql output missing result under read-only history: %q", got)
+		}
+	})
+
+	t.Run("batch mode succeeds and warns when history is unwritable", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", filepath.Join("testdata", "actor.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.usecases.history = historyUsecaseStub{createTableErr: readonlyErr, createErr: readonlyErr}
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("SELECT actor FROM actor ORDER BY actor LIMIT 1\n")
+
+		backupStderr := config.Stderr
+		defer func() { config.Stderr = backupStderr }()
+		var stderr bytes.Buffer
+		config.Stderr = &stderr
+
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "actor") {
+			t.Fatalf("batch output missing result under unwritable history: %q", got)
+		}
+		if !strings.Contains(stderr.String(), "history") {
+			t.Fatalf("expected a history-disabled warning on stderr, got: %q", stderr.String())
 		}
 	})
 }

--- a/spec/history_tolerance_spec.sh
+++ b/spec/history_tolerance_spec.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# History-storage tolerance end-to-end tests (#262). Non-interactive runs must
+# succeed even when the history database cannot be created or written. The
+# history DB path is pointed at a directory that does not exist, so creating it
+# fails the way a read-only or sandboxed config location would.
+
+Describe 'sqly history tolerance'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup_unwritable_history() {
+    HIST_DIR=$(mktemp -d)
+    export HIST_DIR
+    # The "missing" parent does not exist, so the history DB cannot be created.
+    SQLY_HISTORY_DB_PATH="$HIST_DIR/missing/history.db"
+    export SQLY_HISTORY_DB_PATH
+  }
+  cleanup_unwritable_history() {
+    rm -rf "${HIST_DIR:-}"
+    unset SQLY_HISTORY_DB_PATH
+  }
+  Before 'setup_unwritable_history'
+  After 'cleanup_unwritable_history'
+
+  It 'runs --sql and warns instead of failing'
+    When run sqly --csv --sql "SELECT actor FROM actor ORDER BY actor LIMIT 1" testdata/actor.csv
+    The status should be success
+    The output should include 'Adam Sandler'
+    The stderr should include 'history disabled'
+  End
+
+  It 'runs batch mode (.tables plus a query) without a writable history DB'
+    Data
+      #|.tables
+      #|SELECT actor FROM actor ORDER BY actor LIMIT 1
+    End
+    When run sqly testdata/actor.csv
+    The status should be success
+    The output should include 'TABLE NAME'
+    The output should include 'Adam Sandler'
+    The stderr should include 'history disabled'
+  End
+End


### PR DESCRIPTION
## Summary
Non-interactive sqly runs (`--sql` and non-TTY batch mode) failed before the requested query or command could run when the history database could not be created or written, such as a read-only config directory in CI, containers, or sandboxed agents. This makes history best-effort so automation is robust by default.

Closes #262

## Behavior
History persistence is now best-effort. If the history table cannot be created (or a row cannot be written), sqly disables history for the session, prints a one-line warning to stderr, and continues running the requested command. `SQLY_HISTORY_DB_PATH` (already supported) can point history at a writable location to re-enable it.

## Changes
- shell/shell.go: add a session `historyEnabled` flag. `init` no longer returns an error when `history.CreateTable` fails; it warns and disables history. `exec` skips recording history, and the interactive prompt skips preloading persisted history, when disabled. Interactive in-session history is unaffected.
- Docs: README and the GitHub Pages how-to page document the best-effort behavior and `SQLY_HISTORY_DB_PATH`; CHANGELOG.

## Tests
- Go (shell): `--sql` succeeds when the history table cannot be created; batch mode succeeds and warns when history is unwritable (injected failing history usecase).
- shellspec (spec/history_tolerance_spec.sh): `--sql` and batch mode both run with `SQLY_HISTORY_DB_PATH` pointed at an uncreatable path, asserting success, query output, and the stderr warning.