### PR TITLE
fix(shell): treat bracket and backtick identifiers as quoted when splitting batch SQL (#314, #315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Batch Identifier Quoting: Batch statement splitting now recognizes SQLite bracket-quoted (`[ ... ]`) and backtick-quoted (`` `...` ``) identifiers, so a semicolon inside them no longer splits a statement. This matches the existing handling of single-quoted strings, double-quoted identifiers, and comments.
 * File-Output Status On Stderr: Status lines for file-output operations (`--output`, `.dump`, and `.save`/`--save`/`--save-dir`) now go to stderr instead of stdout. When all data is written to files, stdout stays empty, matching `--inspect` and letting scripts rely on an empty stdout for success.
 * Mode-Change Banner On Stderr: The `.mode` change banner now goes to stderr instead of stdout. In batch mode, switching to `.mode json` or `.mode ndjson` no longer prints a human-readable banner ahead of the machine-readable payload, so stdout stays parseable.
 * Directory Output Targets: `--output` and `.dump` now reject a destination that already exists as a directory with a clear error, instead of silently writing to a sibling file such as `dir.csv`.

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -144,6 +144,7 @@ func splitSQLStatements(s string) (stmts []string, remainder string) {
 	var (
 		start                         int
 		inSingle, inDouble            bool
+		inBacktick, inBracket         bool
 		inLineComment, inBlockComment bool
 	)
 	for i := 0; i < len(runes); i++ {
@@ -166,12 +167,27 @@ func splitSQLStatements(s string) (stmts []string, remainder string) {
 			if c == '"' {
 				inDouble = false
 			}
+		case inBacktick:
+			// SQLite backtick-quoted identifier; a doubled backtick escapes one,
+			// which this toggle handles since it re-enters on the next backtick.
+			if c == '`' {
+				inBacktick = false
+			}
+		case inBracket:
+			// SQLite bracket-quoted identifier; "]" closes it (brackets do not nest).
+			if c == ']' {
+				inBracket = false
+			}
 		default:
 			switch {
 			case c == '\'':
 				inSingle = true
 			case c == '"':
 				inDouble = true
+			case c == '`':
+				inBacktick = true
+			case c == '[':
+				inBracket = true
 			case c == '-' && i+1 < len(runes) && runes[i+1] == '-':
 				inLineComment = true
 				i++

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1894,6 +1894,24 @@ func TestShellRunBatch_MultilineStatements(t *testing.T) {
 		}
 	})
 
+	t.Run("semicolon inside a bracket-quoted identifier does not split (#314)", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "SELECT 'v' AS [a;b];\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "v") || !strings.Contains(got, "a;b") {
+			t.Fatalf("bracket-quoted identifier was split: %q", got)
+		}
+	})
+
+	t.Run("semicolon inside a backtick-quoted identifier does not split (#315)", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "SELECT 'v' AS `a;b`;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "v") || !strings.Contains(got, "a;b") {
+			t.Fatalf("backtick-quoted identifier was split: %q", got)
+		}
+	})
+
 	t.Run("statement opening with a comment still runs", func(t *testing.T) {
 		shell, cleanup := newBatchShell(t, "-- header comment\nSELECT actor FROM actor ORDER BY actor LIMIT 1;\n")
 		defer cleanup()

--- a/spec/batch_spec.sh
+++ b/spec/batch_spec.sh
@@ -95,6 +95,26 @@ Describe 'sqly batch mode (piped stdin)'
       The output should include 'booker12'
     End
 
+    It 'does not split on a semicolon inside a bracket-quoted identifier (#314)'
+      Data
+        #|SELECT 'v' AS [a;b];
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'a;b'
+      The output should include 'v'
+    End
+
+    It 'does not split on a semicolon inside a backtick-quoted identifier (#315)'
+      Data
+        #|SELECT 'v' AS `a;b`;
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'a;b'
+      The output should include 'v'
+    End
+
     It 'reports an error for incomplete SQL'
       Data
         #|SELECT * FROM (


### PR DESCRIPTION
Batch-mode statement splitting tracked single-quoted strings, double-quoted identifiers, and comments, but not SQLite's other identifier quoting forms. A semicolon inside a bracket-quoted (`[a;b]`) or backtick-quoted (`` `a;b` ``) identifier was treated as a statement terminator, so a valid single statement was split into broken fragments that failed.

`splitSQLStatements` now also tracks `[ ... ]` and `` `...` `` regions, so semicolons inside them do not split a statement. A doubled backtick (the SQLite escape for a literal backtick) is handled by the same toggle.

Tests:
- Unit: `TestShellRunBatch_MultilineStatements` gains bracket and backtick cases that run as a single statement.
- shellspec (`spec/batch_spec.sh`): `SELECT 'v' AS [a;b];` and the backtick form succeed and return the quoted column. Runs in the existing E2E CI job.

Closes #314
Closes #315


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batch statement splitting to properly handle SQLite bracket-quoted (`[ ... ]`) and backtick-quoted (`` `...` ``) identifiers, preventing semicolons inside these constructs from causing incorrect statement splits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->