### PR TITLE
release: v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v0.17.0](https://github.com/nao1215/sqly/compare/v0.16.0...v0.17.0) (2026-05-31)
+
 ### Performance
 * Faster Imports: Files are streamed directly into the session database with filesql's `LoadInto` instead of being loaded into a temporary database and copied table by table. A 100k-row CSV import is about 2.5x faster and uses roughly half the peak memory. Behavior is unchanged (last-wins overwrite, cross-file JOINs, `.schema`/`.describe`/`--inspect`, and export all work as before).
 


### PR DESCRIPTION
## Summary
Release v0.17.0. Finalizes the CHANGELOG by moving the accumulated Unreleased entries under the v0.17.0 heading with the compare link and date. No code changes.

## Highlights since v0.16.0
New Features: write-back (`--save`/`--save-dir`/`.save`), `--inspect` JSON report, export format and compression inference for `--output`/`.dump`, multiline SQL in batch mode, and `--stdin` dataset input.

Performance: imports stream directly into the session database via filesql `LoadInto` (about 2.5x faster, roughly half the peak memory; no more table-by-table copy).

Bug Fixes: runtime and startup history tolerance, and flags parsed correctly after input paths.

Dependencies: filesql 0.12.2 to 0.13.0.