### PR TITLE
fix(shell): tolerate runtime history failures after startup (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Runtime History Tolerance: A history database that becomes read-only after startup no longer aborts `--sql`, `--inspect`, or batch runs. The first runtime read or write failure disables history for the rest of the session and warns once, instead of failing the command or retrying on every command. This extends the startup tolerance to the post-initialization path.
 * Flags After Input Paths: Flags placed after file or directory arguments (e.g. `sqly --sql ... data.csv --output out.json`) are now parsed as flags instead of being silently treated as import paths that fail with "path does not exist". An unknown flag in any position fails fast with a clear parse error.
 * History Storage Tolerance: Non-interactive runs (`--sql` and batch mode) no longer fail when the history database cannot be created or written (for example, a read-only config directory in CI or containers). History is disabled for the session with a warning, and the requested command still runs. Point `SQLY_HISTORY_DB_PATH` at a writable path to re-enable it.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ sqly:~/github/github.com/nao1215/sqly(table)$
   
 The sqly shell functions similarly to a common SQL client (e.g., `sqlite3` command or `mysql` command). The sqly shell has helper commands that begin with a dot. The sqly-shell also supports command history, and input completion.  
 
-Command history is persisted to a SQLite database under the config directory. History is best-effort: if that database cannot be created or written (for example a read-only config directory in CI or a container), sqly disables history for the session with a warning and still runs the requested query or command. Set `SQLY_HISTORY_DB_PATH` to choose a writable location.
+Command history is persisted to a SQLite database under the config directory. History is best-effort: if that database cannot be created or written, or stops accepting reads or writes mid-session (for example a read-only config directory in CI or a container), sqly disables history for the rest of the session with a warning and still runs the requested query or command. Set `SQLY_HISTORY_DB_PATH` to choose a writable location.
 
 The sqly-shell has the following helper commands:
 

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -115,7 +115,7 @@ $ cat testdata/user.csv | sqly --stdin csv --sql "SELECT user_name FROM stdin LI
 
 ### Command history
 
-The sqly shell persists command history to a SQLite database under the config directory. History is best-effort: if that database cannot be created or written (for example a read-only config directory in CI or a container), sqly disables history for the session with a warning and still runs the requested query or command. Set `SQLY_HISTORY_DB_PATH` to choose a writable location.
+The sqly shell persists command history to a SQLite database under the config directory. History is best-effort: if that database cannot be created or written, or stops accepting reads or writes mid-session (for example a read-only config directory in CI or a container), sqly disables history for the rest of the session with a warning and still runs the requested query or command. Set `SQLY_HISTORY_DB_PATH` to choose a writable location.
 
 ### Change output format
 

--- a/shell/commands_test.go
+++ b/shell/commands_test.go
@@ -35,6 +35,73 @@ func newBoundaryTestShell(t *testing.T, usecases Usecases) *Shell {
 	}
 }
 
