### PR TITLE
fix(shell): send file-output status messages to stderr (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* File-Output Status On Stderr: Status lines for file-output operations (`--output`, `.dump`, and `.save`/`--save`/`--save-dir`) now go to stderr instead of stdout. When all data is written to files, stdout stays empty, matching `--inspect` and letting scripts rely on an empty stdout for success.
 * Mode-Change Banner On Stderr: The `.mode` change banner now goes to stderr instead of stdout. In batch mode, switching to `.mode json` or `.mode ndjson` no longer prints a human-readable banner ahead of the machine-readable payload, so stdout stays parseable.
 * Directory Output Targets: `--output` and `.dump` now reject a destination that already exists as a directory with a clear error, instead of silently writing to a sibling file such as `dir.csv`.
 * Output Path Preservation: `--output` and `.dump` no longer rewrite a destination with an unknown extension to a sibling `.csv` file. The CSV fallback now writes to the exact path given (for example `--output out.unknown` writes to `out.unknown`), instead of silently creating `out.csv`.

--- a/shell/commands_test.go
+++ b/shell/commands_test.go
@@ -511,6 +511,18 @@ func captureStdout(t *testing.T, f func()) string {
 	return buf.String()
 }
 
+// captureStderr captures what f writes to config.Stderr. File-output status
+// messages (--output, .dump, .save) go to stderr to keep stdout data-only.
+func captureStderr(t *testing.T, f func()) string {
+	t.Helper()
+	backup := config.Stderr
+	defer func() { config.Stderr = backup }()
+	var buf bytes.Buffer
+	config.Stderr = &buf
+	f()
+	return buf.String()
+}
+
 // TestCommandList_tablesCommand_dependsOnMetadataUsecase verifies that .tables
 // is satisfied by a MetadataUsecase mock alone: given two table names, it lists
 // both.
@@ -628,15 +640,16 @@ func TestCommandList_dumpCommand_dependsOnMetadataAndExportUsecases(t *testing.T
 		export:   exporter,
 	})
 
