### PR TITLE
fix(shell): fail on sanitized table-name collisions instead of silent overwrite (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Table-Name Collision Detection: When two inputs sanitize to the same table name (for example `a-b.csv` and `a_b.csv`, both becoming `a_b`), sqly now fails with a clear collision error instead of letting the later import silently overwrite the earlier one while keeping the first file's source metadata.
 * Input Path Validation False Positives: Input path validation no longer rejects legitimate paths. The arbitrary 10-level directory-depth limit is removed, so deeply nested workspace paths import (#316), and the URL-encoded traversal patterns (`..%2f`, `..%5c`) are no longer matched, so a real filename that merely contains those bytes is accepted (#317). sqly runs locally with the user's own permissions, so these web-style traversal checks only produced false rejections.
 * Helper Commands Reject Extra Arguments: `.schema`, `.describe`, `.header`, `.mode`, `.tables`, and `.help` now reject unexpected trailing arguments with a clear error instead of silently ignoring them, so typos no longer pass unnoticed.
 * Output Requires SQL: `--output` is now rejected with a clear error when no `--sql` query is supplied (including batch stdin, `--sql-file`, and interactive runs), instead of being silently ignored while the command still exits successfully. `--output` is only honored by the single-result `--sql` path.

--- a/shell/import.go
+++ b/shell/import.go
@@ -314,13 +314,37 @@ func (s *Shell) importFile(ctx context.Context, cleanPath, displayPath, sheetNam
 	// "a-b.csv" and "a_b.csv" both sanitize to "a_b"). filesql overwrote the
 	// earlier table in memory, which would leave the first file's source mapped
 	// to the second file's rows. Fail instead of silently overwriting. Ref #286.
+	//
+	// A re-import of the same source path is harmless (last-wins), so only reject
+	// when this file's path is not already a recorded source: that means a
+	// different input produced the same sanitized name.
 	newNames := diffTableNames(after, existingTables)
 	if len(newNames) == 0 {
+		if s.isRecordedSource(displayPath) {
+			return nil
+		}
 		return fmt.Errorf("table-name collision: %s sanitizes to a table name already imported from another input; rename the file to disambiguate", displayPath)
 	}
 	s.recordTableSources(newNames, displayPath)
 
 	return nil
+}
+
+// isRecordedSource reports whether path (resolved to an absolute path, matching
+// recordTableSources) is already the source of an imported table. It lets a
+// re-import of the same file be treated as a harmless last-wins overwrite rather
+// than a table-name collision.
+func (s *Shell) isRecordedSource(path string) bool {
+	abs := path
+	if a, err := filepath.Abs(path); err == nil {
+		abs = a
+	}
+	for _, src := range s.tableSources {
+		if src == abs {
+			return true
+		}
+	}
+	return false
 }
 
 // recordTableSources remembers which source path produced each table name, so

--- a/shell/import.go
+++ b/shell/import.go
@@ -308,7 +308,17 @@ func (s *Shell) importFile(ctx context.Context, cleanPath, displayPath, sheetNam
 	if err != nil {
 		return fmt.Errorf("failed to get table names after importing %s: %w", displayPath, err)
 	}
-	s.recordTableSources(diffTableNames(after, existingTables), displayPath)
+
+	// A successful import that produced no new table means this file's table
+	// name collided with one already imported in this session (for example
+	// "a-b.csv" and "a_b.csv" both sanitize to "a_b"). filesql overwrote the
+	// earlier table in memory, which would leave the first file's source mapped
+	// to the second file's rows. Fail instead of silently overwriting. Ref #286.
+	newNames := diffTableNames(after, existingTables)
+	if len(newNames) == 0 {
+		return fmt.Errorf("table-name collision: %s sanitizes to a table name already imported from another input; rename the file to disambiguate", displayPath)
+	}
+	s.recordTableSources(newNames, displayPath)
 
 	return nil
 }

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -572,6 +572,28 @@ func TestImportCommand_TableNameCollision(t *testing.T) {
 	}
 }
 
+func TestImportCommand_ReimportSameFileIsNotACollision(t *testing.T) {
+	// Re-importing the same source path is a harmless last-wins overwrite, not a
+	// collision; it must not be rejected by the #286 collision check.
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	path := filepath.Join(t.TempDir(), "data.csv")
+	if err := os.WriteFile(path, []byte("id,name\n1,A\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.commands.importCommand(context.Background(), s, []string{path}); err != nil {
+		t.Fatalf("first import failed: %v", err)
+	}
+	if err := s.commands.importCommand(context.Background(), s, []string{path}); err != nil {
+		t.Fatalf("re-import of the same file was rejected: %v", err)
+	}
+}
+
 func TestImportCommand_PartialSuccess(t *testing.T) {
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -547,6 +547,31 @@ func TestImportDirectory_WithCSVFiles(t *testing.T) {
 	}
 }
 
+func TestImportCommand_TableNameCollision(t *testing.T) {
+	// Regression for #286: two inputs that sanitize to the same table name must
+	// fail instead of one silently overwriting the other.
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	dir := t.TempDir()
+	first := filepath.Join(dir, "a-b.csv")
+	second := filepath.Join(dir, "a_b.csv")
+	if err := os.WriteFile(first, []byte("id,name\n1,A\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("id,name\n2,B\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.commands.importCommand(context.Background(), s, []string{first, second})
+	if err == nil {
+		t.Fatal("importing two inputs with colliding sanitized names returned nil, want error")
+	}
+}
+
 func TestImportCommand_PartialSuccess(t *testing.T) {
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {

--- a/spec/collision_spec.sh
+++ b/spec/collision_spec.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Sanitized table-name collisions (#286). Two inputs that sanitize to the same
+# table name must fail instead of one silently overwriting the other.
+
+Describe 'sqly table-name collision (#286)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    WORK=$(mktemp -d)
+    printf 'id,name\n1,A\n' > "$WORK/a-b.csv"
+    printf 'id,name\n2,B\n' > "$WORK/a_b.csv"
+  }
+  cleanup() {
+    rm -rf "$WORK"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'fails when two inputs sanitize to the same table name'
+    When run sqly --inspect "$WORK/a-b.csv" "$WORK/a_b.csv"
+    The status should be failure
+    The stderr should include 'collision'
+  End
+End


### PR DESCRIPTION
When two inputs sanitized to the same table name (for example `a-b.csv` and `a_b.csv`, both becoming `a_b`), the later import silently overwrote the earlier table in memory. The table kept the first file's `source` in `--inspect` but exposed the second file's rows, and a direct query returned only the later file's data.

`importFile` already snapshots the table names before and after a load. It now treats a successful import that produced no new table as a collision (the file overwrote an existing table) and returns a clear error instead, so the run fails rather than exposing inconsistent state.

Tests:
- Unit: `TestImportCommand_TableNameCollision` imports `a-b.csv` and `a_b.csv` and expects an error.
- shellspec (`spec/collision_spec.sh`): `--inspect` over the two colliding files fails with a collision error. Runs in the existing E2E CI job.

Closes #286


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Table-name collision detection: sqly now fails with a clear error when multiple input files sanitize to the same destination table name, preventing silent data overwrites.

## Tests
* Added regression and shellspec tests to verify table-name collision detection behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->