### PR TITLE
feat: parse batch stdin into statements so multiline SQL works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * History Storage Tolerance: Non-interactive runs (`--sql` and batch mode) no longer fail when the history database cannot be created or written (for example, a read-only config directory in CI or containers). History is disabled for the session with a warning, and the requested command still runs. Point `SQLY_HISTORY_DB_PATH` at a writable path to re-enable it.
 
 ### New Features
+* Multiline SQL in Batch Mode: Piped stdin is now parsed into statements instead of one statement per line, so SQL (including CTEs) can span multiple lines. A statement ends at a top-level `;`; separate multiple statements with `;`. Helper commands stay single-line, and a single trailing statement without `;` still runs. Errors report the statement index.
 * Stdin Dataset Input: `--stdin <format>` (csv|tsv|ltsv|json|jsonl) imports piped stdin as a dataset instead of reading it as SQL/helper commands, so sqly works in Unix pipelines (e.g. `cat users.csv | sqly --stdin csv --sql "SELECT * FROM stdin"`). The table defaults to `stdin` and is overridable with `--stdin-name`; piped data can be joined with file and directory arguments. Without `--stdin`, non-TTY batch mode is unchanged.
 
 ## [v0.16.0](https://github.com/nao1215/sqly/compare/v0.15.0...v0.16.0) (2026-05-30)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $ sqly --sql "SELECT user_name, position FROM user INNER JOIN identifier ON user
 ```
 
 ### Batch mode: pipe commands via stdin
-When standard input is not a terminal (piped or redirected), sqly reads SQL queries and shell commands from stdin, one per line, instead of starting the interactive shell. A failed command makes sqly exit non-zero, so batch runs are scriptable.
+When standard input is not a terminal (piped or redirected), sqly reads SQL statements and shell commands from stdin instead of starting the interactive shell. SQL statements end at a top-level `;` and may span multiple lines (separate multiple statements with `;`); helper commands such as `.tables` are single-line. A single trailing statement without `;` still runs. A failed statement makes sqly exit non-zero, so batch runs are scriptable.
 
 ```shell
 $ echo "SELECT * FROM user LIMIT 1" | sqly testdata/user.csv
@@ -121,6 +121,9 @@ $ printf '.tables\nSELECT COUNT(*) FROM user\n' | sqly testdata/user.csv
 +----------+
 |        3 |
 +----------+
+
+# Multiline SQL terminated by ;
+$ printf 'WITH x AS (\n  SELECT user_name FROM user\n)\nSELECT * FROM x;\n' | sqly testdata/user.csv
 ```
 
 ### Pipe data into sqly: --stdin option

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -63,6 +63,14 @@ $ sqly --sql "SELECT user_name, position FROM user INNER JOIN identifier ON user
 +-----------+-----------+
 ```
 
+### Batch mode: pipe commands via stdin
+
+When stdin is not a terminal (piped or redirected), sqly reads SQL statements and helper commands from stdin instead of starting the shell. SQL statements end at a top-level `;` and may span multiple lines, so formatted queries and CTEs work; separate multiple statements with `;`. Helper commands such as `.tables` are single-line. A single trailing statement without `;` still runs. A failed statement makes sqly exit non-zero.
+
+```shell
+$ printf 'WITH x AS (\n  SELECT user_name FROM user\n)\nSELECT * FROM x;\n' | sqly testdata/user.csv
+```
+
 ### Pipe data into sqly: --stdin option
 
 By default piped stdin is read as SQL and helper commands (batch mode). Use `--stdin <format>` to treat stdin as an input dataset instead. The format is given explicitly (`csv`, `tsv`, `ltsv`, `json`, or `jsonl`) because a pipe has no filename to detect it from. The table defaults to `stdin`; override it with `--stdin-name`. Piped data can be joined with file and directory arguments.

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -47,6 +47,7 @@ func (s *Shell) runBatch(ctx context.Context) error {
 	}
 
 	var pending strings.Builder
