### PR TITLE
fix(shell): reject --sheet for empty values and non-Excel directories (#312, #313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Sheet Flag Validation For Directories And Empty Values: `--sheet` is now rejected when a directory input contains no Excel files, and when it is given an explicit empty value (`--sheet ""`). Both previously slipped past validation and were silently ignored. This applies to the CLI flag and the `.import` command.
 * Batch Identifier Quoting: Batch statement splitting now recognizes SQLite bracket-quoted (`[ ... ]`) and backtick-quoted (`` `...` ``) identifiers, so a semicolon inside them no longer splits a statement. This matches the existing handling of single-quoted strings, double-quoted identifiers, and comments.
 * File-Output Status On Stderr: Status lines for file-output operations (`--output`, `.dump`, and `.save`/`--save`/`--save-dir`) now go to stderr instead of stdout. When all data is written to files, stdout stays empty, matching `--inspect` and letting scripts rely on an empty stdout for success.
 * Mode-Change Banner On Stderr: The `.mode` change banner now goes to stderr instead of stdout. In batch mode, switching to `.mode json` or `.mode ndjson` no longer prints a human-readable banner ahead of the machine-readable payload, so stdout stays parseable.

--- a/config/argument.go
+++ b/config/argument.go
@@ -136,6 +136,13 @@ func NewArg(args []string) (*Arg, error) {
 		return nil, err
 	}
 
+	// An explicit empty --sheet ("--sheet \"\"") is a mistake: the empty string
+	// is the "no sheet selected" sentinel, so accepting it would silently behave
+	// like the flag was never passed. Reject it so the error is visible. Ref #313.
+	if flag.Changed("sheet") && *sheetName == "" {
+		return nil, errEmptySheet
+	}
+
 	arg.Usage = usage(flag)
 	arg.Version = version
 	arg.Output = newOutput(*output, oFlag)

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -224,6 +224,13 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit empty --sheet is rejected (#313)", func(t *testing.T) {
+		_, err := NewArg([]string{"sqly", "--sheet", "", "testdata/user.csv"})
+		if err == nil {
+			t.Fatal("expected an error for an explicit empty --sheet, got nil")
+		}
+	})
+
 	t.Run("--inspect sets the inspect flag (#259)", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "--inspect", "testdata/user.csv"})
 		if err != nil {

--- a/config/errors.go
+++ b/config/errors.go
@@ -4,3 +4,7 @@ import "errors"
 
 // ErrEmptyArg is argument for NewArg() is empty
 var ErrEmptyArg = errors.New("argument is empty")
+
+// errEmptySheet is returned when --sheet is given an explicit empty value, which
+// would otherwise be indistinguishable from the flag being absent.
+var errEmptySheet = errors.New("--sheet requires a non-empty sheet name")

--- a/shell/import.go
+++ b/shell/import.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,16 +33,73 @@ func (s *Shell) validateSheetFlag() error {
 	if s.argument.SheetName == "" {
 		return nil
 	}
-	for _, path := range s.argument.FilePaths {
-		info, err := os.Stat(path)
-		if err != nil {
-			return nil //nolint:nilerr // a bad path is reported by the import step, not here
-		}
-		if info.IsDir() || s.usecases.importer.IsExcelFile(path) {
-			return nil
-		}
+	if s.sheetAppliesTo(s.argument.FilePaths) {
+		return nil
 	}
 	return errors.New("--sheet is only valid for Excel (.xlsx) inputs")
+}
+
+// sheetAppliesTo reports whether --sheet can affect any of the given input
+// paths: a path is meaningful for --sheet when it is an Excel file or a
+// directory that contains at least one Excel file. A path that cannot be stat'd
+// is treated as applicable so the import step reports the real path error
+// instead of this validation misattributing it to --sheet.
+func (s *Shell) sheetAppliesTo(paths []string) bool {
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return true
+		}
+		if info.IsDir() {
+			if s.dirContainsExcel(path) {
+				return true
+			}
+			continue
+		}
+		if s.usecases.importer.IsExcelFile(path) {
+			return true
+		}
+	}
+	return false
+}
+
+// dirContainsExcel reports whether dir contains at least one Excel file,
+// searched recursively. Walk errors are ignored: a directory that cannot be
+// traversed simply yields no Excel match, and the import step surfaces the real
+// error.
+func (s *Shell) dirContainsExcel(dir string) bool {
+	found := false
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || found {
+			return nil //nolint:nilerr // skip unreadable entries; import reports real errors
+		}
+		if !d.IsDir() && s.usecases.importer.IsExcelFile(path) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+// importPaths returns the file/directory arguments from a .import argv,
+// excluding the --sheet flag and its value in both the separated and joined
+// forms. It mirrors the flag handling in importCommand's main loop.
+func importPaths(argv []string) []string {
+	var paths []string
+	for i := 0; i < len(argv); i++ {
+		a := argv[i]
+		if a == sheetFlag {
+			if i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "--") {
+				i++ // skip the separated sheet value
+			}
+			continue
+		}
+		if strings.HasPrefix(a, sheetFlagAssign) {
+			continue
+		}
+		paths = append(paths, a)
+	}
+	return paths
 }
 
 // importCommand imports files into the in-memory database.
