### PR TITLE
fix(config): require --stdin-name to be a valid table identifier (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Stdin Name Must Be Queryable: `--stdin-name` now requires a valid table identifier (letters, digits, and underscores, not starting with a digit) and rejects values such as `my data` or `2023-data` up front. Previously such names were silently sanitized (`my data` became `my_data`), leaving the advertised name unusable in SQL.
 * Table-Name Collision Detection: When two inputs sanitize to the same table name (for example `a-b.csv` and `a_b.csv`, both becoming `a_b`), sqly now fails with a clear collision error instead of letting the later import silently overwrite the earlier one while keeping the first file's source metadata.
 * Input Path Validation False Positives: Input path validation no longer rejects legitimate paths. The arbitrary 10-level directory-depth limit is removed, so deeply nested workspace paths import (#316), and the URL-encoded traversal patterns (`..%2f`, `..%5c`) are no longer matched, so a real filename that merely contains those bytes is accepted (#317). sqly runs locally with the user's own permissions, so these web-style traversal checks only produced false rejections.
 * Helper Commands Reject Extra Arguments: `.schema`, `.describe`, `.header`, `.mode`, `.tables`, and `.help` now reject unexpected trailing arguments with a clear error instead of silently ignoring them, so typos no longer pass unnoticed.

--- a/config/argument.go
+++ b/config/argument.go
@@ -182,7 +182,32 @@ func validateStdinName(name string) error {
 	if strings.ContainsAny(name, `/\`) {
 		return errInvalidStdinName
 	}
+	// Require a bare-identifier name so the advertised --stdin-name is the exact
+	// queryable table name. Otherwise filesql sanitizes spaces and dashes (e.g.
+	// "my data" -> "my_data"), leaving the name the user gave unusable. Ref #289.
+	if !isValidTableIdentifier(name) {
+		return errInvalidStdinName
+	}
 	return nil
+}
+
+// isValidTableIdentifier reports whether name is a bare SQL identifier: ASCII
+// letters, digits, and underscores, not starting with a digit. Such a name is
+// imported and queryable verbatim, with no sanitization.
+func isValidTableIdentifier(name string) bool {
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return name != ""
 }
 
 // newOutput retur *Output

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -232,6 +232,16 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("non-identifier --stdin-name values are rejected (#289)", func(t *testing.T) {
+		// These would be sanitized by filesql, leaving the advertised name
+		// unqueryable, so they are rejected up front.
+		for _, name := range []string{"my data", "2023-data", "a-b", "weird!"} {
+			if _, err := NewArg([]string{"sqly", "--stdin", "csv", "--stdin-name", name}); err == nil {
+				t.Errorf("NewArg accepted non-identifier --stdin-name %q, want error", name)
+			}
+		}
+	})
+
 	t.Run("a normal --stdin-name is accepted (#305)", func(t *testing.T) {
 		if _, err := NewArg([]string{"sqly", "--stdin", "csv", "--stdin-name", "people"}); err != nil {
 			t.Errorf("NewArg rejected a valid --stdin-name: %v", err)

--- a/config/errors.go
+++ b/config/errors.go
@@ -9,7 +9,8 @@ var ErrEmptyArg = errors.New("argument is empty")
 // would otherwise be indistinguishable from the flag being absent.
 var errEmptySheet = errors.New("--sheet requires a non-empty sheet name")
 
-// errInvalidStdinName is returned when --stdin-name is empty or contains path
-// separators, which would otherwise produce odd staging file names or escape
-// the temp directory.
-var errInvalidStdinName = errors.New("--stdin-name must be non-empty and must not contain path separators")
+// errInvalidStdinName is returned when --stdin-name is not a valid table
+// identifier (empty, path-like, or containing characters that filesql would
+// sanitize), which would otherwise stage odd files or leave the advertised
+// table name unqueryable.
+var errInvalidStdinName = errors.New("--stdin-name must be a valid table name: letters, digits, and underscores only, not starting with a digit")

--- a/spec/stdin_dataset_spec.sh
+++ b/spec/stdin_dataset_spec.sh
@@ -92,6 +92,16 @@ Describe 'sqly --stdin dataset'
       The stderr should include 'stdin'
     End
 
+    It 'rejects a non-identifier --stdin-name so the name stays queryable (#289)'
+      Data
+        #|id,name
+        #|1,alice
+      End
+      When run sqly --stdin csv --stdin-name "my data" --sql 'SELECT * FROM "my data"'
+      The status should be failure
+      The stderr should include 'stdin-name'
+    End
+
     It 'rejects a path-like --stdin-name (#305)'
       Data
         #|a


### PR DESCRIPTION
`--stdin-name` was silently sanitized before import, so a value like `my data` became the table `my_data` and the name the user advertised was not queryable (`SELECT * FROM "my data"` failed with "no such table"). `2023-data` similarly became `sheet_2023_data`.

Per the issue's accepted resolution ("reject invalid names up front"), `--stdin-name` now requires a valid bare table identifier (letters, digits, and underscores, not starting with a digit) and rejects anything else in `config.NewArg`, so the name given is always the exact, queryable table name. This builds on the path-safety validation added for #305.

Tests:
- Unit: `TestNewArg` rejects `my data`, `2023-data`, `a-b`, `weird!` and still accepts `people`/`stdin`.
- shellspec (`spec/stdin_dataset_spec.sh`): `--stdin-name "my data"` is rejected with a clear error. Runs in the existing E2E CI job.

Closes #289