+scan:
 	for scanner.Scan() {
 		line := scanner.Text()
 		// At a statement boundary, a dot-command is a complete single-line
@@ -59,7 +60,7 @@ func (s *Shell) runBatch(ctx context.Context) error {
 			if strings.HasPrefix(trimmed, ".") {
 				run(trimmed)
 				if exited {
-					return nil
+					break scan
 				}
 				continue
 			}
@@ -73,19 +74,19 @@ func (s *Shell) runBatch(ctx context.Context) error {
 		for _, stmt := range stmts {
 			run(stmt)
 			if exited {
-				return nil
+				break scan
 			}
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("failed to read batch input: %w", err)
-	}
 
-	// Execute any trailing statement that was not terminated by ";".
-	if leftover := strings.TrimSpace(pending.String()); leftover != "" {
-		run(leftover)
-		if exited {
-			return nil
+	// On ".exit", stop reading but still report any earlier failure below.
+	if !exited {
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("failed to read batch input: %w", err)
+		}
+		// Execute any trailing statement that was not terminated by ";".
+		if leftover := strings.TrimSpace(pending.String()); leftover != "" {
+			run(leftover)
 		}
 	}
 

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/nao1215/sqly/config"
 )
@@ -13,39 +14,137 @@ import (
 // growth on input without newlines.
 const maxBatchLineBytes = 10 * 1024 * 1024
 
-// runBatch executes SQL queries and helper commands read from stdin, one per
-// line, until EOF. It is used when sqly runs without a TTY (piped stdin), where
-// the interactive prompt cannot start.
+// runBatch executes SQL statements and helper commands read from stdin until
+// EOF. It is used when sqly runs without a TTY (piped stdin), where the
+// interactive prompt cannot start.
 //
-// Each non-empty line is executed via exec, so quoting rules match the
-// interactive shell. Errors are reported to stderr but do not stop processing;
-// if any line failed, runBatch returns an error so the process exits non-zero.
-// A line of ".exit" stops processing early with a success status, mirroring the
-// interactive shell.
+// Input is parsed into statements, not raw lines, so SQL can span multiple
+// lines (e.g. a formatted CTE). A SQL statement ends at a top-level ";"; helper
+// commands (lines beginning with ".") are single-line. A trailing statement
+// without ";" at EOF still runs, so one-shot queries keep working; incomplete
+// SQL surfaces SQLite's error. Errors are reported to
+// stderr with the statement index and do not stop processing; if any statement
+// failed, runBatch returns an error so the process exits non-zero. A ".exit"
+// command stops early with a success status, mirroring the interactive shell.
 func (s *Shell) runBatch(ctx context.Context) error {
 	scanner := bufio.NewScanner(s.stdin)
 	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxBatchLineBytes)
 
 	failed := false
-	lineNo := 0
-	for scanner.Scan() {
-		lineNo++
-		line := scanner.Text()
-		if err := s.exec(ctx, line); err != nil {
+	stmtNo := 0
+	exited := false
+
+	run := func(stmt string) {
+		stmtNo++
+		if err := s.exec(ctx, stmt); err != nil {
 			if errors.Is(err, ErrExitSqly) {
-				return nil // user input ".exit"
+				exited = true
+				return
 			}
-			// Report the line number and content so a failing command is
-			// identifiable when many lines are piped in.
-			fmt.Fprintf(config.Stderr, "batch line %d failed: %q: %v\n", lineNo, line, err)
+			fmt.Fprintf(config.Stderr, "batch statement %d failed: %q: %v\n", stmtNo, stmt, err)
 			failed = true
+		}
+	}
+
+	var pending strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		// At a statement boundary, a dot-command is a complete single-line
+		// statement. Inside an open SQL statement, the line is SQL.
+		if pending.Len() == 0 {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if strings.HasPrefix(trimmed, ".") {
+				run(trimmed)
+				if exited {
+					return nil
+				}
+				continue
+			}
+		}
+
+		pending.WriteString(line)
+		pending.WriteString("\n")
+		stmts, remainder := splitSQLStatements(pending.String())
+		pending.Reset()
+		pending.WriteString(remainder)
+		for _, stmt := range stmts {
+			run(stmt)
+			if exited {
+				return nil
+			}
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("failed to read batch input: %w", err)
 	}
+
+	// Execute any trailing statement that was not terminated by ";".
+	if leftover := strings.TrimSpace(pending.String()); leftover != "" {
+		run(leftover)
+		if exited {
+			return nil
+		}
+	}
+
 	if failed {
-		return errors.New("one or more batch commands failed")
+		return errors.New("one or more batch statements failed")
 	}
 	return nil
+}
+
+// splitSQLStatements splits accumulated text into complete statements terminated
+// by a top-level ";" and returns the trailing unterminated remainder. Semicolons
+// inside string literals, identifiers, and comments are ignored so they do not
+// split a statement mid-value.
+func splitSQLStatements(s string) (stmts []string, remainder string) {
+	runes := []rune(s)
+	var (
+		start                         int
+		inSingle, inDouble            bool
+		inLineComment, inBlockComment bool
+	)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		switch {
+		case inLineComment:
+			if c == '\n' {
+				inLineComment = false
+			}
+		case inBlockComment:
+			if c == '*' && i+1 < len(runes) && runes[i+1] == '/' {
+				inBlockComment = false
+				i++
+			}
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			}
+		default:
+			switch {
+			case c == '\'':
+				inSingle = true
+			case c == '"':
+				inDouble = true
+			case c == '-' && i+1 < len(runes) && runes[i+1] == '-':
+				inLineComment = true
+				i++
+			case c == '/' && i+1 < len(runes) && runes[i+1] == '*':
+				inBlockComment = true
+				i++
+			case c == ';':
+				if stmt := strings.TrimSpace(string(runes[start:i])); stmt != "" {
+					stmts = append(stmts, stmt)
+				}
+				start = i + 1
+			}
+		}
+	}
+	return stmts, string(runes[start:])
 }

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1795,7 +1795,7 @@ func TestShellRunBatch_ReturnsErrorOnCommandFailure(t *testing.T) {
 	defer cleanup()
 
 	shell.isTTY = func() bool { return false }
-	shell.stdin = strings.NewReader("SELECT 1\nSELECT * FROM no_such_table\n")
+	shell.stdin = strings.NewReader("SELECT 1;\nSELECT * FROM no_such_table;\n")
 
 	backupStderr := config.Stderr
 	defer func() { config.Stderr = backupStderr }()
@@ -1805,13 +1805,87 @@ func TestShellRunBatch_ReturnsErrorOnCommandFailure(t *testing.T) {
 	if err := shell.Run(context.Background()); err == nil {
 		t.Fatal("batch Run returned nil error for failing command, want non-nil")
 	}
-	// The failing line is the second input line; stderr must identify it.
-	if !strings.Contains(stderr.String(), "batch line 2 failed") {
-		t.Fatalf("stderr = %q, want it to name the failing line number", stderr.String())
+	// The second statement fails; stderr must identify it by statement index.
+	if !strings.Contains(stderr.String(), "batch statement 2 failed") {
+		t.Fatalf("stderr = %q, want it to name the failing statement index", stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "no_such_table") {
-		t.Fatalf("stderr = %q, want it to include the failing line content", stderr.String())
+		t.Fatalf("stderr = %q, want it to include the failing statement content", stderr.String())
 	}
+}
+
+func TestShellRunBatch_MultilineStatements(t *testing.T) {
+	// Regression for #263: batch mode parses statements, so SQL can span lines.
+	newBatchShell := func(t *testing.T, stdin string) (*Shell, func()) {
+		t.Helper()
+		shell, cleanup, err := newShell(t, []string{"sqly", "--csv"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := shell.commands.importCommand(context.Background(), shell, []string{filepath.Join("testdata", "actor.csv")}); err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader(stdin)
+		return shell, cleanup
+	}
+
+	t.Run("multiline SELECT terminated by semicolon", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "SELECT actor\nFROM actor\nORDER BY actor\nLIMIT 1;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "Adam Sandler") {
+			t.Fatalf("multiline SELECT did not execute: %q", got)
+		}
+	})
+
+	t.Run("multiline WITH (CTE) query", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "WITH x AS (\n  SELECT actor FROM actor ORDER BY actor LIMIT 1\n)\nSELECT * FROM x;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "Adam Sandler") {
+			t.Fatalf("multiline WITH did not execute: %q", got)
+		}
+	})
+
+	t.Run("multiple statements execute in order", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "SELECT 'first' AS x;\nSELECT 'second' AS x;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if strings.Index(got, "first") > strings.Index(got, "second") {
+			t.Fatalf("statements not executed in order: %q", got)
+		}
+	})
+
+	t.Run("helper command and SQL coexist", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, ".tables\nSELECT actor FROM actor ORDER BY actor LIMIT 1;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "TABLE NAME") || !strings.Contains(got, "Adam Sandler") {
+			t.Fatalf("helper + SQL did not both run: %q", got)
+		}
+	})
+
+	t.Run("single statement without a terminator still runs", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "SELECT actor FROM actor ORDER BY actor LIMIT 1\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "Adam Sandler") {
+			t.Fatalf("unterminated single statement did not run: %q", got)
+		}
+	})
+
+	t.Run("incomplete SQL returns an error", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "SELECT actor FROM (\n")
+		defer cleanup()
+		backupStderr := config.Stderr
+		defer func() { config.Stderr = backupStderr }()
+		config.Stderr = &bytes.Buffer{}
+		if err := shell.Run(context.Background()); err == nil {
+			t.Fatal("incomplete SQL returned nil error, want error")
+		}
+	})
 }
 
 func TestShellRunBatch_ExitStopsEarly(t *testing.T) {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1903,6 +1903,27 @@ func TestShellRunBatch_ExitStopsEarly(t *testing.T) {
 	}
 }
 
