### PR TITLE
fix(shell): stop rejecting deep paths and literal URL-encoded filenames (#316, #317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Input Path Validation False Positives: Input path validation no longer rejects legitimate paths. The arbitrary 10-level directory-depth limit is removed, so deeply nested workspace paths import (#316), and the URL-encoded traversal patterns (`..%2f`, `..%5c`) are no longer matched, so a real filename that merely contains those bytes is accepted (#317). sqly runs locally with the user's own permissions, so these web-style traversal checks only produced false rejections.
 * Helper Commands Reject Extra Arguments: `.schema`, `.describe`, `.header`, `.mode`, `.tables`, and `.help` now reject unexpected trailing arguments with a clear error instead of silently ignoring them, so typos no longer pass unnoticed.
 * Output Requires SQL: `--output` is now rejected with a clear error when no `--sql` query is supplied (including batch stdin, `--sql-file`, and interactive runs), instead of being silently ignored while the command still exits successfully. `--output` is only honored by the single-result `--sql` path.
 * Empty Command Arguments Rejected: `.save ""`, `.dump TABLE ""`, and `.import ""` now fail with a clear error instead of being reinterpreted. `.save ""` no longer behaves like an in-place save (which bypassed `--force`), `.dump TABLE ""` no longer writes a file named `.csv`, and `.import ""` no longer imports the current working directory.

--- a/shell/import.go
+++ b/shell/import.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	// maxDirectoryDepth is the maximum directory depth to prevent deep traversal.
-	maxDirectoryDepth = 10
 	// sheetFlag is the .import flag selecting a single Excel sheet. It accepts
 	// both the separated form "--sheet NAME" and the joined form "--sheet=NAME".
 	sheetFlag = "--sheet"
@@ -434,20 +432,19 @@ func validatePath(path string) (string, error) {
 	// Clean the path to resolve any ".." or "." components
 	cleanPath := filepath.Clean(path)
 
-	// Check directory depth to prevent deep traversal
-	pathParts := strings.Split(cleanPath, string(filepath.Separator))
-	if len(pathParts) > maxDirectoryDepth {
-		return "", fmt.Errorf("path exceeds maximum directory depth of %d: %s", maxDirectoryDepth, path)
-	}
+	// No directory-depth limit: sqly is a local CLI run with the user's own
+	// permissions, so legitimate deeply nested workspace paths must import. Ref
+	// #316.
 
-	// Check for dangerous patterns that could indicate path traversal attacks
-	// These are the most common patterns used in path traversal attacks
+	// Check for dangerous patterns that could indicate path traversal attacks.
+	// URL-encoded sequences (..%2f, ..%5c) are intentionally NOT matched: the
+	// filesystem never URL-decodes a path, so those bytes only ever appear in a
+	// legitimate literal filename, and matching them rejected real files. Ref
+	// #317.
 	dangerousPatterns := []string{
 		"../../../",    // Multiple levels up
 		"..\\..\\..\\", // Windows path traversal
 		"....//",       // Double encoding attempts
-		"..%2f",        // URL encoded path traversal
-		"..%5c",        // URL encoded backslash
 	}
 
 	for _, pattern := range dangerousPatterns {

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -631,7 +631,11 @@ func TestValidatePath_Import(t *testing.T) {
 		{"normal path", "testdata/sample.csv", false, false},
 		{"relative path", "./foo/bar.csv", false, false},
 		{"path traversal", "../../../etc/passwd", true, false},
-		{"url encoded traversal", "..%2f..%2fetc/passwd", true, false},
+		// A literal filename containing "..%2f" is not traversal: the filesystem
+		// never URL-decodes it, so it must be accepted. Ref #317.
+		{"literal ..%2f filename", "data/..%2fuser.csv", false, false},
+		// Deep paths must import regardless of nesting depth. Ref #316.
+		{"deep path", "a/b/c/d/e/f/g/h/i/j/k/user.csv", false, false},
 		{"system dir /etc", "/etc/hosts", true, true},
 		{"system dir /proc", "/proc/cpuinfo", true, true},
 	}

--- a/spec/path_validation_spec.sh
+++ b/spec/path_validation_spec.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Input path validation false positives (#316, #317). sqly runs locally with the
+# user's own permissions, so legitimate readable paths must import regardless of
+# nesting depth or filenames that merely contain traversal-looking byte
+# sequences.
+
+Describe 'sqly input path validation (#316, #317)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    WORK=$(mktemp -d)
+  }
+  cleanup() {
+    rm -rf "$WORK"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'imports a deeply nested path (#316)'
+    deep="$WORK/a/b/c/d/e/f/g/h/i/j/k"
+    mkdir -p "$deep"
+    cp testdata/user.csv "$deep/user.csv"
+    When run sqly --csv --sql "SELECT COUNT(*) AS c FROM user" "$deep/user.csv"
+    The status should be success
+    The line 2 should equal '3'
+  End
+
+  It 'imports a file whose name literally contains ..%2f (#317)'
+    cp testdata/user.csv "$WORK/..%2fuser.csv"
+    When run sqly --inspect "$WORK/..%2fuser.csv"
+    The status should be success
+    The output should include 'user_name'
+    The stderr should not include 'dangerous path pattern'
+  End
+End


### PR DESCRIPTION
sqly runs as a local CLI with the user's own filesystem permissions, but `validatePath` applied web-server-style path-traversal defenses that produced false rejections of legitimate, readable files:

- #316: an arbitrary 10-level directory-depth limit rejected ordinary deeply nested workspace/data paths.
- #317: matching the URL-encoded sequences `..%2f`/`..%5c` rejected real filenames that merely contain those bytes (the filesystem never URL-decodes a path).

The depth limit is removed and the URL-encoded patterns are dropped. Literal `../../../` traversal and the system-directory guard are kept. Real errors (missing or unreadable files) are still reported by the import step.

Tests:
- Unit: `TestValidatePath_Import` now accepts a deep path and a literal `..%2f` filename, and still rejects `../../../etc/passwd` and system dirs.
- shellspec (`spec/path_validation_spec.sh`): a deeply nested file and a `..%2fuser.csv` file both import. Runs in the existing E2E CI job.

Closes #316
Closes #317