-	out := captureStdout(t, func() {
+	// The dump status line is control-plane output and goes to stderr (#309).
+	out := captureStderr(t, func() {
 		if err := NewCommands().dumpCommand(context.Background(), s, []string{"users", outputPath}); err != nil {
 			t.Fatalf("dumpCommand returned error: %v", err)
 		}
 	})
 	if !strings.Contains(out, "dump `") || !strings.Contains(out, "table to") {
-		t.Fatalf("output %q does not describe dump execution", out)
+		t.Fatalf("stderr %q does not describe dump execution", out)
 	}
 	if !strings.Contains(out, normalizedPath) {
-		t.Fatalf("output %q does not include normalized csv path %q", out, normalizedPath)
+		t.Fatalf("stderr %q does not include normalized csv path %q", out, normalizedPath)
 	}
 }

--- a/shell/dump.go
+++ b/shell/dump.go
@@ -63,7 +63,9 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 	if err := s.usecases.export.DumpTable(filePath, table, exportFmt, compression); err != nil {
 		return err
 	}
-	fmt.Fprintf(config.Stdout, "dump `%s` table to %s (mode=%s)\n",
+	// .dump writes data to a file, so its status line is control-plane output
+	// and goes to stderr, keeping stdout free of non-data noise.
+	fmt.Fprintf(config.Stderr, "dump `%s` table to %s (mode=%s)\n",
 		color.CyanString(argv[0]), color.HiCyanString(filePath), exportFmt.String())
 
 	return nil

--- a/shell/save.go
+++ b/shell/save.go
@@ -159,7 +159,9 @@ func (s *Shell) writeBack(ctx context.Context, destDir string) error {
 		if err := s.usecases.export.DumpTable(tgt.dest, table, tgt.format, tgt.comp); err != nil {
 			return fmt.Errorf("failed to save table %s to %s: %w", tgt.table, tgt.dest, err)
 		}
-		fmt.Fprintf(config.Stdout, "Saved %s to %s\n", tgt.table, tgt.dest)
+		// Write-back is a file-output operation; its confirmation is control-plane
+		// output and goes to stderr so stdout stays free of non-data noise.
+		fmt.Fprintf(config.Stderr, "Saved %s to %s\n", tgt.table, tgt.dest)
 	}
 	return nil
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -649,7 +649,9 @@ func (s *Shell) outputToFile(table *model.Table) error {
 	if err := s.usecases.export.DumpTable(filePath, table, exportFmt, compression); err != nil {
 		return err
 	}
-	fmt.Fprintf(config.Stdout, "Output sql result to %s (output mode=%s)\n",
+	// Status for a file-output operation is control-plane information; the data
+	// went to the file, so keep stdout empty and report progress on stderr.
+	fmt.Fprintf(config.Stderr, "Output sql result to %s (output mode=%s)\n",
 		color.HiCyanString(filePath), exportFmt.String())
 	return nil
 }

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -52,7 +52,7 @@ Describe 'sqly CLI surface'
       export out_dir
       When run sqly --json --output "$out_dir/result.json" --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv
       The status should be success
-      The output should include 'result.json'
+      The stderr should include 'result.json'
       The path "$out_dir/result.json" should be file
       The contents of file "$out_dir/result.json" should include '"user_name":"booker12"'
       rm -rf "$out_dir"
@@ -65,6 +65,7 @@ Describe 'sqly CLI surface'
       export out_dir
       When run sqly --json --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv --output "$out_dir/result.json"
       The status should be success
+      The stderr should include 'result.json'
       The output should not include 'path does not exist'
       The path "$out_dir/result.json" should be file
       The contents of file "$out_dir/result.json" should include '"user_name":"booker12"'

--- a/spec/excel_export_spec.sh
+++ b/spec/excel_export_spec.sh
@@ -19,7 +19,7 @@ Describe 'sqly excel export (#296)'
   It 'writes a non-executable .xlsx with --output'
     When run sqly --excel --output "$OUT_DIR/out.xlsx" --sql "SELECT * FROM user LIMIT 1" testdata/user.csv
     The status should be success
-    The output should include 'output mode=excel'
+    The stderr should include 'output mode=excel'
     The path "$OUT_DIR/out.xlsx" should be file
     The path "$OUT_DIR/out.xlsx" should not be executable
   End
@@ -31,8 +31,7 @@ Describe 'sqly excel export (#296)'
     End
     When run sqly testdata/user.csv
     The status should be success
-    The output should include 'mode=excel'
-    The stderr should include 'Change output mode'
+    The stderr should include 'mode=excel'
     The path "$OUT_DIR/dump.xlsx" should be file
     The path "$OUT_DIR/dump.xlsx" should not be executable
   End

--- a/spec/export_inference_spec.sh
+++ b/spec/export_inference_spec.sh
@@ -14,7 +14,7 @@ Describe 'sqly export format inference (#260)'
       export out_dir
       When run sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv --output "$out_dir/result.parquet"
       The status should be success
-      The output should include 'output mode=parquet'
+      The stderr should include 'output mode=parquet'
       The path "$out_dir/result.parquet" should be file
       rm -rf "$out_dir"
     End
@@ -24,7 +24,7 @@ Describe 'sqly export format inference (#260)'
       export out_dir
       When run sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv --output "$out_dir/result.ndjson.gz"
       The status should be success
-      The output should include 'output mode=ndjson'
+      The stderr should include 'output mode=ndjson'
       The path "$out_dir/result.ndjson.gz" should be file
       The contents of file "$out_dir/result.ndjson.gz" should not include 'booker12'
       rm -rf "$out_dir"
@@ -34,7 +34,7 @@ Describe 'sqly export format inference (#260)'
     It 're-imports a gzip-compressed csv it wrote'
       out_dir=$(mktemp -d)
       export out_dir
-      sqly --csv --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv --output "$out_dir/result.csv.gz"
+      sqly --csv --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv --output "$out_dir/result.csv.gz" >/dev/null 2>&1
       When run sqly --csv --sql "SELECT user_name FROM result LIMIT 1" "$out_dir/result.csv.gz"
       The status should be success
       The line 1 should equal 'user_name'
@@ -49,7 +49,7 @@ Describe 'sqly export format inference (#260)'
       export out_dir
       When run sqly --sql "SELECT user_name FROM user LIMIT 1" testdata/user.csv --output "$out_dir/out.unknown"
       The status should be success
-      The output should include "$out_dir/out.unknown"
+      The stderr should include "$out_dir/out.unknown"
       The path "$out_dir/out.unknown" should be file
       The path "$out_dir/out.csv" should not be exist
       rm -rf "$out_dir"
@@ -119,7 +119,7 @@ Describe 'sqly export format inference (#260)'
       End
       When run sqly testdata/user.csv
       The status should be success
-      The output should include 'mode=tsv'
+      The stderr should include 'mode=tsv'
       The path "$out_dir/dump.tsv" should be file
       rm -rf "$out_dir"
     End
@@ -131,7 +131,7 @@ Describe 'sqly export format inference (#260)'
       export out_dir
       When run sqly --json --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" testdata/user.csv --output "$out_dir/result.json"
       The status should be success
-      The output should include 'output mode=json'
+      The stderr should include 'output mode=json'
       The path "$out_dir/result.json" should be file
       The contents of file "$out_dir/result.json" should include '"user_name":"booker12"'
       rm -rf "$out_dir"

--- a/spec/metamorphic_spec.sh
+++ b/spec/metamorphic_spec.sh
@@ -66,7 +66,7 @@ Describe 'sqly metamorphic relations'
     check_roundtrip() {
       dir=$(mktemp -d)
       out="$dir/rt.csv"
-      printf '.dump user %s\n' "$out" | sqly testdata/user.csv >/dev/null
+      printf '.dump user %s\n' "$out" | sqly testdata/user.csv >/dev/null 2>&1
       original=$(sqly --csv --sql "SELECT * FROM user ORDER BY identifier" testdata/user.csv)
       reimported=$(sqly --csv --sql "SELECT * FROM rt ORDER BY identifier" "$out")
       rm -rf "$dir"

--- a/spec/output_status_spec.sh
+++ b/spec/output_status_spec.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# File-output status routing (#309). When data is written to a file via
+# --output, .dump, or .save, the success/status line is control-plane output
+# and must go to stderr so stdout stays empty for scripts.
+
+Describe 'sqly file-output status routing (#309)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    OUT_DIR=$(mktemp -d)
+  }
+  cleanup() {
+    rm -rf "$OUT_DIR"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'keeps stdout empty for --output and reports on stderr'
+    When run sqly --sql "SELECT 1 AS x" --output "$OUT_DIR/out.csv" testdata/user.csv
+    The status should be success
+    The output should equal ''
+    The stderr should include 'Output sql result to'
+    The path "$OUT_DIR/out.csv" should be file
+  End
+
+  It 'keeps stdout free of the .dump status line'
+    Data:expand
+      #|.dump user ${OUT_DIR}/dump.csv
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+    The output should equal ''
+    The stderr should include 'dump `user` table to'
+    The path "$OUT_DIR/dump.csv" should be file
+  End
+
+  It 'keeps the .save confirmation off stdout'
+    cp testdata/user.csv "$OUT_DIR/u.csv"
+    Data:expand
+      #|UPDATE u SET first_name = 'X' WHERE identifier = 1;
+      #|.save ${OUT_DIR}/saved
+    End
+    When run sqly "$OUT_DIR/u.csv"
+    The status should be success
+    The output should include 'affected'
+    The output should not include 'Saved'
+    The stderr should include 'Saved u to'
+  End
+End

--- a/spec/parquet_export_spec.sh
+++ b/spec/parquet_export_spec.sh
@@ -49,7 +49,7 @@ Describe 'sqly parquet export'
       export out_dir
       When run sqly --parquet --output "$out_dir/q.parquet" --sql "SELECT user_name FROM user LIMIT 2" testdata/user.csv
       The status should be success
-      The output should include 'q.parquet'
+      The stderr should include 'q.parquet'
       The path "$out_dir/q.parquet" should be file
       rm -rf "$out_dir"
     End

--- a/spec/save_spec.sh
+++ b/spec/save_spec.sh
@@ -22,7 +22,8 @@ Describe 'sqly write-back (#261)'
   It 'writes to --save-dir without modifying the source'
     When run sqly --sql "UPDATE u SET first_name = 'CHANGED' WHERE identifier = 1" "$WORK/u.csv" --save-dir "$WORK/out"
     The status should be success
-    The output should include 'Saved u to'
+    The output should include 'affected'
+    The stderr should include 'Saved u to'
     The contents of file "$WORK/u.csv" should not include 'CHANGED'
     The contents of file "$WORK/out/u.csv" should include 'CHANGED'
   End
@@ -37,13 +38,14 @@ Describe 'sqly write-back (#261)'
   It 'overwrites the source in place with --save --force'
     When run sqly --sql "DELETE FROM u WHERE identifier > 1" "$WORK/u.csv" --save --force
     The status should be success
-    The output should include 'Saved u to'
+    The output should include 'affected'
+    The stderr should include 'Saved u to'
     # Re-import the rewritten file: only one row remains.
     rm -rf "$WORK/out"
   End
 
   It 're-imports a file rewritten in place (round-trip)'
-    sqly --sql "DELETE FROM u WHERE identifier > 1" "$WORK/u.csv" --save --force
+    sqly --sql "DELETE FROM u WHERE identifier > 1" "$WORK/u.csv" --save --force >/dev/null 2>&1
     When run sqly --csv --sql "SELECT COUNT(*) AS c FROM u" "$WORK/u.csv"
     The status should be success
     The line 2 should equal '1'
@@ -51,7 +53,7 @@ Describe 'sqly write-back (#261)'
 
   It 'preserves gzip compression on in-place save'
     gzip -c testdata/user.csv > "$WORK/c.csv.gz"
-    sqly --sql "UPDATE c SET first_name = 'GZ' WHERE identifier = 1" "$WORK/c.csv.gz" --save --force
+    sqly --sql "UPDATE c SET first_name = 'GZ' WHERE identifier = 1" "$WORK/c.csv.gz" --save --force >/dev/null 2>&1
     When run sqly --csv --sql "SELECT first_name FROM c WHERE identifier = 1" "$WORK/c.csv.gz"
     The status should be success
     The line 2 should equal 'GZ'
@@ -64,7 +66,8 @@ Describe 'sqly write-back (#261)'
     End
     When run sqly "$WORK/u.csv"
     The status should be success
-    The output should include 'Saved u to'
+    The output should include 'affected'
+    The stderr should include 'Saved u to'
     The contents of file "$WORK/u.csv" should include 'BATCH'
   End
 End


### PR DESCRIPTION
When output went to a file via `--output`, `.dump`, or `.save`/`--save`/`--save-dir`, sqly printed the success/status line ("Output sql result to ...", "dump `t` table to ...", "Saved t to ...") to stdout. Since the data is in the file, these lines are pure control-plane information, so they made stdout noisy and inconsistent with `--inspect`, which keeps progress on stderr.

These status messages now go to stderr. When all data is written to files, stdout stays empty, so scripts can rely on an empty stdout for success. DML result summaries ("affected is N row(s)") remain on stdout because they are the statement's result, not a file-output status.

Tests:
- Unit: the `.dump` boundary test now captures the status line from stderr via a new `captureStderr` helper.
- shellspec (`spec/output_status_spec.sh`): `--output`, `.dump`, and `.save` keep stdout empty (or data-only) and report on stderr. Existing export/save/metamorphic specs are updated to assert the status on stderr.

Closes #309
