### PR TITLE
fix(shell): reject --sheet for non-Excel inputs instead of ignoring it (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 * Excel Export Permissions: Exported `.xlsx` files are now created without executable bits (mode 0600), matching CSV, TSV, LTSV, and Parquet outputs. excelize's `SaveAs` created them as 0777, so they were left executable.
+* Sheet Flag Validation: `--sheet` is now rejected with a clear error when no input can be an Excel file (for example a single CSV input or a `--stdin` dataset), instead of being silently ignored. Directory inputs are still accepted because they may contain Excel files.
 
 ### New Features
 * Inspect Sample Control: `--inspect-sample N` sets how many sample rows `--inspect` includes per table (default 5). `--inspect-sample 0` produces a schema-only report, which keeps the output small for wide or multi-table sources such as Fedwire.

--- a/shell/import.go
+++ b/shell/import.go
@@ -23,6 +23,27 @@ const (
 	sheetFlagAssign = sheetFlag + "="
 )
 
+// validateSheetFlag rejects the CLI --sheet option when no input can be an
+// Excel file. --sheet selects a single Excel sheet and is silently ignored for
+// other formats, so a typo (or pairing it with --stdin) would otherwise pass
+// unnoticed. A directory input is allowed because it may contain Excel files,
+// and a path that cannot be stat'd is left for the import step to report.
+func (s *Shell) validateSheetFlag() error {
+	if s.argument.SheetName == "" {
+		return nil
+	}
+	for _, path := range s.argument.FilePaths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil //nolint:nilerr // a bad path is reported by the import step, not here
+		}
+		if info.IsDir() || s.usecases.importer.IsExcelFile(path) {
+			return nil
+		}
+	}
+	return errors.New("--sheet is only valid for Excel (.xlsx) inputs")
+}
+
 // importCommand imports files into the in-memory database.
 // Each file/directory is loaded individually so that same-name tables from
 // different directories are overwritten (last-wins) rather than failing,

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -129,6 +129,12 @@ func (s *Shell) Run(ctx context.Context) error {
 		return nil
 	}
 
+	// --sheet only affects Excel imports; reject it up front when no input can
+	// be an Excel file so a typo is not silently ignored.
+	if err := s.validateSheetFlag(); err != nil {
+		return err
+	}
+
 	// --sql and --sql-file both supply a non-interactive query; accepting both
 	// would be ambiguous. Read and validate the SQL file before importing so a
 	// bad path fails fast without spending time on the import.

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2406,6 +2406,71 @@ func TestShellRun_SQLFile(t *testing.T) {
 	})
 }
 
+func TestShellValidateSheetFlag(t *testing.T) {
+	// Regression for #287: --sheet only affects Excel imports, so it must be
+	// rejected when no input can be an Excel file instead of being silently
+	// ignored.
+	t.Run("rejects --sheet when the only input is a non-Excel file", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sheet", "A test", filepath.Join("testdata", "sample.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if err := shell.validateSheetFlag(); err == nil {
+			t.Fatal("validateSheetFlag returned nil for a non-Excel input, want error")
+		}
+	})
+
+	t.Run("rejects --sheet for a stdin dataset", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "csv", "--sheet", "A test"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if err := shell.validateSheetFlag(); err == nil {
+			t.Fatal("validateSheetFlag returned nil for a stdin dataset, want error")
+		}
+	})
+
+	t.Run("allows --sheet for an Excel input", func(t *testing.T) {
+		xlsx := filepath.Join(t.TempDir(), "book.xlsx")
+		if err := os.WriteFile(xlsx, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sheet", "A test", xlsx})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if err := shell.validateSheetFlag(); err != nil {
+			t.Fatalf("validateSheetFlag returned error for an Excel input: %v", err)
+		}
+	})
+
+	t.Run("allows --sheet for a directory input that may contain Excel files", func(t *testing.T) {
+		dir := t.TempDir()
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sheet", "A test", dir})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if err := shell.validateSheetFlag(); err != nil {
+			t.Fatalf("validateSheetFlag returned error for a directory input: %v", err)
+		}
+	})
+
+	t.Run("allows an unset --sheet", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", filepath.Join("testdata", "sample.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if err := shell.validateSheetFlag(); err != nil {
+			t.Fatalf("validateSheetFlag returned error when --sheet is unset: %v", err)
+		}
+	})
+}
+
 func TestShellRun_HistoryUnavailable(t *testing.T) {
 	// Regression for #262: non-interactive runs must succeed even when the
 	// history DB cannot be created or written (e.g. read-only config dir).

--- a/spec/sheet_flag_spec.sh
+++ b/spec/sheet_flag_spec.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# --sheet validation end-to-end tests (#287). --sheet only affects Excel
+# imports, so it must be rejected for non-Excel inputs instead of being
+# silently ignored.
+
+Describe 'sqly --sheet validation (#287)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'rejects --sheet with a non-Excel file and --sql'
+    When run sqly --sql "SELECT * FROM user" --sheet "A test" testdata/user.csv
+    The status should be failure
+    The stderr should include '--sheet'
+  End
+
+  It 'rejects --sheet with a non-Excel file and --inspect'
+    When run sqly --inspect --sheet "A test" testdata/user.csv
+    The status should be failure
+    The stderr should include '--sheet'
+  End
+
+  It 'still imports an Excel file with --sheet'
+    When run sqly --csv --sql "SELECT * FROM sample_test_sheet" --sheet test_sheet testdata/sample.xlsx
+    The status should be success
+    The output should include 'name'
+  End
+End


### PR DESCRIPTION
`--sheet` selects a single Excel sheet during import and is silently ignored for non-Excel inputs. A typo, or pairing it with `--stdin`, would pass unnoticed.

`Run` now validates `--sheet` up front and rejects it with a clear error when no input can be an Excel file. Directory inputs are still allowed because they may contain Excel files, and a path that cannot be stat'd is left for the import step to report rather than being misattributed to `--sheet`.

Tests:
- Unit: `TestShellValidateSheetFlag` covers a non-Excel file, a stdin dataset, an Excel file, a directory, and an unset flag.
- shellspec (`spec/sheet_flag_spec.sh`): `--sheet` is rejected with `--sql` and with `--inspect` on a CSV input, and still works for an Excel input. Runs in the existing E2E CI job.

Closes #287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `--sheet` flag now rejects invalid inputs early with a clear error message when used with non-Excel sources like CSV files or stdin, while accepting directories that may contain Excel files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->