+func TestExec_RuntimeHistoryFailureDisablesHistoryAndContinues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	history := mock.NewMockHistoryUsecase(ctrl)
+	query := mock.NewMockQueryUsecase(ctrl)
+
+	table := model.NewTable("t", model.NewHeader([]string{"n"}), []model.Record{
+		model.NewRecord([]string{"1"}),
+	})
+
+	// First command: the history read succeeds but the write fails as if the DB
+	// became read-only after startup. The query must still run.
+	history.EXPECT().List(gomock.Any()).Return(model.Histories{}, nil)
+	history.EXPECT().Create(gomock.Any(), gomock.Any()).
+		Return(errors.New("attempt to write a readonly database"))
+	query.EXPECT().ExecSQL(gomock.Any(), "SELECT 1").Return(table, int64(0), nil)
+
+	s := newBoundaryTestShell(t, Usecases{history: history, query: query})
+	s.historyEnabled = true
+
+	_ = captureStdout(t, func() {
+		if err := s.exec(context.Background(), "SELECT 1"); err != nil {
+			t.Fatalf("exec aborted on a best-effort history failure: %v", err)
+		}
+	})
+
+	if s.historyEnabled {
+		t.Error("historyEnabled should be false after a runtime history failure")
+	}
+
+	// Second command: history must not be touched again. No further history
+	// expectations are set, so gomock fails the test if List or Create is called.
+	query.EXPECT().ExecSQL(gomock.Any(), "SELECT 2").Return(table, int64(0), nil)
+	_ = captureStdout(t, func() {
+		if err := s.exec(context.Background(), "SELECT 2"); err != nil {
+			t.Fatalf("second exec errored after history was disabled: %v", err)
+		}
+	})
+}
+
+func TestExec_HistoryReadFailureAlsoDisablesHistory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	history := mock.NewMockHistoryUsecase(ctrl)
+	query := mock.NewMockQueryUsecase(ctrl)
+
+	table := model.NewTable("t", model.NewHeader([]string{"n"}), []model.Record{
+		model.NewRecord([]string{"1"}),
+	})
+
+	// The history read itself fails (e.g. the DB file vanished); the command must
+	// still run and history is disabled for the rest of the session.
+	history.EXPECT().List(gomock.Any()).Return(model.Histories{}, errors.New("disk I/O error"))
+	query.EXPECT().ExecSQL(gomock.Any(), "SELECT 1").Return(table, int64(0), nil)
+
+	s := newBoundaryTestShell(t, Usecases{history: history, query: query})
+	s.historyEnabled = true
+
+	_ = captureStdout(t, func() {
+		if err := s.exec(context.Background(), "SELECT 1"); err != nil {
+			t.Fatalf("exec aborted on a best-effort history read failure: %v", err)
+		}
+	})
+
+	if s.historyEnabled {
+		t.Error("historyEnabled should be false after a runtime history read failure")
+	}
+}
+
 func TestCommandList_cdCommand(t *testing.T) {
 	// Note: Cannot use t.Parallel() because of t.Chdir() and t.Setenv() usage
 	tests := []struct {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -192,21 +192,33 @@ func (s *Shell) newPromptSession(ctx context.Context) (promptSession, error) {
 	}
 
 	// Preload persisted history only when it is available; the prompt still
-	// keeps in-session history when persistence is disabled.
+	// keeps in-session history when persistence is disabled. On read failure,
+	// stay best-effort: disable history and start the shell anyway instead of
+	// refusing to open the prompt.
 	if s.historyEnabled {
 		histories, err := s.usecases.history.List(ctx)
 		if err != nil {
-			if errClose := p.Close(); errClose != nil {
-				return nil, errors.Join(err, fmt.Errorf("failed to close prompt session: %w", errClose))
+			s.disableHistory(err)
+		} else {
+			for _, h := range histories.ToStringList() {
+				p.AddHistory(h)
 			}
-			return nil, err
-		}
-		for _, h := range histories.ToStringList() {
-			p.AddHistory(h)
 		}
 	}
 
 	return p, nil
+}
+
+// disableHistory turns off history persistence for the rest of the session and
+// warns once. It is called when the history DB cannot be created at startup or a
+// later read/write fails (e.g. the DB became read-only), so history stays
+// best-effort and never aborts the requested --sql, --inspect, or batch command.
+func (s *Shell) disableHistory(err error) {
+	if !s.historyEnabled {
+		return
+	}
+	s.historyEnabled = false
+	fmt.Fprintf(config.Stderr, "warning: command history disabled (%v). Set SQLY_HISTORY_DB_PATH to a writable path to enable it.\n", err)
 }
 
 // init store CSV data to in-memory DB and create table for sqly history.
@@ -215,8 +227,7 @@ func (s *Shell) init(ctx context.Context) error {
 	// sandboxes, containers) must not block the requested query or command.
 	// Disable history for the session and warn instead of failing.
 	if err := s.usecases.history.CreateTable(ctx); err != nil {
-		s.historyEnabled = false
-		fmt.Fprintf(config.Stderr, "warning: command history disabled (%v). Set SQLY_HISTORY_DB_PATH to a writable path to enable it.\n", err)
+		s.disableHistory(err)
 	}
 
 	paths := s.argument.FilePaths
@@ -525,10 +536,12 @@ func (s *Shell) exec(ctx context.Context, request string) error {
 	}
 
 	// Skip history persistence when it is disabled so a read-only history DB
-	// cannot fail the requested command.
+	// cannot fail the requested command. History is best-effort: a runtime
+	// failure after startup disables history for the rest of the session and
+	// warns, instead of aborting the command.
 	if s.historyEnabled {
 		if err := s.recordUserRequest(ctx, req); err != nil {
-			return err
+			s.disableHistory(err)
 		}
 	}
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1422,33 +1422,34 @@ func TestShellCommunicate_LogsPromptCloseError(t *testing.T) {
 	}
 }
 
-func TestShellNewPromptSession_JoinsCloseErrorOnHistoryFailure(t *testing.T) {
+func TestShellNewPromptSession_DisablesHistoryOnPreloadFailure(t *testing.T) {
 	shell, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanup()
 
+	// History preload is best-effort: a read failure must not stop the prompt
+	// from opening. The session continues with history disabled.
 	listErr := errors.New("history list failed")
-	closeErr := errors.New("prompt close failed")
-	fakePrompt := &fakePromptSession{closeErr: closeErr}
+	fakePrompt := &fakePromptSession{}
 	shell.newPrompt = func(_ string, _ func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
 		return fakePrompt, nil
 	}
 	shell.usecases.history = historyUsecaseStub{listErr: listErr}
 
-	_, err = shell.newPromptSession(context.Background())
-	if err == nil {
-		t.Fatal("newPromptSession returned nil error")
+	p, err := shell.newPromptSession(context.Background())
+	if err != nil {
+		t.Fatalf("newPromptSession returned error on best-effort preload failure: %v", err)
 	}
-	if !errors.Is(err, listErr) {
-		t.Fatalf("error %v does not include history list failure", err)
+	if p == nil {
+		t.Fatal("newPromptSession returned a nil prompt")
 	}
-	if !errors.Is(err, closeErr) {
-		t.Fatalf("error %v does not include prompt close failure", err)
+	if shell.historyEnabled {
+		t.Error("historyEnabled should be false after a preload failure")
 	}
-	if fakePrompt.closeCalls != 1 {
-		t.Fatalf("prompt close calls = %d, want 1", fakePrompt.closeCalls)
+	if fakePrompt.closeCalls != 0 {
+		t.Fatalf("prompt close calls = %d, want 0 (prompt must stay open)", fakePrompt.closeCalls)
 	}
 }
 

--- a/spec/history_tolerance_spec.sh
+++ b/spec/history_tolerance_spec.sh
@@ -42,3 +42,51 @@ Describe 'sqly history tolerance'
     The stderr should include 'history disabled'
   End
 End
+
+# Runtime history failures (#273): the DB is created successfully at startup but a
+# later write fails, simulating a history DB that becomes read-only mid-session.
+Describe 'sqly history tolerance after startup'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup_readonly_history() {
+    RO_DIR=$(mktemp -d)
+    export RO_DIR
+    RO_HIST="$RO_DIR/history.db"
+    # Seed a valid history DB so the table exists, then make the file reject
+    # writes. Startup's CREATE TABLE IF NOT EXISTS is then a no-op that succeeds,
+    # while a later history insert fails like a DB that turned read-only.
+    printf 'SELECT 1\n' | SQLY_HISTORY_DB_PATH="$RO_HIST" "$SQLY_BIN" "$PROJECT_ROOT/testdata/user.csv" >/dev/null
+    chmod 0444 "$RO_HIST"
+    SQLY_HISTORY_DB_PATH="$RO_HIST"
+    export SQLY_HISTORY_DB_PATH
+  }
+  cleanup_readonly_history() {
+    rm -rf "${RO_DIR:-}"
+    unset SQLY_HISTORY_DB_PATH
+  }
+  Before 'setup_readonly_history'
+  After 'cleanup_readonly_history'
+
+  It 'runs --sql when the history DB is read-only after startup'
+    When run sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv
+    The status should be success
+    The output should include 'booker12'
+  End
+
+  It 'runs --inspect when the history DB is read-only after startup'
+    When run sqly --inspect testdata/user.csv
+    The status should be success
+    The line 1 should equal '{'
+    The output should include '"name": "user"'
+  End
+
+  It 'runs batch mode and warns when a history write fails after startup'
+    Data
+      #|SELECT user_name FROM user ORDER BY identifier LIMIT 1
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+    The output should include 'booker12'
+    The stderr should include 'history disabled'
+  End
+End


### PR DESCRIPTION
## Summary
Follow-up to #262. sqly already tolerated a history database that cannot be created at startup, but a history DB that becomes read-only or otherwise rejects reads/writes after a successful startup could still abort the requested command. `recordUserRequest()` runs on each non-interactive batch command (and interactive command), so a runtime `attempt to write a readonly database` error propagated out of `exec` and failed the batch run. History is meant to be best-effort, so this hardens the post-initialization path.

## Changes
shell/shell.go centralizes the disable-and-warn logic in `disableHistory`, which flips the session to history-disabled and warns once (guarding against repeat warnings). The startup `CreateTable` failure path, the `exec` record-history path, and the interactive history preload path all route through it.

In `exec`, a `recordUserRequest` failure now disables history and continues instead of returning the error, so a history write failure after startup no longer aborts `--sql` (unaffected, it does not record), `--inspect` (unaffected), or batch execution. After the first failure, history is disabled for the rest of the session, so it does not retry and re-warn on every command.

In `newPromptSession`, a history preload read failure now disables history and opens the prompt anyway, instead of closing the prompt and refusing to start the interactive shell.

## Tests
shell/commands_test.go adds unit coverage asserting that a runtime history write failure and a runtime history read failure both keep the command running and flip the session into history-disabled mode, and that the next command does not touch history again.

shell/shell_test.go updates the prompt-session test to the new best-effort contract: a preload read failure disables history and still returns an open prompt rather than erroring.

spec/history_tolerance_spec.sh adds binary-level coverage that seeds a valid history DB, makes the file read-only, and then runs `--sql`, `--inspect`, and batch mode. All succeed; batch warns on stderr that history is disabled while still printing the query result.

README, GitHub Pages, and the CHANGELOG document that history tolerance now covers mid-session read/write failures, not only startup.

## Design Decisions
The fix keeps history strictly best-effort: any history read or write failure, at startup or at runtime, disables history for the session rather than surfacing as a command error. Disabling after the first failure avoids per-command retries and repeated warnings. `--sql` and `--inspect` do not record history today, so they were already safe; the added coverage locks that contract so a future change cannot regress it.

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime history tolerance: when the history database becomes read-only mid-session (e.g., in CI/containers), sqly now disables history with a warning instead of aborting execution.

* **Documentation**
  * Updated documentation to clarify that command history is "best-effort" and may disable gracefully if the history database becomes unavailable mid-session.
  * Added `SQLY_HISTORY_DB_PATH` environment variable guidance for specifying a writable history location.

* **Tests**
  * Added end-to-end and unit test coverage for runtime history failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->