### PR TITLE
fix(shell): make batch mode fail-fast and skip write-back for empty input (#308, #320, #321, #322, #330, #331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Batch Fail-Fast: Batch mode (piped stdin and `--sql-file`) now stops at the first failed statement or helper command instead of continuing. Later statements no longer run, so their output cannot leak into a pipeline the process then reports as failed, and side-effecting commands such as `.save` and `.dump` placed after a failure no longer execute. The run still exits non-zero.
+* Empty Batch No Write-Back: An empty batch (for example empty piped stdin) no longer triggers `--save`/`--save-dir` write-back. With nothing executed, source files are left untouched and the run is a no-op.
 * Sheet Flag Validation For Directories And Empty Values: `--sheet` is now rejected when a directory input contains no Excel files, and when it is given an explicit empty value (`--sheet ""`). Both previously slipped past validation and were silently ignored. This applies to the CLI flag and the `.import` command.
 * Batch Identifier Quoting: Batch statement splitting now recognizes SQLite bracket-quoted (`[ ... ]`) and backtick-quoted (`` `...` ``) identifiers, so a semicolon inside them no longer splits a statement. This matches the existing handling of single-quoted strings, double-quoted identifiers, and comments.
 * File-Output Status On Stderr: Status lines for file-output operations (`--output`, `.dump`, and `.save`/`--save`/`--save-dir`) now go to stderr instead of stdout. When all data is written to files, stdout stays empty, matching `--inspect` and letting scripts rely on an empty stdout for success.

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -19,42 +19,50 @@ const maxBatchLineBytes = 10 * 1024 * 1024
 // runBatch executes SQL statements and helper commands read from stdin until
 // EOF. It is used when sqly runs without a TTY (piped stdin), where the
 // interactive prompt cannot start.
+func (s *Shell) runBatch(ctx context.Context) (ranAny bool, err error) {
+	return s.runBatchReader(ctx, s.stdin)
+}
+
+// runBatchReader executes SQL statements and helper commands read from r. It is
+// shared by batch stdin mode and --sql-file so both follow identical
+// statement-splitting and error reporting; --sql-file passes a file reader
+// instead of stdin, which frees stdin to carry a piped --stdin dataset.
 //
 // Input is parsed into statements, not raw lines, so SQL can span multiple
 // lines (e.g. a formatted CTE). A SQL statement ends at a top-level ";"; helper
 // commands (lines beginning with ".") are single-line. A trailing statement
-// without ";" at EOF still runs, so one-shot queries keep working; incomplete
-// SQL surfaces SQLite's error. Errors are reported to
-// stderr with the statement index and do not stop processing; if any statement
-// failed, runBatch returns an error so the process exits non-zero. A ".exit"
-// command stops early with a success status, mirroring the interactive shell.
-func (s *Shell) runBatch(ctx context.Context) error {
-	return s.runBatchReader(ctx, s.stdin)
-}
-
-// runBatchReader executes SQL statements and helper commands read from r using
-// the same parsing rules as runBatch. It is shared by batch stdin mode and
-// --sql-file so both follow identical statement-splitting and error reporting;
-// --sql-file passes a file reader instead of stdin, which frees stdin to carry
-// a piped --stdin dataset.
-func (s *Shell) runBatchReader(ctx context.Context, r io.Reader) error {
+// without ";" at EOF still runs.
+//
+// Execution is fail-fast: the first failed statement or helper command stops
+// the run and returns an error, so later statements never execute and their
+// output cannot leak into a pipeline that the process then reports as failed
+// (Ref #308). A ".exit" command stops early with success, mirroring the
+// interactive shell. ranAny reports whether at least one statement or command
+// was executed, so callers can skip post-run side effects (e.g. --save
+// write-back) for an empty batch (Ref #330).
+func (s *Shell) runBatchReader(ctx context.Context, r io.Reader) (ranAny bool, err error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxBatchLineBytes)
 
-	failed := false
 	stmtNo := 0
 	exited := false
+	var failErr error
 
-	run := func(stmt string) {
+	// run executes one statement/command and returns whether to stop the batch
+	// (on failure or ".exit"). The first failure records failErr for the caller.
+	run := func(stmt string) (stop bool) {
 		stmtNo++
+		ranAny = true
 		if err := s.exec(ctx, stmt); err != nil {
 			if errors.Is(err, ErrExitSqly) {
 				exited = true
-				return
+				return true
 			}
 			fmt.Fprintf(config.Stderr, "batch statement %d failed: %q: %v\n", stmtNo, stmt, err)
-			failed = true
+			failErr = errors.New("batch stopped: statement failed")
+			return true
 		}
+		return false
 	}
 
 	var pending strings.Builder
@@ -69,8 +77,7 @@ scan:
 				continue
 			}
 			if strings.HasPrefix(trimmed, ".") {
-				run(trimmed)
-				if exited {
+				if run(trimmed) {
 					break scan
 				}
 				continue
@@ -83,28 +90,24 @@ scan:
 		pending.Reset()
 		pending.WriteString(remainder)
 		for _, stmt := range stmts {
-			run(stmt)
-			if exited {
+			if run(stmt) {
 				break scan
 			}
 		}
 	}
 
-	// On ".exit", stop reading but still report any earlier failure below.
-	if !exited {
+	// On ".exit" or a failure, stop reading. Otherwise run any trailing
+	// statement that was not terminated by ";".
+	if !exited && failErr == nil {
 		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("failed to read batch input: %w", err)
+			return ranAny, fmt.Errorf("failed to read batch input: %w", err)
 		}
-		// Execute any trailing statement that was not terminated by ";".
 		if leftover := stripLeadingSQLComments(pending.String()); leftover != "" {
 			run(leftover)
 		}
 	}
 
-	if failed {
-		return errors.New("one or more batch statements failed")
-	}
-	return nil
+	return ranAny, failErr
 }
 
 // stripLeadingSQLComments removes leading line ("--") and block ("/* */")

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -188,8 +188,12 @@ func (s *Shell) Run(ctx context.Context) error {
 	// error reporting as batch stdin mode, so multiline SQL and multiple
 	// statements behave identically whether they arrive from a file or a pipe.
 	if s.argument.SQLFilePath != "" {
-		if err := s.runBatchReader(ctx, strings.NewReader(sqlScript)); err != nil {
+		ranAny, err := s.runBatchReader(ctx, strings.NewReader(sqlScript))
+		if err != nil {
 			return err
+		}
+		if !ranAny {
+			return nil
 		}
 		return s.maybeSave(ctx)
 	}
@@ -197,8 +201,14 @@ func (s *Shell) Run(ctx context.Context) error {
 	// Without a terminal (e.g. piped stdin) the interactive prompt cannot
 	// initialize, so read SQL and helper commands from stdin in batch mode.
 	if !s.isTTY() {
-		if err := s.runBatch(ctx); err != nil {
+		ranAny, err := s.runBatch(ctx)
+		if err != nil {
 			return err
+		}
+		// Skip write-back when nothing ran (e.g. empty stdin), so an empty batch
+		// does not trigger --save/--save-dir side effects. Ref #330, #331.
+		if !ranAny {
+			return nil
 		}
 		return s.maybeSave(ctx)
 	}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1142,10 +1142,10 @@ func getStdoutForRunFunc(t *testing.T, f func(ctx context.Context) error) []byte
 	return buffer.Bytes()
 }
 
-// getStdoutForErr captures stdout while running f and ignores its returned
-// error. Used when the error is expected (e.g. a fail-fast batch run) and the
-// test asserts on what did or did not reach stdout.
-func getStdoutForErr(t *testing.T, f func(ctx context.Context) error) []byte {
+// getStdoutForErr captures stdout while running f and returns both the captured
+// bytes and f's error. Used when the error is expected (e.g. a fail-fast batch
+// run) so the test can assert both the error and what reached stdout.
+func getStdoutForErr(t *testing.T, f func(ctx context.Context) error) ([]byte, error) {
 	t.Helper()
 	backupColorStdout := config.Stdout
 	defer func() {
@@ -1155,8 +1155,8 @@ func getStdoutForErr(t *testing.T, f func(ctx context.Context) error) []byte {
 	var buffer bytes.Buffer
 	config.Stdout = &buffer
 
-	_ = f(context.Background())
-	return buffer.Bytes()
+	err := f(context.Background())
+	return buffer.Bytes(), err
 }
 
 func getStdout(t *testing.T, f func()) []byte {
@@ -1865,9 +1865,12 @@ func TestShellRunBatch_FailFast(t *testing.T) {
 		defer func() { config.Stderr = backupStderr }()
 		config.Stderr = &bytes.Buffer{}
 
-		got := string(getStdoutForErr(t, shell.Run))
-		if strings.Contains(got, "later") {
-			t.Fatalf("later statement ran after a failure: %q", got)
+		out, runErr := getStdoutForErr(t, shell.Run)
+		if runErr == nil {
+			t.Fatal("fail-fast batch returned nil error, want non-nil")
+		}
+		if strings.Contains(string(out), "later") {
+			t.Fatalf("later statement ran after a failure: %q", string(out))
 		}
 	})
 
@@ -1884,9 +1887,12 @@ func TestShellRunBatch_FailFast(t *testing.T) {
 		defer func() { config.Stderr = backupStderr }()
 		config.Stderr = &bytes.Buffer{}
 
-		got := string(getStdoutForErr(t, shell.Run))
-		if strings.Contains(got, "later") {
-			t.Fatalf("later statement ran after a helper-command failure: %q", got)
+		out, runErr := getStdoutForErr(t, shell.Run)
+		if runErr == nil {
+			t.Fatal("fail-fast batch returned nil error, want non-nil")
+		}
+		if strings.Contains(string(out), "later") {
+			t.Fatalf("later statement ran after a helper-command failure: %q", string(out))
 		}
 	})
 }

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1142,6 +1142,23 @@ func getStdoutForRunFunc(t *testing.T, f func(ctx context.Context) error) []byte
 	return buffer.Bytes()
 }
 
+// getStdoutForErr captures stdout while running f and ignores its returned
+// error. Used when the error is expected (e.g. a fail-fast batch run) and the
+// test asserts on what did or did not reach stdout.
+func getStdoutForErr(t *testing.T, f func(ctx context.Context) error) []byte {
+	t.Helper()
+	backupColorStdout := config.Stdout
+	defer func() {
+		config.Stdout = backupColorStdout
+	}()
+
+	var buffer bytes.Buffer
+	config.Stdout = &buffer
+
+	_ = f(context.Background())
+	return buffer.Bytes()
+}
+
 func getStdout(t *testing.T, f func()) []byte {
 	t.Helper()
 	backupColorStdout := config.Stdout
@@ -1829,6 +1846,82 @@ func TestShellRunBatch_ReturnsErrorOnCommandFailure(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "no_such_table") {
 		t.Fatalf("stderr = %q, want it to include the failing statement content", stderr.String())
+	}
+}
+
+func TestShellRunBatch_FailFast(t *testing.T) {
+	// Regression for #308: the first failed statement stops the batch, so later
+	// statements do not run and cannot leak output into a failed pipeline.
+	t.Run("a SQL failure stops a later statement", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--csv"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("SELECT * FROM no_such_table;\nSELECT 1 AS later;\n")
+
+		backupStderr := config.Stderr
+		defer func() { config.Stderr = backupStderr }()
+		config.Stderr = &bytes.Buffer{}
+
+		got := string(getStdoutForErr(t, shell.Run))
+		if strings.Contains(got, "later") {
+			t.Fatalf("later statement ran after a failure: %q", got)
+		}
+	})
+
+	t.Run("a helper-command failure stops a later statement", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly", "--csv"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader(".schema no_such_table\nSELECT 1 AS later;\n")
+
+		backupStderr := config.Stderr
+		defer func() { config.Stderr = backupStderr }()
+		config.Stderr = &bytes.Buffer{}
+
+		got := string(getStdoutForErr(t, shell.Run))
+		if strings.Contains(got, "later") {
+			t.Fatalf("later statement ran after a helper-command failure: %q", got)
+		}
+	})
+}
+
+func TestShellRunBatch_EmptyStdinSkipsSave(t *testing.T) {
+	// Regression for #330/#331: empty batch stdin must not trigger --save
+	// write-back, which would rewrite source files even though nothing ran.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "u.csv")
+	original := "id,first_name\n1,Alice\n"
+	if err := os.WriteFile(src, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	shell, cleanup, err := newShell(t, []string{"sqly", "--save", "--force", src})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	shell.isTTY = func() bool { return false }
+	shell.stdin = strings.NewReader("")
+
+	backupStderr := config.Stderr
+	defer func() { config.Stderr = backupStderr }()
+	config.Stderr = &bytes.Buffer{}
+
+	if err := shell.Run(context.Background()); err != nil {
+		t.Fatalf("empty batch Run returned error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Clean(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Fatalf("source file was rewritten by an empty batch run: got %q, want %q", string(got), original)
 	}
 }
 

--- a/spec/batch_failfast_spec.sh
+++ b/spec/batch_failfast_spec.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Batch fail-fast semantics (#308, #320, #321, #322, #330, #331). The first
+# failed statement stops the batch, so later statements and side-effecting
+# helper commands (.save, .dump) do not run, and an empty batch performs no
+# write-back.
+
+Describe 'sqly batch fail-fast (#308)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    WORK=$(mktemp -d)
+    cp testdata/user.csv "$WORK/u.csv"
+  }
+  cleanup() {
+    rm -rf "$WORK"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'stops later statements after a SQL failure'
+    Data
+      #|SELECT * FROM no_such_table;
+      #|SELECT 1 AS later;
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The output should not include 'later'
+    The stderr should include 'no_such_table'
+  End
+
+  It 'does not run .save --force after an earlier failure (#320)'
+    Data:expand
+      #|UPDATE u SET first_name = 'BROKEN' WHERE identifier = 1;
+      #|SELECT * FROM no_such_table;
+      #|.save --force
+    End
+    When run sqly "$WORK/u.csv"
+    The status should be failure
+    The output should include 'affected'
+    The stderr should not include 'Saved'
+    The contents of file "$WORK/u.csv" should not include 'BROKEN'
+  End
+
+  It 'does not run .dump after an earlier failure (#322)'
+    Data:expand
+      #|SELECT * FROM no_such_table;
+      #|.dump u ${WORK}/out.csv
+    End
+    When run sqly "$WORK/u.csv"
+    The status should be failure
+    The stderr should include 'no_such_table'
+    The path "$WORK/out.csv" should not be exist
+  End
+
+  It 'does not write back for empty stdin with --save --force (#330)'
+    When run sqly "$WORK/u.csv" --save --force
+    The status should be success
+    The stderr should not include 'Saved'
+    The contents of file "$WORK/u.csv" should equal "$(cat testdata/user.csv)"
+  End
+End


### PR DESCRIPTION
Batch mode (piped stdin and `--sql-file`) continued executing after a statement failed. The process exited non-zero, but later statements still ran, so their output leaked to stdout and side-effecting helper commands placed after a failure (`.save`, `.dump`) still wrote files. Separately, an empty batch (empty piped stdin) still triggered `--save`/`--save-dir` write-back, rewriting source files even though nothing ran.

`runBatchReader` is now fail-fast: the first failed statement or helper command stops the run and returns an error, so later statements never execute. It also reports whether any statement ran, and `Run` skips the post-run write-back when nothing executed, so an empty batch is a no-op that leaves source files untouched. A `.exit` still stops with success.

Tests:
- Unit: `TestShellRunBatch_FailFast` (SQL and helper-command failures stop a later statement) and `TestShellRunBatch_EmptyStdinSkipsSave`.
- shellspec (`spec/batch_failfast_spec.sh`): later statements, `.save --force`, and `.dump` after a failure do not run, and empty stdin with `--save --force` leaves the source unchanged. Runs in the existing E2E CI job.

Closes #308
Closes #320
Closes #321
Closes #322
Closes #330
Closes #331


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch execution now stops immediately upon the first failed statement, preventing subsequent statements from running and avoiding unintended side effects.
  * Empty batch inputs (e.g., empty stdin) no longer trigger `--save` or `--save-dir` operations, leaving source files untouched.

* **Tests**
  * Added comprehensive test coverage for batch fail-fast and empty batch behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->