### PR TITLE
fix(shell): reject --inspect combined with conflicting flags (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Inspect Flag Conflicts: `--inspect` now rejects conflicting action and side-effecting flags (`--sql`, `--sql-file`, `--output`, `--save`, `--save-dir`) with a clear error instead of silently discarding them.
 * Excel Export Permissions: Exported `.xlsx` files are now created without executable bits (mode 0600), matching CSV, TSV, LTSV, and Parquet outputs. excelize's `SaveAs` created them as 0777, so they were left executable.
 * Sheet Flag Validation: `--sheet` is now rejected with a clear error when no input can be an Excel file (for example a single CSV input or a `--stdin` dataset), instead of being silently ignored. Directory inputs are still accepted because they may contain Excel files.
 

--- a/shell/inspect.go
+++ b/shell/inspect.go
@@ -35,6 +35,30 @@ type inspectReport struct {
 	Tables []inspectTable `json:"tables"`
 }
 
+// validateInspectFlags rejects --inspect combined with other effectful flags.
+// --inspect is a self-contained discovery path that imports inputs, prints a
+// JSON report, and exits, so flags that ask for a different action (--sql,
+// --sql-file) or a side effect (--output, --save, --save-dir) would otherwise be
+// silently discarded. Failing fast keeps the contract explicit for scripts.
+func (s *Shell) validateInspectFlags() error {
+	if !s.argument.InspectFlag {
+		return nil
+	}
+	switch {
+	case s.argument.Query != "":
+		return errors.New("--inspect cannot be combined with --sql")
+	case s.argument.SQLFilePath != "":
+		return errors.New("--inspect cannot be combined with --sql-file")
+	case s.argument.Output.FilePath != "":
+		return errors.New("--inspect cannot be combined with --output")
+	case s.argument.SaveInPlace:
+		return errors.New("--inspect cannot be combined with --save")
+	case s.argument.SaveDir != "":
+		return errors.New("--inspect cannot be combined with --save-dir")
+	}
+	return nil
+}
+
 // runInspect prints a machine-readable JSON report of the imported tables:
 // names, source mapping, columns, row counts, and a small sample of rows. It is
 // the non-interactive discovery path for scripts and LLMs, so JSON is the

--- a/shell/inspect_test.go
+++ b/shell/inspect_test.go
@@ -56,6 +56,37 @@ func writeCSV(t *testing.T, dir, name, content string) string {
 	return path
 }
 
+func TestInspect_RejectsConflictingFlags(t *testing.T) {
+	// Regression for #288: --inspect must reject other effectful flags instead
+	// of silently discarding them.
+	dir := t.TempDir()
+	csv := writeCSV(t, dir, "people.csv", "name,age\nAlice,30\n")
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"with --sql", []string{"sqly", "--inspect", "--sql", "SELECT 1", csv}},
+		{"with --output", []string{"sqly", "--inspect", "--output", filepath.Join(dir, "out.csv"), csv}},
+		{"with --save-dir", []string{"sqly", "--inspect", "--save-dir", dir, csv}},
+		{"with --save --force", []string{"sqly", "--inspect", "--save", "--force", csv}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shell, cleanup, err := newShell(t, tc.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+			shell.isTTY = func() bool { return true }
+
+			if err := shell.Run(context.Background()); err == nil {
+				t.Fatalf("Run returned nil for --inspect %s, want a conflict error", tc.name)
+			}
+		})
+	}
+}
+
 func TestInspect_SingleFile(t *testing.T) {
 	dir := t.TempDir()
 	csv := writeCSV(t, dir, "people.csv", "name,age\nAlice,30\nBob,25\n")

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -135,6 +135,12 @@ func (s *Shell) Run(ctx context.Context) error {
 		return err
 	}
 
+	// --inspect is self-contained; reject conflicting action/side-effect flags
+	// up front instead of silently discarding them.
+	if err := s.validateInspectFlags(); err != nil {
+		return err
+	}
+
 	// --sql and --sql-file both supply a non-interactive query; accepting both
 	// would be ambiguous. Read and validate the SQL file before importing so a
 	// bad path fails fast without spending time on the import.

--- a/spec/inspect_conflicts_spec.sh
+++ b/spec/inspect_conflicts_spec.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# --inspect conflicting-flag validation (#288). --inspect is self-contained, so
+# combining it with action or side-effecting flags must fail instead of
+# silently discarding them.
+
+Describe 'sqly --inspect conflicts (#288)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    OUT_DIR=$(mktemp -d)
+  }
+  cleanup() {
+    rm -rf "$OUT_DIR"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'rejects --inspect with --sql'
+    When run sqly --inspect --sql "SELECT * FROM user LIMIT 1" testdata/user.csv
+    The status should be failure
+    The stderr should include '--inspect'
+  End
+
+  It 'rejects --inspect with --output and writes no file'
+    When run sqly --inspect --output "$OUT_DIR/out.csv" testdata/user.csv
+    The status should be failure
+    The stderr should include '--inspect'
+    The path "$OUT_DIR/out.csv" should not be exist
+  End
+
+  It 'rejects --inspect with --save-dir and creates no save dir'
+    When run sqly --inspect --save-dir "$OUT_DIR/save" testdata/user.csv
+    The status should be failure
+    The stderr should include '--inspect'
+    The path "$OUT_DIR/save" should not be exist
+  End
+End


### PR DESCRIPTION
`--inspect` imports its inputs, prints a JSON report, and exits. When combined with `--sql`, `--output`, `--save`, or `--save-dir`, those flags were silently discarded: the command still printed inspect JSON and exited 0 without running the query or writing the requested file or directory.

`Run` now validates `--inspect` up front and rejects it when combined with `--sql`, `--sql-file`, `--output`, `--save`, or `--save-dir`, with a clear error naming the conflict. The check runs before import, so no side effects occur.

Tests:
- Unit: `TestInspect_RejectsConflictingFlags` covers `--sql`, `--output`, `--save-dir`, and `--save --force`.
- shellspec (`spec/inspect_conflicts_spec.sh`): rejects the combinations and confirms no output file or save directory is created. Runs in the existing E2E CI job.

Closes #288
