### PR TITLE
fix(shell): fail non-interactive runs on partial import and keep diagnostics on stderr (#297, #300, #302, #306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Import Failure Handling: When an explicitly requested input fails to import, non-interactive runs now exit non-zero instead of continuing on the partially imported subset. This covers query mode (`--sql`/`--sql-file`), `--inspect`, and the batch `.import` command (which also stops later commands). Import diagnostics now always go to stderr, so stdout stays reserved for query results and the `--inspect` JSON report. The interactive shell still starts after a partial import, with a warning, since the loaded tables remain usable.
 * Batch Fail-Fast: Batch mode (piped stdin and `--sql-file`) now stops at the first failed statement or helper command instead of continuing. Later statements no longer run, so their output cannot leak into a pipeline the process then reports as failed, and side-effecting commands such as `.save` and `.dump` placed after a failure no longer execute. The run still exits non-zero.
 * Empty Batch No Write-Back: An empty batch (for example empty piped stdin) no longer triggers `--save`/`--save-dir` write-back. With nothing executed, source files are left untouched and the run is a no-op.
 * Sheet Flag Validation For Directories And Empty Values: `--sheet` is now rejected when a directory input contains no Excel files, and when it is given an explicit empty value (`--sheet ""`). Both previously slipped past validation and were silently ignored. This applies to the CLI flag and the `.import` command.

--- a/shell/import.go
+++ b/shell/import.go
@@ -24,6 +24,11 @@ const (
 	sheetFlagAssign = sheetFlag + "="
 )
 
+// errPartialImport is returned when some explicitly requested inputs imported
+// successfully and at least one failed. Callers use errors.Is to decide whether
+// to continue (interactive shell) or fail the run (non-interactive modes).
+var errPartialImport = errors.New("one or more inputs failed to import")
+
 // validateSheetFlag rejects the CLI --sheet option when no input can be an
 // Excel file. --sheet selects a single Excel sheet and is silently ignored for
 // other formats, so a typo (or pairing it with --stdin) would otherwise pass
@@ -192,6 +197,11 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 		if successCount == 0 {
 			return errors.New("all import attempts failed")
 		}
+		// An explicitly requested input failed even though others succeeded.
+		// Return a partial-failure error so non-interactive runs exit non-zero
+		// (Ref #297, #300, #302); the interactive shell tolerates it and starts
+		// with the tables that did load.
+		return errPartialImport
 	}
 
 	return nil
@@ -316,13 +326,12 @@ func (s *Shell) recordTableSources(tableNames []string, source string) {
 	}
 }
 
-// importStatusWriter selects where import progress messages go. Under --inspect,
-// stdout must carry only the JSON report, so progress is sent to stderr instead.
+// importStatusWriter returns where import progress and error messages go.
+// Import diagnostics are control-plane output, so they always go to stderr.
+// This keeps stdout reserved for query results and the --inspect JSON report,
+// so machine-readable output is never mixed with import banners. Ref #306.
 func (s *Shell) importStatusWriter() io.Writer {
-	if s.argument.InspectFlag {
-		return config.Stderr
-	}
-	return config.Stdout
+	return config.Stderr
 }
 
 // filterExcelSheets keeps only the requested sheet from a specific Excel file,

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -120,7 +121,8 @@ func TestShell_importDirectory_dependsOnImportUsecase(t *testing.T) {
 		imported bool
 		err      error
 	)
