### PR TITLE
fix(persistence): write Excel exports without executable bits (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+* Excel Export Permissions: Exported `.xlsx` files are now created without executable bits (mode 0600), matching CSV, TSV, LTSV, and Parquet outputs. excelize's `SaveAs` created them as 0777, so they were left executable.
+
 ### New Features
 * Inspect Sample Control: `--inspect-sample N` sets how many sample rows `--inspect` includes per table (default 5). `--inspect-sample 0` produces a schema-only report, which keeps the output small for wide or multi-table sources such as Fedwire.
 * SQL File Input: `--sql-file PATH` runs SQL loaded from a file for non-interactive runs. Because the query no longer comes from stdin, `--stdin <format>` can pipe a dataset while the query comes from the file (`cat data.csv | sqly --stdin csv --sql-file query.sql`). The file supports multiline statements and multiple statements separated by `;`, using the same splitting rules as batch stdin mode, and a leading header comment is allowed. It cannot be combined with `--sql`, and missing, unreadable, or empty files fail with a clear error.

--- a/infrastructure/persistence/excel.go
+++ b/infrastructure/persistence/excel.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/domain/repository"
@@ -50,5 +51,12 @@ func (r *excelRepository) Dump(excelFilePath string, table *model.Table) (err er
 			return err
 		}
 	}
-	return f.SaveAs(excelFilePath)
+	if err := f.SaveAs(excelFilePath); err != nil {
+		return err
+	}
+	// excelize's SaveAs creates the file with os.ModePerm (0777), which leaves
+	// the export executable. Reset to the same non-executable mode as other
+	// outputs so .xlsx files are plain data files. Why not pass excelize
+	// Options: SaveAs hard-codes the mode and ignores a permissions option.
+	return os.Chmod(excelFilePath, defaultFilePerm)
 }

--- a/infrastructure/persistence/excel_test.go
+++ b/infrastructure/persistence/excel_test.go
@@ -55,4 +55,27 @@ func TestExcelRepositoryDump(t *testing.T) {
 			t.Fatalf("differs: (-got +want)\n%s", diff)
 		}
 	})
+
+	t.Run("dumped excel file is not executable (#296)", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewExcelRepository()
+		table := model.NewTable(
+			"test_sheet",
+			model.Header{"id", "name"},
+			[]model.Record{{"1", "Gina"}},
+		)
+		tempFilePath := filepath.Join(t.TempDir(), "perms.xlsx")
+		if err := r.Dump(tempFilePath, table); err != nil {
+			t.Fatal(err)
+		}
+
+		info, err := os.Stat(tempFilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mode := info.Mode().Perm(); mode&0o111 != 0 {
+			t.Errorf("excel export mode = %o, want no executable bits", mode)
+		}
+	})
 }

--- a/infrastructure/persistence/file.go
+++ b/infrastructure/persistence/file.go
@@ -7,6 +7,11 @@ import (
 	"github.com/nao1215/sqly/domain/repository"
 )
 
+// defaultFilePerm is the permission for files sqly writes. It is non-executable
+// (0600) so exports are treated as ordinary data files, consistent across CSV,
+// TSV, LTSV, Parquet, and Excel outputs.
+const defaultFilePerm = 0o600
+
 // _ interface implementation check
 var _ repository.FileRepository = (*fileRepository)(nil)
 
@@ -22,6 +27,5 @@ func NewFileRepository() repository.FileRepository {
 // shorter content (for example saving a smaller table over its source, or a
 // compressed export) does not leave stale trailing bytes that corrupt the file.
 func (fr *fileRepository) Create(path string) (*os.File, error) {
-	const defaultFilePerm = 0o600
 	return os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE|os.O_TRUNC, defaultFilePerm)
 }

--- a/spec/excel_export_spec.sh
+++ b/spec/excel_export_spec.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Excel export end-to-end tests (#296). Exported .xlsx files must be ordinary
+# data files, not executables, matching other output formats.
+
+Describe 'sqly excel export (#296)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    OUT_DIR=$(mktemp -d)
+  }
+  cleanup() {
+    rm -rf "$OUT_DIR"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'writes a non-executable .xlsx with --output'
+    When run sqly --excel --output "$OUT_DIR/out.xlsx" --sql "SELECT * FROM user LIMIT 1" testdata/user.csv
+    The status should be success
+    The output should include 'output mode=excel'
+    The path "$OUT_DIR/out.xlsx" should be file
+    The path "$OUT_DIR/out.xlsx" should not be executable
+  End
+
+  It 'writes a non-executable .xlsx with the .dump command'
+    Data:expand
+      #|.mode excel
+      #|.dump user "$OUT_DIR/dump.xlsx"
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+    The output should include 'excel'
+    The path "$OUT_DIR/dump.xlsx" should be file
+    The path "$OUT_DIR/dump.xlsx" should not be executable
+  End
+End


### PR DESCRIPTION
Exported `.xlsx` files were created with executable permission bits (mode 0775). excelize's `SaveAs` opens the destination with `os.ModePerm` (0777), so the resulting file was left executable, unlike CSV, TSV, LTSV, and Parquet outputs which are written with mode 0600.

This resets the Excel file mode to 0600 after `SaveAs` (the mode cannot be passed through excelize's options, which ignore a permissions field). A shared `defaultFilePerm` constant now backs both the generic file writer and the Excel writer.

Tests:
- Unit: `TestExcelRepositoryDump` asserts the dumped file has no executable bits.
- shellspec (`spec/excel_export_spec.sh`): `--output out.xlsx` and `.dump ... out.xlsx` produce non-executable files. Runs in the existing E2E CI job.

Closes #296


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excel `.xlsx` file exports are now created with non-executable file permissions instead of potentially retaining executable bits, improving security and cross-platform behavior.

* **Tests**
  * Added tests to verify Excel export files are created with proper non-executable permissions.
  * Added end-to-end tests for Excel export functionality to validate complete workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->