### PR TITLE
fix(shell): reject unexpected extra arguments in helper commands (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Helper Commands Reject Extra Arguments: `.schema`, `.describe`, `.header`, `.mode`, `.tables`, and `.help` now reject unexpected trailing arguments with a clear error instead of silently ignoring them, so typos no longer pass unnoticed.
 * Output Requires SQL: `--output` is now rejected with a clear error when no `--sql` query is supplied (including batch stdin, `--sql-file`, and interactive runs), instead of being silently ignored while the command still exits successfully. `--output` is only honored by the single-result `--sql` path.
 * Empty Command Arguments Rejected: `.save ""`, `.dump TABLE ""`, and `.import ""` now fail with a clear error instead of being reinterpreted. `.save ""` no longer behaves like an in-place save (which bypassed `--force`), `.dump TABLE ""` no longer writes a file named `.csv`, and `.import ""` no longer imports the current working directory.
 * Stdin Dataset Source And Name Safety: `--inspect` now reports a stable `stdin` source for a piped `--stdin` dataset instead of leaking the ephemeral staging temp path. `--save`/`--save-dir` reject a stdin-backed table up front instead of failing late while trying to write to a deleted temp file. `--stdin-name` is validated and rejects empty or path-like values, so it can no longer stage files outside the temp directory.

--- a/shell/describe.go
+++ b/shell/describe.go
@@ -17,6 +17,9 @@ func (c CommandList) describeCommand(ctx context.Context, s *Shell, argv []strin
 		fmt.Fprintln(config.Stdout, "  .describe TABLE_NAME")
 		return nil
 	}
+	if len(argv) > 1 {
+		return fmt.Errorf(".describe accepts a single table name, got %d arguments", len(argv))
+	}
 	tableName := argv[0]
 
 	cols, err := s.tableColumns(ctx, tableName)

--- a/shell/header.go
+++ b/shell/header.go
@@ -18,6 +18,9 @@ func (c CommandList) headerCommand(ctx context.Context, s *Shell, argv []string)
 		fmt.Fprintln(config.Stdout, "  .header TABLE_NAME")
 		return nil
 	}
+	if len(argv) > 1 {
+		return fmt.Errorf(".header accepts a single table name, got %d arguments", len(argv))
+	}
 
 	table, err := s.usecases.metadata.Header(ctx, argv[0])
 	if err != nil {

--- a/shell/help.go
+++ b/shell/help.go
@@ -9,7 +9,10 @@ import (
 )
 
 // helpCommand print all sqly command and their description.
-func (c CommandList) helpCommand(_ context.Context, _ *Shell, _ []string) error {
+func (c CommandList) helpCommand(_ context.Context, _ *Shell, argv []string) error {
+	if len(argv) > 0 {
+		return fmt.Errorf(".help takes no arguments, got %d", len(argv))
+	}
 	for _, cmdName := range c.sortCommandNameKey() {
 		fmt.Fprintf(config.Stdout, "%20s: %s\n",
 			color.CyanString(cmdName), c[cmdName].description)

--- a/shell/mode.go
+++ b/shell/mode.go
@@ -24,5 +24,8 @@ func (c CommandList) modeCommand(_ context.Context, s *Shell, argv []string) err
 		fmt.Fprintln(config.Stdout, "  parquet ※ active only when executing .dump, otherwise same as csv mode")
 		return nil
 	}
+	if len(argv) > 1 {
+		return fmt.Errorf(".mode accepts a single mode name, got %d arguments", len(argv))
+	}
 	return s.state.mode.changeOutputModeIfNeeded(argv[0])
 }

--- a/shell/schema.go
+++ b/shell/schema.go
@@ -22,6 +22,9 @@ func (c CommandList) schemaCommand(ctx context.Context, s *Shell, argv []string)
 		fmt.Fprintln(config.Stdout, "  .schema TABLE_NAME")
 		return nil
 	}
+	if len(argv) > 1 {
+		return fmt.Errorf(".schema accepts a single table name, got %d arguments", len(argv))
+	}
 	tableName := argv[0]
 
 	createSQL, err := s.tableCreateStatement(ctx, tableName)

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2630,6 +2630,40 @@ func TestShellRun_OutputToDirectoryIsRejected(t *testing.T) {
 	}
 }
 