-	out := captureStdout(t, func() {
+	// Import progress goes to stderr (#306), so capture stderr here.
+	out := captureStderr(t, func() {
 		imported, err = s.importDirectory(context.Background(), dir, "fixtures", "")
 	})
 	if err != nil {
@@ -559,10 +561,12 @@ func TestImportCommand_PartialSuccess(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	// One valid file + one missing file → partial success (no error returned)
+	// One valid file + one missing file → partial failure. The valid table is
+	// still loaded, but importCommand returns errPartialImport so non-interactive
+	// runs exit non-zero (#297). The loaded table remains queryable.
 	err = s.commands.importCommand(ctx, s, []string{csvPath, "missing.csv"})
-	if err != nil {
-		t.Errorf("expected nil error for partial success, got: %v", err)
+	if !errors.Is(err, errPartialImport) {
+		t.Errorf("expected errPartialImport for partial failure, got: %v", err)
 	}
 }
 

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -163,7 +163,15 @@ func (s *Shell) Run(ctx context.Context) error {
 	}
 
 	if err := s.init(ctx); err != nil {
-		return err
+		// A partial import (some inputs loaded, some failed) keeps the loaded
+		// tables usable, so the interactive shell still starts after a warning.
+		// Non-interactive modes (--sql, --sql-file, --inspect, batch) treat it as
+		// a hard failure so automation sees a non-zero exit. Ref #297, #300, #302.
+		if errors.Is(err, errPartialImport) && s.startsInteractiveShell() {
+			fmt.Fprintf(config.Stderr, "%v\n", err)
+		} else {
+			return err
+		}
 	}
 
 	// --inspect is a non-interactive discovery path: after import it prints a
@@ -283,6 +291,13 @@ func (s *Shell) disableHistory(err error) {
 	}
 	s.historyEnabled = false
 	fmt.Fprintf(config.Stderr, "warning: command history disabled (%v). Set SQLY_HISTORY_DB_PATH to a writable path to enable it.\n", err)
+}
+
+// startsInteractiveShell reports whether this run will open the interactive
+// prompt: a terminal with no non-interactive action requested (--inspect,
+// --sql, --sql-file). Batch mode (non-TTY) and those flags are non-interactive.
+func (s *Shell) startsInteractiveShell() bool {
+	return s.isTTY() && !s.argument.InspectFlag && s.argument.Query == "" && s.argument.SQLFilePath == ""
 }
 
 // init store CSV data to in-memory DB and create table for sqly history.

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -26,8 +26,7 @@ Describe 'sqly CLI surface'
     It 'fails on a non-existent file'
       When run sqly --sql "SELECT 1" testdata/does_not_exist.csv
       The status should be failure
-      The output should include 'does not exist'
-      The stderr should be present
+      The stderr should include 'does not exist'
     End
 
     It 'fails on invalid SQL with --sql'

--- a/spec/import_failure_spec.sh
+++ b/spec/import_failure_spec.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Import-failure handling (#297, #300, #302, #306). When an explicitly requested
+# input fails to import, non-interactive runs exit non-zero and keep import
+# diagnostics on stderr so stdout stays machine-readable.
+
+Describe 'sqly import failure handling'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'fails query mode on a partial import and keeps stdout clean (#297, #306)'
+    When run sqly --json --sql "SELECT user_name FROM user LIMIT 1" testdata/user.csv /no/such/file.csv
+    The status should be failure
+    The output should equal ''
+    The stderr should include 'failed to import'
+  End
+
+  It 'fails --inspect on a partial import (#300)'
+    When run sqly --inspect testdata/user.csv /no/such/file.csv
+    The status should be failure
+    The output should equal ''
+    The stderr should include 'failed to import'
+  End
+
+  It 'fails batch .import on a partial import and stops later commands (#302)'
+    Data
+      #|.import testdata/user.csv /no/such/file.csv
+      #|.tables
+    End
+    When run sqly
+    The status should be failure
+    The output should not include 'TABLE NAME'
+    The stderr should include 'failed to import'
+  End
+
+  It 'keeps stdout clean when a stdin dataset fails to import (#306)'
+    Data
+      #|
+    End
+    When run sqly --stdin csv --json --sql "SELECT COUNT(*) FROM stdin"
+    The status should be failure
+    The output should equal ''
+    The stderr should include 'Import failed'
+  End
+End


### PR DESCRIPTION
In non-interactive runs, sqly continued on the successfully imported subset when one of the requested inputs failed to import, exiting 0 and (in query mode) printing the import error summary to stdout ahead of results. Automation could not distinguish a complete run from a partial one, and machine-readable stdout was polluted.

Changes:
- `importCommand` returns a new `errPartialImport` sentinel when some inputs import and at least one fails (a total failure still returns "all import attempts failed").
- Import progress and error diagnostics always go to stderr now, so stdout carries only query results or the `--inspect` JSON report.
- `Run` fails the run on a partial import for query mode, `--sql-file`, `--inspect`, and batch `.import` (where fail-fast then stops later commands). The interactive shell still starts after a partial import, with a warning, since the loaded tables remain usable.

Tests:
- Unit: `TestImportCommand_PartialSuccess` now expects `errPartialImport`; the import-directory boundary test captures the progress line from stderr.
- shellspec (`spec/import_failure_spec.sh`): query mode, `--inspect`, batch `.import`, and a failing `--stdin` dataset all exit non-zero with clean stdout. Runs in the existing E2E CI job.

Closes #297
Closes #300
Closes #302
Closes #306