@@ -57,6 +115,12 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 	sheetName := s.argument.SheetName
 	if sheetName == "" {
 		sheetName = extractSheetNameFromArgs(argv)
+	}
+
+	// Reject --sheet when none of the inputs is an Excel file (or a directory
+	// containing one), so the flag is not silently ignored. Ref #312.
+	if sheetName != "" && !s.sheetAppliesTo(importPaths(argv)) {
+		return errors.New("--sheet is only valid for Excel (.xlsx) inputs")
 	}
 
 	var errorMessages []string

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2505,15 +2505,33 @@ func TestShellValidateSheetFlag(t *testing.T) {
 		}
 	})
 
-	t.Run("allows --sheet for a directory input that may contain Excel files", func(t *testing.T) {
+	t.Run("allows --sheet for a directory that contains an Excel file", func(t *testing.T) {
 		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "book.xlsx"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
 		shell, cleanup, err := newShell(t, []string{"sqly", "--sheet", "A test", dir})
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer cleanup()
 		if err := shell.validateSheetFlag(); err != nil {
-			t.Fatalf("validateSheetFlag returned error for a directory input: %v", err)
+			t.Fatalf("validateSheetFlag returned error for a directory with an Excel file: %v", err)
+		}
+	})
+
+	t.Run("rejects --sheet for a directory with no Excel files (#312)", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "u.csv"), []byte("a\n1\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sheet", "A test", dir})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		if err := shell.validateSheetFlag(); err == nil {
+			t.Fatal("validateSheetFlag returned nil for a directory without Excel files, want error")
 		}
 	})
 

--- a/spec/sheet_flag_spec.sh
+++ b/spec/sheet_flag_spec.sh
@@ -25,4 +25,19 @@ Describe 'sqly --sheet validation (#287)'
     The status should be success
     The output should include 'name'
   End
+
+  It 'rejects an explicit empty --sheet (#313)'
+    When run sqly --inspect --sheet "" testdata/user.csv
+    The status should be failure
+    The stderr should include 'sheet'
+  End
+
+  It 'rejects --sheet for a directory with no Excel files (#312)'
+    work=$(mktemp -d)
+    cp testdata/user.csv "$work/u.csv"
+    When run sqly --inspect --sheet anything "$work"
+    The status should be failure
+    The stderr should include '--sheet'
+    rm -rf "$work"
+  End
 End


### PR DESCRIPTION
Extends the `--sheet` validation (#287) to two more cases that previously slipped through and silently ignored the flag:

- A directory input that contains no Excel file. The validator now walks directory inputs and rejects `--sheet` when none of the inputs is an Excel file or a directory containing one. This applies to the CLI flag and the `.import` command.
- An explicit empty value (`--sheet ""`). The empty string is the "no sheet" sentinel, so it was indistinguishable from the flag being absent; `config.NewArg` now rejects it via `pflag`'s Changed check.

Tests:
- Unit: `TestNewArg` rejects `--sheet ""`; `TestShellValidateSheetFlag` adds a directory-with-Excel (allowed) and directory-without-Excel (rejected) case.
- shellspec (`spec/sheet_flag_spec.sh`): `--inspect --sheet ""` and `--inspect --sheet anything <dir-with-no-excel>` both fail. Runs in the existing E2E CI job.

Closes #312
Closes #313
