### PR TITLE
fix(shell): send the .mode change banner to stderr to keep batch stdout pure (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Mode-Change Banner On Stderr: The `.mode` change banner now goes to stderr instead of stdout. In batch mode, switching to `.mode json` or `.mode ndjson` no longer prints a human-readable banner ahead of the machine-readable payload, so stdout stays parseable.
 * Directory Output Targets: `--output` and `.dump` now reject a destination that already exists as a directory with a clear error, instead of silently writing to a sibling file such as `dir.csv`.
 * Output Path Preservation: `--output` and `.dump` no longer rewrite a destination with an unknown extension to a sibling `.csv` file. The CSV fallback now writes to the exact path given (for example `--output out.unknown` writes to `out.unknown`), instead of silently creating `out.csv`.
 * Inspect Flag Conflicts: `--inspect` now rejects conflicting action and side-effecting flags (`--sql`, `--sql-file`, `--output`, `--save`, `--save-dir`) with a clear error instead of silently discarding them.

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -224,7 +224,7 @@ func TestShellExec(t *testing.T) {
 		}
 		defer cleanup()
 
-		got, err := getExecStdOutput(t, shell.exec, ".mode table")
+		got, err := getExecStdErrOutput(t, shell.exec, ".mode table")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -245,7 +245,7 @@ func TestShellExec(t *testing.T) {
 		}
 		defer cleanup()
 
-		got, err := getExecStdOutput(t, shell.exec, ".mode csv")
+		got, err := getExecStdErrOutput(t, shell.exec, ".mode csv")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -266,7 +266,7 @@ func TestShellExec(t *testing.T) {
 		}
 		defer cleanup()
 
-		got, err := getExecStdOutput(t, shell.exec, ".mode markdown")
+		got, err := getExecStdErrOutput(t, shell.exec, ".mode markdown")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -287,7 +287,7 @@ func TestShellExec(t *testing.T) {
 		}
 		defer cleanup()
 
-		got, err := getExecStdOutput(t, shell.exec, ".mode tsv")
+		got, err := getExecStdErrOutput(t, shell.exec, ".mode tsv")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -308,7 +308,7 @@ func TestShellExec(t *testing.T) {
 		}
 		defer cleanup()
 
-		got, err := getExecStdOutput(t, shell.exec, ".mode ltsv")
+		got, err := getExecStdErrOutput(t, shell.exec, ".mode ltsv")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -329,7 +329,7 @@ func TestShellExec(t *testing.T) {
 		}
 		defer cleanup()
 
-		got, err := getExecStdOutput(t, shell.exec, ".mode excel")
+		got, err := getExecStdErrOutput(t, shell.exec, ".mode excel")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1165,6 +1165,23 @@ func getExecStdOutput(t *testing.T, f func(context.Context, string) error, arg s
 
 	var buffer bytes.Buffer
 	config.Stdout = &buffer
+
+	execErr := f(context.Background(), arg)
+	return buffer.Bytes(), execErr
+}
+
+// getExecStdErrOutput runs f and captures what it writes to config.Stderr. Used
+// for status messages (e.g. the .mode change banner) that go to stderr so they
+// do not pollute machine-readable stdout.
+func getExecStdErrOutput(t *testing.T, f func(context.Context, string) error, arg string) ([]byte, error) {
+	t.Helper()
+	backupStderr := config.Stderr
+	defer func() {
+		config.Stderr = backupStderr
+	}()
+
+	var buffer bytes.Buffer
+	config.Stderr = &buffer
 
 	execErr := f(context.Background(), arg)
 	return buffer.Bytes(), execErr

--- a/shell/state.go
+++ b/shell/state.go
@@ -59,6 +59,11 @@ func newMode(w io.Writer, m model.PrintMode) *mode {
 
 // changeOutputModeIfNeeded change output mode.
 // modeName is new output mode (e.g. table).
+//
+// The mode-change banner is written to stderr, not stdout. In batch mode a
+// `.mode json`/`.mode ndjson` switch is followed by machine-readable output on
+// stdout, so a banner there would corrupt it; keeping the status message on
+// stderr preserves stdout purity for every mode.
 func (m *mode) changeOutputModeIfNeeded(modeName string) error {
 	if modeName == m.String() {
 		return fmt.Errorf("already %s mode", modeName)
@@ -66,32 +71,32 @@ func (m *mode) changeOutputModeIfNeeded(modeName string) error {
 
 	switch modeName {
 	case model.PrintModeTable.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeTable.String())
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeTable.String())
 		m.PrintMode = model.PrintModeTable
 	case model.PrintModeMarkdownTable.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s table\n", m.String(), model.PrintModeMarkdownTable.String())
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s table\n", m.String(), model.PrintModeMarkdownTable.String())
 		m.PrintMode = model.PrintModeMarkdownTable
 	case model.PrintModeCSV.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeCSV.String())
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeCSV.String())
 		m.PrintMode = model.PrintModeCSV
 	case model.PrintModeTSV.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeTSV.String())
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeTSV.String())
 		m.PrintMode = model.PrintModeTSV
 	case model.PrintModeLTSV.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeLTSV.String())
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeLTSV.String())
 		m.PrintMode = model.PrintModeLTSV
 	case model.PrintModeJSON.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeJSON.String())
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeJSON.String())
 		m.PrintMode = model.PrintModeJSON
 	case model.PrintModeNDJSON.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s\n", m.String(), model.PrintModeNDJSON.String())
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeNDJSON.String())
 		m.PrintMode = model.PrintModeNDJSON
 	case model.PrintModeExcel.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
 			m.String(), model.PrintModeExcel.String())
 		m.PrintMode = model.PrintModeExcel
 	case model.PrintModeParquet.String():
