### PR TITLE
fix(export): reject directory output destinations instead of rewriting them (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Directory Output Targets: `--output` and `.dump` now reject a destination that already exists as a directory with a clear error, instead of silently writing to a sibling file such as `dir.csv`.
 * Output Path Preservation: `--output` and `.dump` no longer rewrite a destination with an unknown extension to a sibling `.csv` file. The CSV fallback now writes to the exact path given (for example `--output out.unknown` writes to `out.unknown`), instead of silently creating `out.csv`.
 * Inspect Flag Conflicts: `--inspect` now rejects conflicting action and side-effecting flags (`--sql`, `--sql-file`, `--output`, `--save`, `--save-dir`) with a clear error instead of silently discarding them.
 * Excel Export Permissions: Exported `.xlsx` files are now created without executable bits (mode 0600), matching CSV, TSV, LTSV, and Parquet outputs. excelize's `SaveAs` created them as 0777, so they were left executable.

--- a/shell/commands_test.go
+++ b/shell/commands_test.go
@@ -591,6 +591,26 @@ func TestShell_execSQL_dependsOnQueryUsecase(t *testing.T) {
 	})
 }
 
+func TestCommandList_dumpCommand_RejectsDirectoryTarget(t *testing.T) {
+	// Regression for #303: a directory destination must be rejected, not
+	// rewritten to a sibling .csv file.
+	ctrl := gomock.NewController(t)
+	metadata := mock.NewMockMetadataUsecase(ctrl)
+	exporter := mock.NewMockExportUsecase(ctrl)
+	// Neither usecase should be called: the directory is rejected up front.
+
+	dir := t.TempDir()
+	s := newBoundaryTestShell(t, Usecases{metadata: metadata, export: exporter})
+
+	err := NewCommands().dumpCommand(context.Background(), s, []string{"users", dir})
+	if err == nil {
+		t.Fatal("dumpCommand returned nil for a directory destination, want error")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Fatalf("error = %q, want it to mention a directory", err.Error())
+	}
+}
+
 func TestCommandList_dumpCommand_dependsOnMetadataAndExportUsecases(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	metadata := mock.NewMockMetadataUsecase(ctrl)

--- a/shell/dump.go
+++ b/shell/dump.go
@@ -41,6 +41,12 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 		return fmt.Errorf(".dump does not support Fedwire format output; use csv/tsv/xlsx instead (e.g., .dump %s %s.csv)", tableName, strings.TrimSuffix(userPath, filepath.Ext(userPath)))
 	}
 
+	// Reject a directory destination before doing any work, so it is not
+	// silently rewritten to a sibling file (e.g. "dir" -> "dir.csv").
+	if err := ensureNotDirectory(userPath); err != nil {
+		return err
+	}
+
 	table, err := s.usecases.metadata.List(ctx, tableName)
 	if err != nil {
 		return err

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -141,6 +141,12 @@ func (s *Shell) Run(ctx context.Context) error {
 		return err
 	}
 
+	// Reject an --output destination that is an existing directory before import,
+	// so it is not silently rewritten to a sibling file.
+	if err := ensureNotDirectory(s.argument.Output.FilePath); err != nil {
+		return err
+	}
+
 	// --sql and --sql-file both supply a non-interactive query; accepting both
 	// would be ambiguous. Read and validate the SQL file before importing so a
 	// bad path fails fast without spending time on the import.
@@ -645,6 +651,21 @@ func (s *Shell) outputToFile(table *model.Table) error {
 	}
 	fmt.Fprintf(config.Stdout, "Output sql result to %s (output mode=%s)\n",
 		color.HiCyanString(filePath), exportFmt.String())
+	return nil
+}
+
+// ensureNotDirectory rejects an output destination that already exists as a
+// directory. Without this check the path gets a format extension appended,
+// silently writing to a sibling file (e.g. "out" -> "out.csv") instead of the
+// directory the user named. A non-existent path is fine; it is created on write.
+func ensureNotDirectory(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil //nolint:nilerr // a missing path is created at write time; other errors surface there
+	}
+	if info.IsDir() {
+		return fmt.Errorf("output destination %q is a directory; specify a file path", path)
+	}
 	return nil
 }
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2406,6 +2406,29 @@ func TestShellRun_SQLFile(t *testing.T) {
 	})
 }
 
+func TestShellRun_OutputToDirectoryIsRejected(t *testing.T) {
+	// Regression for #303: --output to an existing directory must be rejected,
+	// not rewritten to a sibling .csv file.
+	dir := t.TempDir()
+	shell, cleanup, err := newShell(t, []string{"sqly", "--csv", "--sql", "SELECT id FROM sample LIMIT 1", "--output", dir, filepath.Join("testdata", "sample.csv")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	shell.isTTY = func() bool { return true }
+
+	runErr := shell.Run(context.Background())
+	if runErr == nil {
+		t.Fatal("Run returned nil for --output to a directory, want error")
+	}
+	if !strings.Contains(runErr.Error(), "directory") {
+		t.Fatalf("error = %q, want it to mention a directory", runErr.Error())
+	}
+	if _, statErr := os.Stat(dir + ".csv"); statErr == nil {
+		t.Fatalf("a sibling file %q was created", dir+".csv")
+	}
+}
+
 func TestShellValidateSheetFlag(t *testing.T) {
 	// Regression for #287: --sheet only affects Excel imports, so it must be
 	// rejected when no input can be an Excel file instead of being silently

--- a/spec/export_inference_spec.sh
+++ b/spec/export_inference_spec.sh
@@ -56,6 +56,31 @@ Describe 'sqly export format inference (#260)'
     End
   End
 
+  Describe 'directory destinations are rejected (#303)'
+    It 'rejects --output to an existing directory'
+      out_dir=$(mktemp -d)
+      export out_dir
+      When run sqly --sql "SELECT id FROM user LIMIT 1" testdata/user.csv --output "$out_dir"
+      The status should be failure
+      The stderr should include 'directory'
+      The path "$out_dir.csv" should not be exist
+      rm -rf "$out_dir"
+    End
+
+    It 'rejects .dump to an existing directory'
+      out_dir=$(mktemp -d)
+      export out_dir
+      Data:expand
+        #|.dump user ${out_dir}
+      End
+      When run sqly testdata/user.csv
+      The status should be failure
+      The stderr should include 'directory'
+      The path "$out_dir.csv" should not be exist
+      rm -rf "$out_dir"
+    End
+  End
+
   Describe 'conflicts and unsupported combinations'
     It 'errors when an explicit mode flag disagrees with the path extension'
       out_dir=$(mktemp -d)


### PR DESCRIPTION
When `--output` or `.dump` was given a path that already exists as a directory, sqly appended a format extension and silently wrote to a sibling file (for example `dir` became `dir.csv`), so the directory the user named was ignored and the command still reported success.

Both paths now reject an existing-directory destination up front with a clear error. The `--output` check runs before import, and the `.dump` check runs before listing the table, so no work is done and no sibling file is created. A non-existent path is still fine and is created on write.

Tests:
- Unit: `TestShellRun_OutputToDirectoryIsRejected` (`--output`) and `TestCommandList_dumpCommand_RejectsDirectoryTarget` (`.dump`) assert the error and that no sibling file is written.
- shellspec (`spec/export_inference_spec.sh`): both `--output` and `.dump` to a directory fail and create no sibling `.csv`. Runs in the existing E2E CI job.

Closes #303
