### PR TITLE
feat(shell): add --sql-file to load SQL from a file for non-interactive runs (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 * Inspect Sample Control: `--inspect-sample N` sets how many sample rows `--inspect` includes per table (default 5). `--inspect-sample 0` produces a schema-only report, which keeps the output small for wide or multi-table sources such as Fedwire.
+* SQL File Input: `--sql-file PATH` runs SQL loaded from a file for non-interactive runs. Because the query no longer comes from stdin, `--stdin <format>` can pipe a dataset while the query comes from the file (`cat data.csv | sqly --stdin csv --sql-file query.sql`). The file supports multiline statements and multiple statements separated by `;`, using the same splitting rules as batch stdin mode, and a leading header comment is allowed. It cannot be combined with `--sql`, and missing, unreadable, or empty files fail with a clear error.
 
 ## [v0.17.0](https://github.com/nao1215/sqly/compare/v0.16.0...v0.17.0) (2026-05-31)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ $ sqly --sql "SELECT user_name, position FROM user INNER JOIN identifier ON user
 +-----------+-----------+
 ```
 
+### Load SQL from a file: --sql-file option
+`--sql-file PATH` runs SQL read from a file instead of from `--sql` or stdin. The file may contain multiple statements separated by `;`, and a statement may span multiple lines, following the same rules as batch stdin mode; a leading header comment is allowed. It cannot be combined with `--sql`, and a missing, unreadable, or empty file fails with a clear error.
+
+Because the query comes from a file, stdin is free to carry a dataset. Combine it with `--stdin <format>` to join piped data:
+
+```shell
+$ cat testdata/user.csv | sqly --stdin csv --sql-file join.sql testdata/identifier.csv
+```
+
+where `join.sql` holds:
+
+```sql
+SELECT s.user_name, i.position
+FROM stdin s
+JOIN identifier i ON s.identifier = i.id
+ORDER BY s.identifier;
+```
+
 ### Inspect tables: --inspect option
 `--inspect` imports the given files and directories and prints a JSON report of every table, then exits without starting the shell. The report lists each table name, its source path, the column schema, the row count, and a small sample of rows. It gives scripts and LLMs a non-interactive equivalent of `.tables`, `.schema`, and `.describe`. Import progress goes to stderr, so stdout carries only the JSON. Excel sheets and ACH/Fedwire files map several tables to one source path. `--inspect-sample N` sets how many sample rows each table includes (default 5); `--inspect-sample 0` produces a schema-only report for wide or multi-table sources.
 

--- a/config/argument.go
+++ b/config/argument.go
@@ -44,6 +44,12 @@ type Arg struct {
 	VersionFlag bool
 	// Query is SQL query (for --sql option)
 	Query string
+	// SQLFilePath is the path to a file containing SQL to execute (for
+	// --sql-file). It lets stdin carry a piped dataset (--stdin) while the query
+	// arrives from a file, which a single stdin stream cannot do. It supports
+	// multiline statements with the same splitting rules as batch stdin mode and
+	// cannot be combined with --sql.
+	SQLFilePath string
 	// InspectFlag, when true, prints a machine-readable JSON report of the
 	// imported tables (names, source mapping, columns, row counts, and sample
 	// rows) and exits without starting the shell.
@@ -117,6 +123,7 @@ func NewArg(args []string) (*Arg, error) {
 	stdinFormat := flag.String("stdin", "", "treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)")
 	stdinName := flag.String("stdin-name", "stdin", "table name for the --stdin dataset")
 	query := flag.StringP("sql", "s", "", "sql query you want to execute")
+	sqlFile := flag.StringP("sql-file", "f", "", "path to a file with SQL to execute (multiline; cannot be used with --sql)")
 	output := flag.StringP("output", "o", "", "destination path for SQL results specified in --sql option")
 	flag.BoolVarP(&arg.InspectFlag, "inspect", "i", false, "print a JSON report of imported tables (schema, row counts, sample rows) and exit")
 	inspectSample := flag.Int("inspect-sample", defaultInspectSample, "rows to include per table in --inspect (0 for schema only)")
@@ -137,6 +144,7 @@ func NewArg(args []string) (*Arg, error) {
 	arg.StdinFormat = *stdinFormat
 	arg.StdinTableName = *stdinName
 	arg.Query = *query
+	arg.SQLFilePath = *sqlFile
 	arg.SaveDir = *saveDir
 	arg.InspectSample = *inspectSample
 
@@ -194,6 +202,8 @@ func usage(flag pflag.FlagSet) string {
 	s += "    sqly file1.csv ./data_dir file2.tsv\n"
 	s += fmt.Sprintf("  - %s\n", color.HiYellowString("Batch mode: pipe SQL/commands via stdin (no TTY)"))
 	s += "    echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv\n"
+	s += fmt.Sprintf("  - %s\n", color.HiYellowString("Join a piped dataset (--stdin) with a query loaded from a file"))
+	s += "    cat data.csv | sqly --stdin csv --sql-file query.sql\n"
 	s += "\n"
 	s += "[OPTIONS]\n"
 	s += flag.FlagUsages()

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -201,6 +201,29 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("--sql-file sets the SQL file path (#281)", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--sql-file", "query.sql", "testdata/user.csv"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.SQLFilePath != "query.sql" {
+			t.Errorf("SQLFilePath = %q, want %q", arg.SQLFilePath, "query.sql")
+		}
+		if diff := cmp.Diff([]string{"testdata/user.csv"}, arg.FilePaths); diff != "" {
+			t.Errorf("FilePaths mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("sql file path defaults to empty (#281)", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "testdata/user.csv"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.SQLFilePath != "" {
+			t.Errorf("SQLFilePath = %q, want empty", arg.SQLFilePath)
+		}
+	})
+
 	t.Run("--inspect sets the inspect flag (#259)", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "--inspect", "testdata/user.csv"})
 		if err != nil {

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -14,6 +14,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
     sqly file1.csv ./data_dir file2.tsv
   - Batch mode: pipe SQL/commands via stdin (no TTY)
     echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv
+  - Join a piped dataset (--stdin) with a query loaded from a file
+    cat data.csv | sqly --stdin csv --sql-file query.sql
 
 [OPTIONS]
   -c, --csv                  change output format to csv (default: table)
@@ -28,6 +30,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
       --stdin string         treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
       --stdin-name string    table name for the --stdin dataset (default "stdin")
   -s, --sql string           sql query you want to execute
+  -f, --sql-file string      path to a file with SQL to execute (multiline; cannot be used with --sql)
   -o, --output string        destination path for SQL results specified in --sql option
   -i, --inspect              print a JSON report of imported tables (schema, row counts, sample rows) and exit
       --inspect-sample int   rows to include per table in --inspect (0 for schema only) (default 5)

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -35,6 +35,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
       --stdin string    treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
       --stdin-name string   table name for the --stdin dataset (default "stdin")
   -s, --sql string      sql query you want to execute
+  -f, --sql-file string   path to a file with SQL to execute (multiline; cannot be used with --sql)
   -o, --output string   destination path for SQL results specified in --sql option
   -i, --inspect         print a JSON report of imported tables (schema, row counts, sample rows) and exit
       --inspect-sample int  rows to include per table in --inspect (0 for schema only) (default 5)
@@ -68,6 +69,25 @@ $ sqly --sql "SELECT user_name, position FROM user INNER JOIN identifier ON user
 | jenkins46 | manager   |
 | smith79   | neet      |
 +-----------+-----------+
+```
+
+### Load SQL from a file: --sql-file option
+
+`--sql-file PATH` runs SQL read from a file instead of from `--sql` or stdin. The file may contain multiple statements separated by `;`, and a statement may span multiple lines, following the same rules as batch stdin mode; a leading header comment is allowed. It cannot be combined with `--sql`, and a missing, unreadable, or empty file fails with a clear error.
+
+Because the query comes from a file, stdin is free to carry a dataset. Combine it with `--stdin <format>` to join piped data:
+
+```shell
+$ cat testdata/user.csv | sqly --stdin csv --sql-file join.sql testdata/identifier.csv
+```
+
+where `join.sql` holds:
+
+```sql
+SELECT s.user_name, i.position
+FROM stdin s
+JOIN identifier i ON s.identifier = i.id
+ORDER BY s.identifier;
 ```
 
 ### Inspect tables: --inspect option

--- a/main_test.go
+++ b/main_test.go
@@ -70,6 +70,20 @@ func Test_run(t *testing.T) {
 		g.Assert(t, "excel_to_csv", got)
 	})
 
