### PR TITLE
fix(model): emit SQL NULL as JSON null in --json and --ndjson (#328, #329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* JSON/NDJSON Preserve NULL: `--json` and `--ndjson` now emit a SQL `NULL` as JSON `null` instead of collapsing it to an empty string, so `NULL` and `''` are distinguishable in machine-readable output. Query results carry per-cell NULL information (a NULL scans as a nil byte slice, an empty string as a non-nil empty one); text formats are unchanged.
 * Stdin Name Must Be Queryable: `--stdin-name` now requires a valid table identifier (letters, digits, and underscores, not starting with a digit) and rejects values such as `my data` or `2023-data` up front. Previously such names were silently sanitized (`my data` became `my_data`), leaving the advertised name unusable in SQL.
 * Table-Name Collision Detection: When two inputs sanitize to the same table name (for example `a-b.csv` and `a_b.csv`, both becoming `a_b`), sqly now fails with a clear collision error instead of letting the later import silently overwrite the earlier one while keeping the first file's source metadata.
 * Input Path Validation False Positives: Input path validation no longer rejects legitimate paths. The arbitrary 10-level directory-depth limit is removed, so deeply nested workspace paths import (#316), and the URL-encoded traversal patterns (`..%2f`, `..%5c`) are no longer matched, so a real filename that merely contains those bytes is accepted (#317). sqly runs locally with the user's own permissions, so these web-style traversal checks only produced false rejections.

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -128,6 +128,12 @@ type Table struct {
 	header Header
 	// Records is table records.
 	records []Record
+	// nulls optionally marks which cells are SQL NULL (as opposed to an empty
+	// string), indexed as nulls[row][col]. It is set only for query results,
+	// where the distinction is known, and is consulted by JSON/NDJSON output so a
+	// NULL is emitted as JSON null. nil means "no NULL information"; text formats
+	// ignore it and render every cell as a string.
+	nulls [][]bool
 }
 
 // NewTable create new Table.
@@ -141,6 +147,18 @@ func NewTable(
 		header:  header,
 		records: records,
 	}
+}
+
+// SetNulls records which cells are SQL NULL, indexed as nulls[row][col]. It is
+// used by query results so JSON/NDJSON output can emit a NULL as JSON null
+// rather than an empty string. Other output formats ignore it.
+func (t *Table) SetNulls(nulls [][]bool) {
+	t.nulls = nulls
+}
+
+// isNull reports whether the cell at (row, col) is a known SQL NULL.
+func (t *Table) isNull(row, col int) bool {
+	return row < len(t.nulls) && col < len(t.nulls[row]) && t.nulls[row][col]
 }
 
 // Name return table name.
@@ -388,7 +406,7 @@ func (t *Table) printExcel(out io.Writer) {
 // string, so emitting strings keeps output lossless (e.g. "007" stays "007")
 // and consistent with the other text formats. Why a manual builder: encoding's
 // map marshaling sorts keys alphabetically, which would drop column order.
-func (t *Table) rowToJSONObject(record Record) ([]byte, error) {
+func (t *Table) rowToJSONObject(row int, record Record) ([]byte, error) {
 	var b bytes.Buffer
 	b.WriteByte('{')
 	for i, h := range t.Header() {
@@ -401,6 +419,13 @@ func (t *Table) rowToJSONObject(record Record) ([]byte, error) {
 		}
 		b.Write(key)
 		b.WriteByte(':')
+
+		// Emit a SQL NULL as JSON null so it is distinguishable from an empty
+		// string in machine-readable output.
+		if t.isNull(row, i) {
+			b.WriteString("null")
+			continue
+		}
 
 		var val string
 		if i < len(record) {
@@ -427,7 +452,7 @@ func (t *Table) printJSON(out io.Writer) error {
 		return err
 	}
 	for i, record := range t.Records() {
-		obj, err := t.rowToJSONObject(record)
+		obj, err := t.rowToJSONObject(i, record)
 		if err != nil {
 			return err
 		}
@@ -446,8 +471,8 @@ func (t *Table) printJSON(out io.Writer) error {
 // printNDJSON prints one JSON object per line (newline-delimited JSON). An empty
 // result set prints nothing — the empty NDJSON stream.
 func (t *Table) printNDJSON(out io.Writer) error {
-	for _, record := range t.Records() {
-		obj, err := t.rowToJSONObject(record)
+	for i, record := range t.Records() {
+		obj, err := t.rowToJSONObject(i, record)
 		if err != nil {
 			return err
 		}

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -450,6 +450,39 @@ aaa:777	bbb:888	ccc:999
 	}
 }
 
+func TestTablePrintJSON_NullDistinctFromEmpty(t *testing.T) {
+	t.Parallel()
+	// Regression for #328/#329: a SQL NULL must render as JSON null, distinct
+	// from an empty string. The null mask marks column 0 (n) as NULL; column 1
+	// (e) is a real empty string.
+	tbl := NewTable("t", Header{"n", "e", "x"}, []Record{{"", "", "1"}})
+	tbl.SetNulls([][]bool{{true, false, false}})
+
+	t.Run("json emits null for a NULL cell", func(t *testing.T) {
+		t.Parallel()
+		out := &bytes.Buffer{}
+		if err := tbl.Print(out, PrintModeJSON); err != nil {
+			t.Fatal(err)
+		}
+		want := "[\n  {\"n\":null,\"e\":\"\",\"x\":\"1\"}\n]\n"
+		if diff := cmp.Diff(out.String(), want); diff != "" {
+			t.Errorf("value is mismatch (-got +want):\n%s", diff)
+		}
+	})
+
+	t.Run("ndjson emits null for a NULL cell", func(t *testing.T) {
+		t.Parallel()
+		out := &bytes.Buffer{}
+		if err := tbl.Print(out, PrintModeNDJSON); err != nil {
+			t.Fatal(err)
+		}
+		want := "{\"n\":null,\"e\":\"\",\"x\":\"1\"}\n"
+		if diff := cmp.Diff(out.String(), want); diff != "" {
+			t.Errorf("value is mismatch (-got +want):\n%s", diff)
+		}
+	})
+}
+
 func TestTableEqual(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/memory/sqlite3.go
+++ b/infrastructure/memory/sqlite3.go
@@ -140,17 +140,27 @@ func (r *sqlite3Repository) Query(ctx context.Context, query string) (*model.Tab
 	}
 
 	records := []model.Record{}
+	// nulls tracks which cells were SQL NULL. With a *[]byte scan target a NULL
+	// yields a nil slice, while an empty string yields a non-nil empty slice, so
+	// the two are distinguishable here even though both render as "".
+	nulls := [][]bool{}
 	for rows.Next() {
 		result := make([]string, len(header))
+		rowNulls := make([]bool, len(header))
 		err := rows.Scan(scanDest...)
 		if err != nil {
 			return nil, err
 		}
 
 		for i, raw := range rawResult {
+			if raw == nil {
+				rowNulls[i] = true
+				continue
+			}
 			result[i] = string(raw)
 		}
 		records = append(records, result)
+		nulls = append(nulls, rowNulls)
 	}
 	if err = rows.Err(); err != nil {
 		return nil, err
@@ -158,7 +168,9 @@ func (r *sqlite3Repository) Query(ctx context.Context, query string) (*model.Tab
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	return model.NewTable(extractTableName(query), header, records), nil
+	table := model.NewTable(extractTableName(query), header, records)
+	table.SetNulls(nulls)
+	return table, nil
 }
 
 // extractTableName extract table name from query.

--- a/spec/json_null_spec.sh
+++ b/spec/json_null_spec.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# JSON/NDJSON NULL rendering (#328, #329). A SQL NULL must be emitted as JSON
+# null, distinct from an empty string, in machine-readable output.
+
+Describe 'sqly JSON/NDJSON NULL handling (#328, #329)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'emits NULL as JSON null in --json'
+    When run sqly --json --sql "SELECT NULL AS n, '' AS e, 1 AS x"
+    The status should be success
+    The output should include '"n":null'
+    The output should include '"e":""'
+  End
+
+  It 'emits NULL as JSON null in --ndjson'
+    When run sqly --ndjson --sql "SELECT NULL AS n, '' AS e, 1 AS x"
+    The status should be success
+    The output should include '"n":null'
+    The output should include '"e":""'
+  End
+End


### PR DESCRIPTION
`--json` and `--ndjson` turned every cell into a JSON string, so a SQL `NULL` was emitted as `""`, indistinguishable from an empty string in a format that represents `null` natively (e.g. `SELECT NULL AS n, '' AS e` produced `{"n":"","e":""}`).

The query path now records per-cell NULL information: with a `*[]byte` scan target a NULL yields a nil slice while an empty string yields a non-nil empty one, so the two are distinguishable at scan time. The table carries an optional null mask (set only for query results), and the JSON/NDJSON renderers emit `null` for a NULL cell. Text formats (table/csv/tsv/ltsv) are unchanged and still render NULL as an empty field.

Tests:
- Unit: `TestTablePrintJSON_NullDistinctFromEmpty` checks both JSON and NDJSON render a NULL as `null` while a real empty string stays `""`.
- shellspec (`spec/json_null_spec.sh`): `SELECT NULL AS n, '' AS e` over `--json` and `--ndjson` emits `"n":null` and `"e":""`. Runs in the existing E2E CI job.

Closes #328
Closes #329