+func TestHelperCommandsRejectExtraArgs(t *testing.T) {
+	// Regression for #327: helper commands must reject unexpected extra
+	// arguments instead of silently ignoring them.
+	cases := []struct {
+		name string
+		run  func(*Shell) error
+	}{
+		{".schema", func(s *Shell) error {
+			return s.commands.schemaCommand(context.Background(), s, []string{"user", "extra"})
+		}},
+		{".describe", func(s *Shell) error {
+			return s.commands.describeCommand(context.Background(), s, []string{"user", "extra"})
+		}},
+		{".header", func(s *Shell) error {
+			return s.commands.headerCommand(context.Background(), s, []string{"user", "extra"})
+		}},
+		{".mode", func(s *Shell) error { return s.commands.modeCommand(context.Background(), s, []string{"csv", "extra"}) }},
+		{".tables", func(s *Shell) error { return s.commands.tablesCommand(context.Background(), s, []string{"extra"}) }},
+		{".help", func(s *Shell) error { return s.commands.helpCommand(context.Background(), s, []string{"extra"}) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+" rejects an extra argument", func(t *testing.T) {
+			shell, cleanup, err := newShell(t, []string{"sqly"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+			if err := tc.run(shell); err == nil {
+				t.Fatalf("%s ignored an extra argument, want error", tc.name)
+			}
+		})
+	}
+}
+
 func TestShellRun_OutputRequiresSQL(t *testing.T) {
 	// Regression for #318/#319: --output is honored only with --sql, so it must
 	// be rejected (not silently ignored) on the batch and no-query paths.

--- a/shell/tables.go
+++ b/shell/tables.go
@@ -13,7 +13,10 @@ import (
 )
 
 // tablesCommand print all tables name in DB.
-func (c CommandList) tablesCommand(ctx context.Context, s *Shell, _ []string) error {
+func (c CommandList) tablesCommand(ctx context.Context, s *Shell, argv []string) error {
+	if len(argv) > 0 {
+		return fmt.Errorf(".tables takes no arguments, got %d", len(argv))
+	}
 	tables, err := s.usecases.metadata.TablesName(ctx)
 	if err != nil {
 		return err

--- a/spec/extra_args_spec.sh
+++ b/spec/extra_args_spec.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Helper commands reject unexpected extra arguments (#327). Trailing arguments
+# must cause a clear error, not be silently ignored.
+
+Describe 'sqly helper commands reject extra args (#327)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'rejects .schema with an extra argument'
+    Data
+      #|.schema user extra
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The stderr should include '.schema'
+  End
+
+  It 'rejects .describe with an extra argument'
+    Data
+      #|.describe user extra
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The stderr should include '.describe'
+  End
+
+  It 'rejects .tables with an extra argument'
+    Data
+      #|.tables extra
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The stderr should include '.tables'
+  End
+
+  It 'rejects .mode with an extra argument'
+    Data
+      #|.mode csv extra
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The stderr should include '.mode'
+  End
+End


### PR DESCRIPTION
Several helper commands ignored trailing arguments instead of rejecting them, so typos passed silently and a command could do something other than what was typed (for example `.schema user extra` ran `.schema user`).

`.schema`, `.describe`, and `.header` now reject more than one argument; `.mode` rejects more than one; and `.tables` and `.help` reject any argument.

Tests:
- Unit: `TestHelperCommandsRejectExtraArgs` covers all six commands.
- shellspec (`spec/extra_args_spec.sh`): `.schema`, `.describe`, `.tables`, and `.mode` with an extra argument fail. Runs in the existing E2E CI job.

Closes #327
