### PR TITLE
test(shell): lock comment-aware batch statement splitting (#299)

### DIFF
--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2011,6 +2011,33 @@ func TestShellRunBatch_MultilineStatements(t *testing.T) {
 		}
 	})
 
+	t.Run("semicolon inside a line comment does not split (#299)", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "-- comment ;\nSELECT 'v' AS x;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "v") {
+			t.Fatalf("line comment with a semicolon split the statement: %q", got)
+		}
+	})
+
+	t.Run("semicolon inside a block comment does not split (#299)", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "/* comment ; */\nSELECT 'v' AS x;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "v") {
+			t.Fatalf("block comment with a semicolon split the statement: %q", got)
+		}
+	})
+
+	t.Run("semicolon inside a trailing line comment does not split (#299)", func(t *testing.T) {
+		shell, cleanup := newBatchShell(t, "SELECT 'first' AS x; -- trailing ; comment\nSELECT 'second' AS y;\n")
+		defer cleanup()
+		got := string(getStdoutForRunFunc(t, shell.Run))
+		if !strings.Contains(got, "first") || !strings.Contains(got, "second") {
+			t.Fatalf("trailing comment with a semicolon split a statement: %q", got)
+		}
+	})
+
 	t.Run("statement opening with a comment still runs", func(t *testing.T) {
 		shell, cleanup := newBatchShell(t, "-- header comment\nSELECT actor FROM actor ORDER BY actor LIMIT 1;\n")
 		defer cleanup()

--- a/spec/batch_spec.sh
+++ b/spec/batch_spec.sh
@@ -95,6 +95,37 @@ Describe 'sqly batch mode (piped stdin)'
       The output should include 'booker12'
     End
 
+    It 'ignores a semicolon inside a leading line comment (#299)'
+      Data
+        #|-- comment ;
+        #|SELECT 'v' AS x;
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'v'
+    End
+
+    It 'ignores a semicolon inside a block comment (#299)'
+      Data
+        #|/* comment ; */
+        #|SELECT 'v' AS x;
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'v'
+    End
+
+    It 'ignores a semicolon inside a trailing line comment (#299)'
+      Data
+        #|SELECT 'first' AS x; -- trailing ; comment
+        #|SELECT 'second' AS y;
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'first'
+      The output should include 'second'
+    End
+
     It 'does not split on a semicolon inside a bracket-quoted identifier (#314)'
       Data
         #|SELECT 'v' AS [a;b];


### PR DESCRIPTION
The statement splitter is already comment-aware on the current main branch: it tracks line (`--`) and block (`/* */`) comments and strips leading comments before classifying a statement (added with the multiline-batch and `--sql-file` work). The published v0.17.0 binary predates those changes.

This PR adds regression coverage that locks the contract from #299, so the comment-aware behavior cannot silently regress: a semicolon inside a leading line comment, inside a block comment, and inside a trailing line comment must not split a statement.

Tests:
- Unit: three cases in `TestShellRunBatch_MultilineStatements`.
- shellspec (`spec/batch_spec.sh`): the same three cases run the binary and confirm success. Runs in the existing E2E CI job.

Closes #299
