### PR TITLE
feat(shell): add --inspect-sample to control inspect verbosity (#283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### New Features
+* Inspect Sample Control: `--inspect-sample N` sets how many sample rows `--inspect` includes per table (default 5). `--inspect-sample 0` produces a schema-only report, which keeps the output small for wide or multi-table sources such as Fedwire.
+
 ## [v0.17.0](https://github.com/nao1215/sqly/compare/v0.16.0...v0.17.0) (2026-05-31)
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $ sqly --sql "SELECT user_name, position FROM user INNER JOIN identifier ON user
 ```
 
 ### Inspect tables: --inspect option
-`--inspect` imports the given files and directories and prints a JSON report of every table, then exits without starting the shell. The report lists each table name, its source path, the column schema, the row count, and a small sample of rows. It gives scripts and LLMs a non-interactive equivalent of `.tables`, `.schema`, and `.describe`. Import progress goes to stderr, so stdout carries only the JSON. Excel sheets and ACH/Fedwire files map several tables to one source path.
+`--inspect` imports the given files and directories and prints a JSON report of every table, then exits without starting the shell. The report lists each table name, its source path, the column schema, the row count, and a small sample of rows. It gives scripts and LLMs a non-interactive equivalent of `.tables`, `.schema`, and `.describe`. Import progress goes to stderr, so stdout carries only the JSON. Excel sheets and ACH/Fedwire files map several tables to one source path. `--inspect-sample N` sets how many sample rows each table includes (default 5); `--inspect-sample 0` produces a schema-only report for wide or multi-table sources.
 
 ```shell
 $ sqly --inspect testdata/user.csv

--- a/config/argument.go
+++ b/config/argument.go
@@ -20,6 +20,10 @@ var (
 	Stderr = colorable.NewColorableStderr()
 )
 
+// defaultInspectSample is the number of sample rows --inspect includes per
+// table unless --inspect-sample overrides it.
+const defaultInspectSample = 5
+
 // Output is configuration for output data to file.
 type Output struct {
 	// FilePath is output destination path
@@ -44,6 +48,10 @@ type Arg struct {
 	// imported tables (names, source mapping, columns, row counts, and sample
 	// rows) and exits without starting the shell.
 	InspectFlag bool
+	// InspectSample caps how many sample rows each --inspect table includes.
+	// 0 means schema-only (no sample rows), which keeps the report small for
+	// wide or multi-table sources.
+	InspectSample int
 	// SaveInPlace, when true, writes each table back over its source file after
 	// the run (for --save). It overwrites source files, so it requires Force.
 	SaveInPlace bool
@@ -111,6 +119,7 @@ func NewArg(args []string) (*Arg, error) {
 	query := flag.StringP("sql", "s", "", "sql query you want to execute")
 	output := flag.StringP("output", "o", "", "destination path for SQL results specified in --sql option")
 	flag.BoolVarP(&arg.InspectFlag, "inspect", "i", false, "print a JSON report of imported tables (schema, row counts, sample rows) and exit")
+	inspectSample := flag.Int("inspect-sample", defaultInspectSample, "rows to include per table in --inspect (0 for schema only)")
 	flag.BoolVar(&arg.SaveInPlace, "save", false, "after the run, write each table back over its source file (requires --force)")
 	saveDir := flag.String("save-dir", "", "after the run, write each table into this directory (originals untouched)")
 	flag.BoolVar(&arg.Force, "force", false, "allow --save to overwrite source files in place")
@@ -129,6 +138,7 @@ func NewArg(args []string) (*Arg, error) {
 	arg.StdinTableName = *stdinName
 	arg.Query = *query
 	arg.SaveDir = *saveDir
+	arg.InspectSample = *inspectSample
 
 	return arg, nil
 }

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -16,25 +16,26 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
     echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv
 
 [OPTIONS]
-  -c, --csv                 change output format to csv (default: table)
-  -e, --excel               change output format to excel (default: table)
-  -l, --ltsv                change output format to ltsv (default: table)
-  -m, --markdown            change output format to markdown table (default: table)
-  -t, --tsv                 change output format to tsv (default: table)
-  -j, --json                change output format to json (default: table)
-  -n, --ndjson              change output format to ndjson (default: table)
-  -p, --parquet             export results as parquet (export-only; use with --output or .dump)
-  -S, --sheet string        excel sheet name you want to import
-      --stdin string        treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
-      --stdin-name string   table name for the --stdin dataset (default "stdin")
-  -s, --sql string          sql query you want to execute
-  -o, --output string       destination path for SQL results specified in --sql option
-  -i, --inspect             print a JSON report of imported tables (schema, row counts, sample rows) and exit
-      --save                after the run, write each table back over its source file (requires --force)
-      --save-dir string     after the run, write each table into this directory (originals untouched)
-      --force               allow --save to overwrite source files in place
-  -h, --help                print help message
-  -v, --version             print sqly version
+  -c, --csv                  change output format to csv (default: table)
+  -e, --excel                change output format to excel (default: table)
+  -l, --ltsv                 change output format to ltsv (default: table)
+  -m, --markdown             change output format to markdown table (default: table)
+  -t, --tsv                  change output format to tsv (default: table)
+  -j, --json                 change output format to json (default: table)
+  -n, --ndjson               change output format to ndjson (default: table)
+  -p, --parquet              export results as parquet (export-only; use with --output or .dump)
+  -S, --sheet string         excel sheet name you want to import
+      --stdin string         treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
+      --stdin-name string    table name for the --stdin dataset (default "stdin")
+  -s, --sql string           sql query you want to execute
+  -o, --output string        destination path for SQL results specified in --sql option
+  -i, --inspect              print a JSON report of imported tables (schema, row counts, sample rows) and exit
+      --inspect-sample int   rows to include per table in --inspect (0 for schema only) (default 5)
+      --save                 after the run, write each table back over its source file (requires --force)
+      --save-dir string      after the run, write each table into this directory (originals untouched)
+      --force                allow --save to overwrite source files in place
+  -h, --help                 print help message
+  -v, --version              print sqly version
 
 [LICENSE]
   MIT LICENSE - Copyright (c) 2022 CHIKAMATSU Naohiro

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -37,6 +37,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -s, --sql string      sql query you want to execute
   -o, --output string   destination path for SQL results specified in --sql option
   -i, --inspect         print a JSON report of imported tables (schema, row counts, sample rows) and exit
+      --inspect-sample int  rows to include per table in --inspect (0 for schema only) (default 5)
       --save                after the run, write each table back over its source file (requires --force)
       --save-dir string     after the run, write each table into this directory (originals untouched)
       --force               allow --save to overwrite source files in place
@@ -94,6 +95,12 @@ $ sqly --inspect testdata/user.csv
 ```
 
 Multi-table sources map several tables to one source path: Excel sheets and ACH/Fedwire files.
+
+`--inspect-sample N` controls how many sample rows each table includes (default 5). Use `--inspect-sample 0` for a schema-only report, which avoids printing a large sample for wide sources such as Fedwire.
+
+```shell
+$ sqly --inspect --inspect-sample 0 testdata/customer-transfer.fed
+```
 
 ### Write changes back to files: --save and --save-dir
 

--- a/shell/inspect.go
+++ b/shell/inspect.go
@@ -13,10 +13,6 @@ import (
 	"github.com/nao1215/sqly/domain/model"
 )
 
-// inspectSampleLimit caps how many sample rows the report includes per table.
-// A small sample is enough to convey shape and values for query authoring.
-const inspectSampleLimit = 5
-
 // inspectColumn describes one column in the inspect report.
 type inspectColumn struct {
 	Name       string `json:"name"`
@@ -44,6 +40,11 @@ type inspectReport struct {
 // the non-interactive discovery path for scripts and LLMs, so JSON is the
 // primary contract and the report is written to stdout.
 func (s *Shell) runInspect(ctx context.Context) error {
+	sampleLimit := s.argument.InspectSample
+	if sampleLimit < 0 {
+		return fmt.Errorf("--inspect-sample must be 0 or greater, got %d", sampleLimit)
+	}
+
 	tables, err := s.usecases.metadata.TablesName(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list tables: %w", err)
@@ -61,7 +62,7 @@ func (s *Shell) runInspect(ctx context.Context) error {
 
 	report := inspectReport{Tables: make([]inspectTable, 0, len(names))}
 	for _, name := range names {
-		entry, err := s.inspectTable(ctx, name)
+		entry, err := s.inspectTable(ctx, name, sampleLimit)
 		if err != nil {
 			return err
 		}
@@ -76,8 +77,9 @@ func (s *Shell) runInspect(ctx context.Context) error {
 	return nil
 }
 
-// inspectTable builds the report entry for a single table.
-func (s *Shell) inspectTable(ctx context.Context, name string) (inspectTable, error) {
+// inspectTable builds the report entry for a single table. sampleLimit caps the
+// sample rows; 0 means schema-only.
+func (s *Shell) inspectTable(ctx context.Context, name string, sampleLimit int) (inspectTable, error) {
 	columns, err := s.inspectColumns(ctx, name)
 	if err != nil {
 		return inspectTable{}, err
@@ -88,7 +90,7 @@ func (s *Shell) inspectTable(ctx context.Context, name string) (inspectTable, er
 		return inspectTable{}, err
 	}
 
-	sample, err := s.inspectSample(ctx, name)
+	sample, err := s.inspectSample(ctx, name, sampleLimit)
 	if err != nil {
 		return inspectTable{}, err
 	}
@@ -149,12 +151,15 @@ func (s *Shell) inspectRowCount(ctx context.Context, name string) (int64, error)
 	return count, nil
 }
 
-// inspectSample returns up to inspectSampleLimit rows rendered as a JSON array,
-// reusing the table JSON renderer so the sample matches sqly's query JSON
-// (ordered keys, string values).
-func (s *Shell) inspectSample(ctx context.Context, name string) (json.RawMessage, error) {
+// inspectSample returns up to limit rows rendered as a JSON array, reusing the
+// table JSON renderer so the sample matches sqly's query JSON (ordered keys,
+// string values). A limit of 0 returns an empty array without querying.
+func (s *Shell) inspectSample(ctx context.Context, name string, limit int) (json.RawMessage, error) {
+	if limit == 0 {
+		return json.RawMessage("[]"), nil
+	}
 	quoted := s.usecases.importer.QuoteIdentifier(name)
-	query := fmt.Sprintf("SELECT * FROM %s LIMIT %d", quoted, inspectSampleLimit)
+	query := fmt.Sprintf("SELECT * FROM %s LIMIT %d", quoted, limit)
 	table, err := s.usecases.query.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sample rows of %s: %w", name, err)

--- a/shell/inspect_test.go
+++ b/shell/inspect_test.go
@@ -106,6 +106,55 @@ func TestInspect_SampleRowsAreLimited(t *testing.T) {
 	}
 }
 
+func TestInspect_SampleRowCountIsConfigurable(t *testing.T) {
+	dir := t.TempDir()
+	csv := writeCSV(t, dir, "nums.csv", "id\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
+
+	report := runInspectJSON(t, []string{"sqly", "--inspect", "--inspect-sample", "2", csv})
+
+	if len(report.Tables) != 1 {
+		t.Fatalf("expected 1 table, got %d", len(report.Tables))
+	}
+	if got := len(report.Tables[0].SampleRows); got != 2 {
+		t.Errorf("sample_rows = %d, want 2", got)
+	}
+}
+
+func TestInspect_SchemaOnlyWithZeroSample(t *testing.T) {
+	dir := t.TempDir()
+	csv := writeCSV(t, dir, "people.csv", "name,age\nAlice,30\nBob,25\n")
+
+	report := runInspectJSON(t, []string{"sqly", "--inspect", "--inspect-sample", "0", csv})
+
+	if len(report.Tables) != 1 {
+		t.Fatalf("expected 1 table, got %d", len(report.Tables))
+	}
+	tbl := report.Tables[0]
+	// Schema and counts are still present; only the sample is suppressed.
+	if len(tbl.Columns) != 2 {
+		t.Errorf("columns = %d, want 2 (schema must remain)", len(tbl.Columns))
+	}
+	if tbl.RowCount != 2 {
+		t.Errorf("row_count = %d, want 2", tbl.RowCount)
+	}
+	if len(tbl.SampleRows) != 0 {
+		t.Errorf("sample_rows = %d, want 0 (schema only)", len(tbl.SampleRows))
+	}
+}
+
+func TestInspect_NegativeSampleErrors(t *testing.T) {
+	dir := t.TempDir()
+	csv := writeCSV(t, dir, "x.csv", "a\n1\n")
+	shell, cleanup, err := newShell(t, []string{"sqly", "--inspect", "--inspect-sample", "-1", csv})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if err := shell.Run(context.Background()); err == nil {
+		t.Fatal("expected an error for a negative --inspect-sample, got nil")
+	}
+}
+
 func TestInspect_MultipleFileArgs(t *testing.T) {
 	dir := t.TempDir()
 	a := writeCSV(t, dir, "a.csv", "x\n1\n")

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -16,25 +16,26 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
     echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv
 
 [OPTIONS]
-  -c, --csv                 change output format to csv (default: table)
-  -e, --excel               change output format to excel (default: table)
-  -l, --ltsv                change output format to ltsv (default: table)
-  -m, --markdown            change output format to markdown table (default: table)
-  -t, --tsv                 change output format to tsv (default: table)
-  -j, --json                change output format to json (default: table)
-  -n, --ndjson              change output format to ndjson (default: table)
-  -p, --parquet             export results as parquet (export-only; use with --output or .dump)
-  -S, --sheet string        excel sheet name you want to import
-      --stdin string        treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
-      --stdin-name string   table name for the --stdin dataset (default "stdin")
-  -s, --sql string          sql query you want to execute
-  -o, --output string       destination path for SQL results specified in --sql option
-  -i, --inspect             print a JSON report of imported tables (schema, row counts, sample rows) and exit
-      --save                after the run, write each table back over its source file (requires --force)
-      --save-dir string     after the run, write each table into this directory (originals untouched)
-      --force               allow --save to overwrite source files in place
-  -h, --help                print help message
-  -v, --version             print sqly version
+  -c, --csv                  change output format to csv (default: table)
+  -e, --excel                change output format to excel (default: table)
+  -l, --ltsv                 change output format to ltsv (default: table)
+  -m, --markdown             change output format to markdown table (default: table)
+  -t, --tsv                  change output format to tsv (default: table)
+  -j, --json                 change output format to json (default: table)
+  -n, --ndjson               change output format to ndjson (default: table)
+  -p, --parquet              export results as parquet (export-only; use with --output or .dump)
+  -S, --sheet string         excel sheet name you want to import
+      --stdin string         treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
+      --stdin-name string    table name for the --stdin dataset (default "stdin")
+  -s, --sql string           sql query you want to execute
+  -o, --output string        destination path for SQL results specified in --sql option
+  -i, --inspect              print a JSON report of imported tables (schema, row counts, sample rows) and exit
+      --inspect-sample int   rows to include per table in --inspect (0 for schema only) (default 5)
+      --save                 after the run, write each table back over its source file (requires --force)
+      --save-dir string      after the run, write each table into this directory (originals untouched)
+      --force                allow --save to overwrite source files in place
+  -h, --help                 print help message
+  -v, --version              print sqly version
 
 [LICENSE]
   MIT LICENSE - Copyright (c) 2022 CHIKAMATSU Naohiro

--- a/spec/inspect_spec.sh
+++ b/spec/inspect_spec.sh
@@ -43,4 +43,27 @@ Describe 'sqly --inspect (#259)'
     The status should be failure
     The stderr should include 'no tables to inspect'
   End
+
+  It 'emits a schema-only report with --inspect-sample 0'
+    When run sqly --inspect --inspect-sample 0 testdata/user.csv
+    The status should be success
+    The line 1 should equal '{'
+    The output should include '"name": "user"'
+    The output should include '"user_name"'
+    The output should include '"sample_rows": []'
+    The output should not include 'booker12'
+  End
+
+  It 'limits sample rows with --inspect-sample'
+    When run sqly --inspect --inspect-sample 1 testdata/user.csv
+    The status should be success
+    The output should include 'booker12'
+    The output should not include 'jenkins46'
+  End
+
+  It 'rejects a negative --inspect-sample'
+    When run sqly --inspect --inspect-sample -1 testdata/user.csv
+    The status should be failure
+    The stderr should include 'inspect-sample'
+  End
 End


### PR DESCRIPTION
## Summary
Hands-on testing of the v0.17.0 binary showed `--inspect` of a single-row Fedwire file produced about 2,297 lines of JSON because it always emits a full sample row on top of the full schema. This adds `--inspect-sample N` to control how many sample rows each table includes, with `--inspect-sample 0` for a schema-only report.

## Changes
config/argument.go adds the `--inspect-sample` int flag (default 5). shell/inspect.go validates it (negative is rejected) and threads the limit through; a limit of 0 returns an empty sample array without querying, so schema, source mapping, and counts remain while the sample object is suppressed. Output stays valid JSON and stdout stays pure.

## Tests
shell/inspect_test.go covers a configurable sample count, schema-only at 0 (columns and row_count kept, sample empty), and the negative-value error. spec/inspect_spec.sh covers the schema-only report, a limited sample, and the negative-value failure on the binary. README, GitHub Pages, and the help/usage goldens document the flag.

Closes #283