-		fmt.Fprintf(config.Stdout, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
+		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
 			m.String(), model.PrintModeParquet.String())
 		m.PrintMode = model.PrintModeParquet
 	default:

--- a/spec/batch_spec.sh
+++ b/spec/batch_spec.sh
@@ -24,6 +24,7 @@ Describe 'sqly batch mode (piped stdin)'
     When run sqly testdata/user.csv
     The status should be success
     The output should include '{"user_name":"booker12"}'
+    The stderr should include 'Change output mode'
   End
 
   It 'exits non-zero and names the failing statement on error'

--- a/spec/excel_export_spec.sh
+++ b/spec/excel_export_spec.sh
@@ -31,7 +31,8 @@ Describe 'sqly excel export (#296)'
     End
     When run sqly testdata/user.csv
     The status should be success
-    The output should include 'excel'
+    The output should include 'mode=excel'
+    The stderr should include 'Change output mode'
     The path "$OUT_DIR/dump.xlsx" should be file
     The path "$OUT_DIR/dump.xlsx" should not be executable
   End

--- a/spec/mode_banner_spec.sh
+++ b/spec/mode_banner_spec.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# .mode change banner routing (#295). In batch mode the mode-change banner must
+# not pollute stdout, so JSON and NDJSON output stay machine-readable. The
+# banner is a status message and goes to stderr instead.
+
+Describe 'sqly .mode banner routing (#295)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'keeps stdout pure JSON after .mode json'
+    Data
+      #|.mode json
+      #|SELECT user_name FROM user LIMIT 1
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+    The line 1 should equal '['
+    The output should not include 'Change output mode'
+    The stderr should include 'Change output mode from table to json'
+  End
+
+  It 'keeps stdout pure NDJSON after .mode ndjson'
+    Data
+      #|.mode ndjson
+      #|SELECT user_name FROM user LIMIT 1
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+    The line 1 should equal '{"user_name":"booker12"}'
+    The output should not include 'Change output mode'
+    The stderr should include 'Change output mode from table to ndjson'
+  End
+End

--- a/spec/parquet_export_spec.sh
+++ b/spec/parquet_export_spec.sh
@@ -22,6 +22,7 @@ Describe 'sqly parquet export'
     It 'writes a parquet file that re-imports with the same rows'
       When call check_dump_roundtrip
       The status should be success
+      The stderr should include 'Change output mode'
     End
   End
 
@@ -38,6 +39,7 @@ Describe 'sqly parquet export'
     It 'appends the .parquet extension'
       When call check_extension
       The status should be success
+      The stderr should include 'Change output mode'
     End
   End
 

--- a/spec/schema_spec.sh
+++ b/spec/schema_spec.sh
@@ -38,6 +38,7 @@ Describe 'sqly schema inspection'
       The status should be success
       The output should include '"table":"user"'
       The output should include '"schema":"CREATE TABLE'
+      The stderr should include 'Change output mode'
     End
 
     It 'errors on a missing table'
@@ -89,6 +90,7 @@ Describe 'sqly schema inspection'
       # Pair name and type for the same column so the assertion verifies
       # user_name's own type rather than matching another column's INTEGER.
       The output should include '"name":"user_name","type":"TEXT"'
+      The stderr should include 'Change output mode'
     End
 
     It 'errors on a missing table'


### PR DESCRIPTION
In batch mode, switching to `.mode json` or `.mode ndjson` printed a human-readable "Change output mode ..." banner to stdout before the machine-readable payload, so stdout was not valid JSON/NDJSON for downstream parsers.

The mode-change banner is a status message, so it now goes to stderr for every mode. stdout stays pure for JSON and NDJSON (and any other format) in batch runs, while interactive users still see the banner on the terminal.

Tests:
- Unit: the existing `.mode` banner golden tests now capture stderr via a new `getExecStdErrOutput` helper; the banner content is unchanged.
- shellspec (`spec/mode_banner_spec.sh`): after `.mode json`/`.mode ndjson` in batch, stdout starts with the payload and contains no banner, and the banner appears on stderr. Existing export/schema specs that switch mode now assert the banner on stderr.

Closes #295