+	t.Run("--sql-file runs a multiline query loaded from a file (#281)", func(t *testing.T) {
+		sqlPath := filepath.Join(t.TempDir(), "query.sql")
+		query := "-- top actor by name\nSELECT actor\nFROM actor\nORDER BY actor ASC\nLIMIT 1;\n"
+		if err := os.WriteFile(sqlPath, []byte(query), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		args := []string{"sqly", "--csv", "--sql-file", sqlPath, "testdata/actor.csv"}
+		got := getStdoutForRunFunc(t, run, args)
+
+		g := golden.New(t,
+			golden.WithFixtureDir(filepath.Join("testdata", "golden")))
+		g.Assert(t, "sql_file_multiline", got)
+	})
+
 	t.Run("Treat numbers as numeric types; support numerical sorting", func(t *testing.T) {
 		// SELECT * FROM numeric ORDER BY id
 		// [Previously Result]

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/nao1215/sqly/config"
@@ -27,7 +29,16 @@ const maxBatchLineBytes = 10 * 1024 * 1024
 // failed, runBatch returns an error so the process exits non-zero. A ".exit"
 // command stops early with a success status, mirroring the interactive shell.
 func (s *Shell) runBatch(ctx context.Context) error {
-	scanner := bufio.NewScanner(s.stdin)
+	return s.runBatchReader(ctx, s.stdin)
+}
+
+// runBatchReader executes SQL statements and helper commands read from r using
+// the same parsing rules as runBatch. It is shared by batch stdin mode and
+// --sql-file so both follow identical statement-splitting and error reporting;
+// --sql-file passes a file reader instead of stdin, which frees stdin to carry
+// a piped --stdin dataset.
+func (s *Shell) runBatchReader(ctx context.Context, r io.Reader) error {
+	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxBatchLineBytes)
 
 	failed := false
@@ -85,7 +96,7 @@ scan:
 			return fmt.Errorf("failed to read batch input: %w", err)
 		}
 		// Execute any trailing statement that was not terminated by ";".
-		if leftover := strings.TrimSpace(pending.String()); leftover != "" {
+		if leftover := stripLeadingSQLComments(pending.String()); leftover != "" {
 			run(leftover)
 		}
 	}
@@ -96,10 +107,38 @@ scan:
 	return nil
 }
 
+// stripLeadingSQLComments removes leading line ("--") and block ("/* */")
+// comments and surrounding whitespace from a statement, returning "" when
+// nothing executable remains. sqly classifies a statement by its first token, so
+// a leading comment would otherwise be rejected as "not sql"; SQL files commonly
+// open with a header comment, so this lets them run unchanged.
+func stripLeadingSQLComments(s string) string {
+	for {
+		s = strings.TrimSpace(s)
+		switch {
+		case strings.HasPrefix(s, "--"):
+			i := strings.IndexByte(s, '\n')
+			if i < 0 {
+				return "" // line comment runs to the end of the input
+			}
+			s = s[i+1:]
+		case strings.HasPrefix(s, "/*"):
+			i := strings.Index(s, "*/")
+			if i < 0 {
+				return "" // unterminated block comment, nothing executable
+			}
+			s = s[i+2:]
+		default:
+			return s
+		}
+	}
+}
+
 // splitSQLStatements splits accumulated text into complete statements terminated
 // by a top-level ";" and returns the trailing unterminated remainder. Semicolons
 // inside string literals, identifiers, and comments are ignored so they do not
-// split a statement mid-value.
+// split a statement mid-value. Each returned statement has leading comments
+// stripped so it is classified by its first SQL keyword.
 func splitSQLStatements(s string) (stmts []string, remainder string) {
 	runes := []rune(s)
 	var (
@@ -140,7 +179,7 @@ func splitSQLStatements(s string) (stmts []string, remainder string) {
 				inBlockComment = true
 				i++
 			case c == ';':
-				if stmt := strings.TrimSpace(string(runes[start:i])); stmt != "" {
+				if stmt := stripLeadingSQLComments(string(runes[start:i])); stmt != "" {
 					stmts = append(stmts, stmt)
 				}
 				start = i + 1
@@ -148,4 +187,19 @@ func splitSQLStatements(s string) (stmts []string, remainder string) {
 		}
 	}
 	return stmts, string(runes[start:])
+}
+
+// readSQLFile reads the SQL script at path for --sql-file. It returns a clear
+// error for a missing or unreadable file (wrapping the OS error so callers can
+// inspect it with errors.Is) and rejects a file with no SQL, so an empty or
+// whitespace-only script fails loudly instead of running nothing.
+func readSQLFile(path string) (string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is the user-specified --sql-file
+	if err != nil {
+		return "", fmt.Errorf("failed to read --sql-file %q: %w", path, err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return "", fmt.Errorf("--sql-file %q is empty", path)
+	}
+	return string(data), nil
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -129,6 +129,21 @@ func (s *Shell) Run(ctx context.Context) error {
 		return nil
 	}
 
+	// --sql and --sql-file both supply a non-interactive query; accepting both
+	// would be ambiguous. Read and validate the SQL file before importing so a
+	// bad path fails fast without spending time on the import.
+	if s.argument.Query != "" && s.argument.SQLFilePath != "" {
+		return errors.New("--sql and --sql-file cannot be used together")
+	}
+	var sqlScript string
+	if s.argument.SQLFilePath != "" {
+		script, err := readSQLFile(s.argument.SQLFilePath)
+		if err != nil {
+			return err
+		}
+		sqlScript = script
+	}
+
 	if err := s.init(ctx); err != nil {
 		return err
 	}
@@ -146,6 +161,16 @@ func (s *Shell) Run(ctx context.Context) error {
 
 	if s.argument.Query != "" {
 		if err := s.execSQL(ctx, s.argument.Query); err != nil {
+			return err
+		}
+		return s.maybeSave(ctx)
+	}
+
+	// --sql-file runs the loaded script with the same statement-splitting and
+	// error reporting as batch stdin mode, so multiline SQL and multiple
+	// statements behave identically whether they arrive from a file or a pipe.
+	if s.argument.SQLFilePath != "" {
+		if err := s.runBatchReader(ctx, strings.NewReader(sqlScript)); err != nil {
 			return err
 		}
 		return s.maybeSave(ctx)

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1877,6 +1877,15 @@ func TestShellRunBatch_MultilineStatements(t *testing.T) {
 		}
 	})
 
+	t.Run("statement opening with a comment still runs", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "-- header comment\nSELECT actor FROM actor ORDER BY actor LIMIT 1;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "Adam Sandler") {
+			t.Fatalf("comment-led statement did not run: %q", got)
+		}
+	})
+
 	t.Run("incomplete SQL returns an error", func(t *testing.T) {
 		shell, cleanup := newBatchShell(t, "SELECT actor FROM (\n")
 		defer cleanup()
@@ -2263,6 +2272,136 @@ func TestShellRun_StdinDataset(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "piped") {
 			t.Fatalf("error = %q, want it to mention piped stdin", err.Error())
+		}
+	})
+}
+
+func TestShellRun_SQLFile(t *testing.T) {
+	// Regression for #281: --sql-file loads SQL from a file for non-interactive
+	// runs, freeing stdin to carry a piped dataset.
+	t.Run("runs a multiline SQL file against a file input", func(t *testing.T) {
+		dir := t.TempDir()
+		sqlPath := filepath.Join(dir, "query.sql")
+		query := "-- pick the first actor\nSELECT actor\nFROM actor\nORDER BY actor\nLIMIT 1;\n"
+		if err := os.WriteFile(sqlPath, []byte(query), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{"sqly", "--csv", "--sql-file", sqlPath, filepath.Join("testdata", "actor.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return true }
+
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "Adam Sandler") {
+			t.Fatalf("multiline SQL file did not execute: %q", got)
+		}
+	})
+
+	t.Run("runs multiple statements from a SQL file in order", func(t *testing.T) {
+		dir := t.TempDir()
+		sqlPath := filepath.Join(dir, "query.sql")
+		if err := os.WriteFile(sqlPath, []byte("SELECT 'first' AS x;\nSELECT 'second' AS x;\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{"sqly", "--csv", "--sql-file", sqlPath, filepath.Join("testdata", "actor.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return true }
+
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if strings.Index(got, "first") > strings.Index(got, "second") {
+			t.Fatalf("SQL file statements not executed in order: %q", got)
+		}
+	})
+
+	t.Run("runs a --stdin csv dataset joined with a SQL file query", func(t *testing.T) {
+		dir := t.TempDir()
+		sqlPath := filepath.Join(dir, "join.sql")
+		idPath := filepath.Join(dir, "identifier.csv")
+		if err := os.WriteFile(idPath, []byte("id,position\n1,dev\n2,manager\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		query := "SELECT s.name, i.position\nFROM stdin s\nJOIN identifier i ON s.id = i.id\nORDER BY s.id;\n"
+		if err := os.WriteFile(sqlPath, []byte(query), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "csv", "--csv", "--sql-file", sqlPath, idPath})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("id,name\n1,alice\n2,bob\n")
+
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "alice") || !strings.Contains(got, "dev") {
+			t.Fatalf("stdin dataset joined with SQL file did not produce expected rows: %q", got)
+		}
+	})
+
+	t.Run("rejects --sql and --sql-file together", func(t *testing.T) {
+		dir := t.TempDir()
+		sqlPath := filepath.Join(dir, "query.sql")
+		if err := os.WriteFile(sqlPath, []byte("SELECT 1;\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sql", "SELECT 1", "--sql-file", sqlPath, filepath.Join("testdata", "actor.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return true }
+
+		err = shell.Run(context.Background())
+		if err == nil {
+			t.Fatal("--sql with --sql-file returned nil error, want error")
+		}
+		if !strings.Contains(err.Error(), "--sql-file") {
+			t.Fatalf("error = %q, want it to mention --sql-file", err.Error())
+		}
+	})
+
+	t.Run("returns an error for a missing SQL file", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "no_such.sql")
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sql-file", missing, filepath.Join("testdata", "actor.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return true }
+
+		err = shell.Run(context.Background())
+		if err == nil {
+			t.Fatal("missing --sql-file returned nil error, want error")
+		}
+		if !strings.Contains(err.Error(), "sql-file") {
+			t.Fatalf("error = %q, want it to mention sql-file", err.Error())
+		}
+	})
+
+	t.Run("returns an error for an empty SQL file", func(t *testing.T) {
+		dir := t.TempDir()
+		sqlPath := filepath.Join(dir, "empty.sql")
+		if err := os.WriteFile(sqlPath, []byte("   \n\t\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sql-file", sqlPath, filepath.Join("testdata", "actor.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return true }
+
+		err = shell.Run(context.Background())
+		if err == nil {
+			t.Fatal("empty --sql-file returned nil error, want error")
+		}
+		if !strings.Contains(err.Error(), "empty") {
+			t.Fatalf("error = %q, want it to mention an empty file", err.Error())
 		}
 	})
 }

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -14,6 +14,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
     sqly file1.csv ./data_dir file2.tsv
   - Batch mode: pipe SQL/commands via stdin (no TTY)
     echo 'SELECT * FROM sample' | sqly ./path/to/sample.csv
+  - Join a piped dataset (--stdin) with a query loaded from a file
+    cat data.csv | sqly --stdin csv --sql-file query.sql
 
 [OPTIONS]
   -c, --csv                  change output format to csv (default: table)
@@ -28,6 +30,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
       --stdin string         treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
       --stdin-name string    table name for the --stdin dataset (default "stdin")
   -s, --sql string           sql query you want to execute
+  -f, --sql-file string      path to a file with SQL to execute (multiline; cannot be used with --sql)
   -o, --output string        destination path for SQL results specified in --sql option
   -i, --inspect              print a JSON report of imported tables (schema, row counts, sample rows) and exit
       --inspect-sample int   rows to include per table in --inspect (0 for schema only) (default 5)

--- a/spec/sql_file_spec.sh
+++ b/spec/sql_file_spec.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# --sql-file end-to-end tests (#281). --sql-file loads SQL from a file for
+# non-interactive runs, which frees stdin to carry a piped --stdin dataset. The
+# file supports multiline statements and the same splitting rules as batch
+# stdin mode.
+
+Describe 'sqly --sql-file (#281)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    SQL_DIR=$(mktemp -d)
+  }
+  cleanup() {
+    rm -rf "$SQL_DIR"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'runs a multiline query loaded from a file against a file input'
+    printf -- '-- top actor by name\nSELECT actor\nFROM actor\nORDER BY actor\nLIMIT 1;\n' > "$SQL_DIR/q.sql"
+    When run sqly --csv --sql-file "$SQL_DIR/q.sql" testdata/actor.csv
+    The status should be success
+    The output should include 'Adam Sandler'
+  End
+
+  It 'joins a piped --stdin dataset with a query loaded from a file'
+    printf 'SELECT s.name, i.position\nFROM stdin s\nJOIN identifier i ON s.id = i.id\nORDER BY s.id;\n' > "$SQL_DIR/join.sql"
+    Data
+      #|id,name
+      #|1,alice
+      #|2,bob
+    End
+    When run sqly --stdin csv --csv --sql-file "$SQL_DIR/join.sql" testdata/identifier.csv
+    The status should be success
+    The output should include 'alice'
+    The output should include 'developrt'
+  End
+
+  It 'runs multiple statements from a file in order'
+    printf "SELECT 'first' AS x;\nSELECT 'second' AS x;\n" > "$SQL_DIR/multi.sql"
+    When run sqly --csv --sql-file "$SQL_DIR/multi.sql" testdata/actor.csv
+    The status should be success
+    The output should include 'first'
+    The output should include 'second'
+  End
+
+  Describe 'error handling'
+    It 'rejects --sql and --sql-file together'
+      printf 'SELECT 1;\n' > "$SQL_DIR/q.sql"
+      When run sqly --sql "SELECT 1" --sql-file "$SQL_DIR/q.sql" testdata/actor.csv
+      The status should be failure
+      The stderr should include '--sql-file'
+    End
+
+    It 'fails for a missing SQL file'
+      When run sqly --sql-file "$SQL_DIR/no_such.sql" testdata/actor.csv
+      The status should be failure
+      The stderr should include 'sql-file'
+    End
+
+    It 'fails for an empty SQL file'
+      : > "$SQL_DIR/empty.sql"
+      When run sqly --sql-file "$SQL_DIR/empty.sql" testdata/actor.csv
+      The status should be failure
+      The stderr should include 'empty'
+    End
+  End
+End

--- a/testdata/golden/sql_file_multiline.golden
+++ b/testdata/golden/sql_file_multiline.golden
@@ -1,0 +1,2 @@
+actor
+Adam Sandler


### PR DESCRIPTION
This adds a first-class `--sql-file PATH` flag for non-interactive runs, loading SQL from a file instead of `--sql` or stdin. Because the query no longer comes from stdin, `--stdin <format>` can pipe a dataset while the query arrives from the file.

The file goes through the same statement-splitting and error reporting as batch stdin mode, so multiline SQL, multiple statements separated by `;`, and helper dot-commands all behave identically. Leading header comments are stripped before classification, which also lets comment-led statements run in batch mode. `--sql-file` cannot be combined with `--sql`, and missing, unreadable, or empty files fail with a clear error.

Done criteria from the issue:
- `--sql-file PATH` for non-interactive runs.
- Multiline statements and the same splitting rules as batch stdin mode.
- Works with file inputs, directory inputs, and `--stdin <format>` dataset imports.
- Explicit errors for missing, unreadable, and empty files, and for combining it with `--sql`.
- Help text and README include an example joining a piped stdin dataset with a query loaded from a file.

Tests:
- Go: config parsing (`TestNewArg`), shell execution covering a multiline file, multiple statements in order, `--stdin csv` joined with a SQL file, the `--sql`/`--sql-file` conflict, and missing and empty file errors; a batch regression for a comment-led statement; a golden test through the `run()` entry point.
- shellspec (`spec/sql_file_spec.sh`): binary-level coverage of the multiline file, the `--stdin` join, multiple statements, and the conflict, missing, and empty file errors. Runs in the existing E2E CI job.

Closes #281


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--sql-file` (`-f`) option to load SQL statements from files
  * Supports multiline statements and multiple semicolon-separated queries with optional header comments
  * Seamlessly combines with `--stdin` for piping datasets alongside file-based SQL
  * Clear error handling for missing, unreadable, or empty SQL files

* **Documentation**
  * Updated CLI help text and user guides with `--sql-file` usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->