### PR TITLE
fix(config): parse flags placed after input paths (#264)

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install tools
         run: |
-          go install github.com/fe3dback/go-arch-lint@v1.12.0
+          go install github.com/fe3dback/go-arch-lint@v1.15.0
       
       - name: Lint architecture
         run: |

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -4,6 +4,11 @@ workdir: .
 excludeFiles:
   - "^.*_test\\.go$"
   - "^.*\/test\/.*$"
+  # work/ is a gitignored local scratch directory (see /work in .gitignore) used
+  # for replace-based library checkouts. go-arch-lint v1.13+ walks the whole
+  # project tree, including gitignored dirs, so exclude it to avoid flagging
+  # those files as "not attached to any component".
+  - "^.*\/work\/.*$"
 
 vendors:
   color: { in: github.com/fatih/color } 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Flags After Input Paths: Flags placed after file or directory arguments (e.g. `sqly --sql ... data.csv --output out.json`) are now parsed as flags instead of being silently treated as import paths that fail with "path does not exist". An unknown flag in any position fails fast with a clear parse error.
 * History Storage Tolerance: Non-interactive runs (`--sql` and batch mode) no longer fail when the history database cannot be created or written (for example, a read-only config directory in CI or containers). History is disabled for the session with a warning, and the requested command still runs. Point `SQLY_HISTORY_DB_PATH` at a writable path to re-enable it.
 
 ### New Features

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ tools: ## Install dependency tools
 	$(GO_INSTALL) github.com/nikolaydubina/go-cover-treemap@latest
 	$(GO_INSTALL) github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	$(GO_INSTALL) go.uber.org/mock/mockgen@latest
-	$(GO_INSTALL) github.com/fe3dback/go-arch-lint@latest
+	$(GO_INSTALL) github.com/fe3dback/go-arch-lint@v1.15.0
 
 lint: ## Lint code
 	golangci-lint run --config .golangci.yml

--- a/README.md
+++ b/README.md
@@ -278,10 +278,11 @@ $ sqly --sql "SELECT * FROM user" --csv testdata/user.csv > test.csv
 
 #### For windows user
 
-The sqly can save SQL execution results to the file using the --output option. The --output option specifies the destination path for SQL results specified in the --sql option.
+The sqly can save SQL execution results to the file using the --output option. The --output option specifies the destination path for SQL results specified in the --sql option. Flags may come before or after the file arguments, so `--output` also works at the end of the command.
 
 ```shell
-$ sqly --sql "SELECT * FROM user" --output=test.csv testdata/user.csv 
+$ sqly --sql "SELECT * FROM user" --output=test.csv testdata/user.csv
+$ sqly --sql "SELECT * FROM user" testdata/user.csv --output=test.csv
 ```
 
 ### Key Binding for sqly-shell

--- a/config/argument.go
+++ b/config/argument.go
@@ -78,6 +78,12 @@ func NewArg(args []string) (*Arg, error) {
 	arg := &Arg{}
 
 	flag := pflag.FlagSet{}
+	// Parse flags even when they appear after file/directory arguments. A
+	// zero-value pflag.FlagSet disables this, which silently turns a misplaced
+	// flag (e.g. "sqly data.csv --output out") and its value into import paths
+	// that fail with "path does not exist". Interspersed parsing instead applies
+	// the flag, and an unknown flag fails fast with a clear parse error. Ref #264.
+	flag.SetInterspersed(true)
 	flag.BoolVarP(&oFlag.csv, "csv", "c", false, "change output format to csv (default: table)")
 	flag.BoolVarP(&oFlag.excel, "excel", "e", false, "change output format to excel (default: table)")
 	flag.BoolVarP(&oFlag.ltsv, "ltsv", "l", false, "change output format to ltsv (default: table)")

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -151,6 +151,56 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("--output after file path sets output destination, not an import path (#264)", func(t *testing.T) {
+		testFile := filepath.Join(t.TempDir(), "result.csv")
+		arg, err := NewArg([]string{"sqly", "--sql", "SELECT * FROM user", "testdata/user.csv", "--output", testFile})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.Output.FilePath != testFile {
+			t.Errorf("Output.FilePath = %q, want %q", arg.Output.FilePath, testFile)
+		}
+		if diff := cmp.Diff([]string{"testdata/user.csv"}, arg.FilePaths); diff != "" {
+			t.Errorf("FilePaths mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("output-mode flag after file path sets mode, not an import path (#264)", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--sql", "SELECT * FROM user", "testdata/user.csv", "--csv"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.Output.Mode != model.PrintModeCSV {
+			t.Errorf("Output.Mode = %v, want %v", arg.Output.Mode, model.PrintModeCSV)
+		}
+		if diff := cmp.Diff([]string{"testdata/user.csv"}, arg.FilePaths); diff != "" {
+			t.Errorf("FilePaths mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("flags interspersed among file paths are not imported as paths (#264)", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "testdata/user.csv", "--json", "testdata/identifier.csv", "--sql", "SELECT 1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.Output.Mode != model.PrintModeJSON {
+			t.Errorf("Output.Mode = %v, want %v", arg.Output.Mode, model.PrintModeJSON)
+		}
+		if arg.Query != "SELECT 1" {
+			t.Errorf("Query = %q, want %q", arg.Query, "SELECT 1")
+		}
+		if diff := cmp.Diff([]string{"testdata/user.csv", "testdata/identifier.csv"}, arg.FilePaths); diff != "" {
+			t.Errorf("FilePaths mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("unknown flag after file path returns a parse error (#264)", func(t *testing.T) {
+		_, err := NewArg([]string{"sqly", "testdata/user.csv", "--nope"})
+		if err == nil {
+			t.Fatal("expected a parse error for an unknown flag, got nil")
+		}
+	})
+
 	t.Run("default print mode", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly"})
 		if err != nil {

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -2,6 +2,8 @@
 
 If no SQL query is specified with the `--sql` option, sqly will start the sqly shell. sqly determines the file type to be loaded from the extension when the shell starts and automatically begins importing it into the SQLite3 in-memory database. Multiple files can be loaded simultaneously. The table names will be the file names (without extensions) or the Excel sheet names. If an SQL query is specified with the `--sql` option, the SQL query result will be displayed in the terminal and sqly will exit without starting the sqly shell.
 
+Flags may appear before or after the file and directory arguments; `sqly --csv data.csv` and `sqly data.csv --csv` are equivalent. A misplaced unknown flag fails with a parse error instead of being read as a file path.
+
 sqly allows you to change the display mode of SQL results with options. By default, the output is in table format. The output format can be changed to csv (`--csv`), tsv (`--tsv`), ltsv (`--ltsv`), markdown (`--markdown`), json (`--json`), or ndjson (`--ndjson`). Excel (`--excel`) and Parquet (`--parquet`) are export-only: they render as csv on screen and write a file only through `.dump` or `--output`. Since the output mode can be changed while the sqly shell is running, it is easy to execute `sqly sample.csv` and then change settings or execute SQL queries within the sqly shell.
 
 

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -58,4 +58,31 @@ Describe 'sqly CLI surface'
       rm -rf "$out_dir"
     End
   End
+
+  Describe 'flags after input paths (#264)'
+    It 'applies --output placed after the file path instead of importing it'
+      out_dir=$(mktemp -d)
+      export out_dir
+      When run sqly --json --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv --output "$out_dir/result.json"
+      The status should be success
+      The output should not include 'path does not exist'
+      The path "$out_dir/result.json" should be file
+      The contents of file "$out_dir/result.json" should include '"user_name":"booker12"'
+      rm -rf "$out_dir"
+    End
+
+    It 'applies an output-mode flag placed after the file path'
+      When run sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv --csv
+      The status should be success
+      The line 1 should equal 'user_name'
+      The output should include 'booker12'
+      The output should not include 'path does not exist'
+    End
+
+    It 'fails fast on an unknown flag after the file path'
+      When run sqly testdata/user.csv --nope
+      The status should be failure
+      The stderr should include 'unknown flag'
+    End
+  End
 End


### PR DESCRIPTION
## Summary
sqly silently treated flags placed after file or directory arguments as more import paths. A command like `sqly --sql ... data.csv --output out.json` exited successfully but read `--output` and `out.json` as paths, failing with "path does not exist" while still printing results to stdout. This hides a real mistake behind a partial success. Flags now parse regardless of position, and an unknown flag fails fast with a clear parse error.

## Changes
The root cause was `config.NewArg` building a zero-value `pflag.FlagSet{}`, which disables interspersed parsing. `config/argument.go` now calls `flag.SetInterspersed(true)` so flags are recognized before or after positional file arguments, and an unrecognized flag in any position returns a parse error instead of becoming a path.

`config/argument_test.go` adds regression cases: `--output` after a path sets the output destination and does not leak into `FilePaths`; an output-mode flag after a path sets the mode; flags interspersed among multiple paths are parsed while only real paths remain in `FilePaths`; an unknown flag after a path returns an error.

`spec/cli_spec.sh` adds binary-level e2e coverage for the same behavior: `--output` after the path writes the file, an output-mode flag after the path applies, and an unknown trailing flag exits non-zero with "unknown flag".

`CHANGELOG.md`, `README.md`, and `doc/pages/markdown/how_to_use.md` document that flags may appear before or after file arguments.

This branch also pins go-arch-lint and makes the local and CI lint runs consistent. CI used `@v1.12.0` while the Makefile installed `@latest` (v1.15.0), and the two disagreed. Both now pin `v1.15.0`. go-arch-lint v1.13+ walks the whole project tree including gitignored directories, so the gitignored `work/` scratch directory (used for replace-based library checkouts) is added to `excludeFiles` to avoid false "not attached to any component" reports.

## Design Decisions
Accepting interspersed flags is friendlier than rejecting them and removes the silent misinterpretation entirely, which satisfies the issue's "accept flags after file arguments" path. Unknown flags still fail fast, so genuine typos are not swallowed. The lint version is pinned rather than tracking `@latest` so local and CI always run the same checker.

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI argument parsing—flags can now be placed before or after file/directory arguments interchangeably
  * Unknown flags now fail fast with clear parse errors instead of being misinterpreted as file paths

* **Documentation**
  * Updated usage guides to clarify flexible flag placement and stricter error handling for unrecognized flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->