+func TestShellRunBatch_ExitPreservesEarlierFailure(t *testing.T) {
+	// .exit stops processing but must not mask an earlier failure: the process
+	// still exits non-zero so scripted runs detect the error.
+	shell, cleanup, err := newShell(t, []string{"sqly", filepath.Join("testdata", "actor.csv")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	shell.isTTY = func() bool { return false }
+	shell.stdin = strings.NewReader("SELECT * FROM no_such_table;\n.exit\n")
+
+	backupStderr := config.Stderr
+	defer func() { config.Stderr = backupStderr }()
+	config.Stderr = &bytes.Buffer{}
+
+	if err := shell.Run(context.Background()); err == nil {
+		t.Fatal("batch Run returned nil after a failure preceding .exit, want non-nil")
+	}
+}
+
 func TestShellRunBatch_QuotedSheetArgument(t *testing.T) {
 	// End-to-end: a quoted --sheet value with a space is parsed as one argument.
 	shell, cleanup, err := newShell(t, []string{"sqly"})

--- a/spec/batch_spec.sh
+++ b/spec/batch_spec.sh
@@ -47,6 +47,16 @@ Describe 'sqly batch mode (piped stdin)'
     The status should be success
   End
 
+  It 'still exits non-zero when a failure precedes .exit'
+    Data
+      #|SELECT * FROM no_such_table;
+      #|.exit
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The stderr should include 'no_such_table'
+  End
+
   Describe 'multiline statements (#263)'
     It 'runs a multiline SELECT terminated by a semicolon'
       Data

--- a/spec/batch_spec.sh
+++ b/spec/batch_spec.sh
@@ -26,15 +26,15 @@ Describe 'sqly batch mode (piped stdin)'
     The output should include '{"user_name":"booker12"}'
   End
 
-  It 'exits non-zero and names the failing line on error'
+  It 'exits non-zero and names the failing statement on error'
     Data
-      #|SELECT user_name FROM user ORDER BY identifier LIMIT 1
-      #|SELECT * FROM no_such_table
+      #|SELECT user_name FROM user ORDER BY identifier LIMIT 1;
+      #|SELECT * FROM no_such_table;
     End
     When run sqly testdata/user.csv
     The status should be failure
     The output should include 'booker12'
-    The stderr should include 'batch line 2 failed'
+    The stderr should include 'batch statement 2 failed'
     The stderr should include 'no_such_table'
   End
 
@@ -45,5 +45,52 @@ Describe 'sqly batch mode (piped stdin)'
     End
     When run sqly testdata/user.csv
     The status should be success
+  End
+
+  Describe 'multiline statements (#263)'
+    It 'runs a multiline SELECT terminated by a semicolon'
+      Data
+        #|SELECT user_name
+        #|FROM user
+        #|ORDER BY identifier
+        #|LIMIT 1;
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'booker12'
+    End
+
+    It 'runs a multiline WITH (CTE) query'
+      Data
+        #|WITH x AS (
+        #|  SELECT user_name FROM user ORDER BY identifier LIMIT 1
+        #|)
+        #|SELECT * FROM x;
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'booker12'
+    End
+
+    It 'runs multiple statements and helper commands in one payload'
+      Data
+        #|.tables
+        #|SELECT COUNT(*) AS c FROM user;
+        #|SELECT user_name FROM user ORDER BY identifier LIMIT 1;
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'TABLE NAME'
+      The output should include 'booker12'
+    End
+
+    It 'reports an error for incomplete SQL'
+      Data
+        #|SELECT * FROM (
+      End
+      When run sqly testdata/user.csv
+      The status should be failure
+      The stderr should include 'batch statement'
+    End
   End
 End


### PR DESCRIPTION
## Summary
Batch mode read piped stdin one line per statement, so multiline SQL (formatted queries, CTEs) failed with incomplete-input errors. Batch mode now parses stdin into statements, so SQL can span multiple lines.

Closes #263

## Behavior
A SQL statement ends at a top-level `;` and may span multiple lines; semicolons inside string literals, quoted identifiers, and comments do not split a statement. Helper commands (lines starting with `.`) remain single-line. A single trailing statement without `;` at EOF still runs, so one-shot queries keep working. Errors report the statement index. A `.exit` command stops early with success.

Because statements are now delimited by `;`, multiple statements in one payload must be separated by `;` (previously each line was its own statement).

```
printf 'WITH x AS (\n  SELECT user_name FROM user\n)\nSELECT * FROM x;\n' | sqly testdata/user.csv
```

## Changes
- shell/batch.go: rewrite `runBatch` to accumulate SQL across lines and split on top-level `;` via a new `splitSQLStatements` that respects quotes and comments. The failure message changes from "batch line N" to "batch statement N".
- Docs: README and the GitHub Pages how-to page describe statement-aware batch mode; CHANGELOG.

## Tests
- Go (shell): multiline SELECT, multiline WITH (CTE), multiple statements in order, helper + SQL coexisting, a single unterminated statement still running, and incomplete SQL returning an error.
- shellspec (spec/batch_spec.sh): the same multiline cases at the binary level, plus the updated failing-statement assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch mode (piped stdin) now parses multiline SQL using top-level semicolons, allowing multi-line CTEs/formatted queries; helper commands remain single-line. A trailing unterminated statement still runs. Failures set a non-zero exit and report by statement index.

* **Documentation**
  * Updated README and docs with batch-mode rules and a multiline stdin example.

* **Tests**
  * Added and updated end-to-end and spec tests covering multiline statements, mixed helper/SQL payloads, and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->