### PR TITLE
fix(shell): report per-file source for directory imports in --inspect (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Inspect Per-File Source For Directories: `--inspect` now reports each table's real source file for directory imports, instead of the directory path for every table, restoring file-level provenance. Tables whose names cannot be matched to a single file fall back to the directory path, and directory-imported tables are still rejected by write-back.
 * JSON/NDJSON Preserve NULL: `--json` and `--ndjson` now emit a SQL `NULL` as JSON `null` instead of collapsing it to an empty string, so `NULL` and `''` are distinguishable in machine-readable output. Query results carry per-cell NULL information (a NULL scans as a nil byte slice, an empty string as a non-nil empty one); text formats are unchanged.
 * Stdin Name Must Be Queryable: `--stdin-name` now requires a valid table identifier (letters, digits, and underscores, not starting with a digit) and rejects values such as `my data` or `2023-data` up front. Previously such names were silently sanitized (`my data` became `my_data`), leaving the advertised name unusable in SQL.
 * Table-Name Collision Detection: When two inputs sanitize to the same table name (for example `a-b.csv` and `a_b.csv`, both becoming `a_b`), sqly now fails with a clear collision error instead of letting the later import silently overwrite the earlier one while keeping the first file's source metadata.

--- a/shell/extension.go
+++ b/shell/extension.go
@@ -44,3 +44,31 @@ func getFileTypeFromPath(filePath string) string {
 	}
 	return name[pos:]
 }
+
+// baseTableName returns the file base name with compression and format
+// extensions removed. It is the candidate table name a file maps to before
+// filesql sanitizes it, used to match a directory-imported table back to its
+// source file for the --inspect report.
+func baseTableName(filePath string) string {
+	name := filepath.Base(filePath)
+
+	compressedExtensions := []string{".gz", ".bz2", ".xz", ".zst", ".z", ".snappy", ".s2", ".lz4"}
+	for {
+		found := false
+		for _, compExt := range compressedExtensions {
+			if before, ok := strings.CutSuffix(name, compExt); ok {
+				name = before
+				found = true
+				break
+			}
+		}
+		if !found {
+			break
+		}
+	}
+
+	if pos := strings.LastIndex(name, "."); pos > 0 {
+		name = name[:pos]
+	}
+	return name
+}

--- a/shell/import.go
+++ b/shell/import.go
@@ -270,10 +270,59 @@ func (s *Shell) importDirectory(ctx context.Context, cleanPath, displayPath, she
 	}
 	remainingNames := diffTableNames(tablesNow, existingTables)
 
-	s.recordTableSources(remainingNames, displayPath)
+	// Record each table's real source file when it can be matched to a file in
+	// the directory, so --inspect reports per-file provenance instead of the
+	// directory path (#326). Tables that cannot be matched (filesql sanitized the
+	// name, or the candidate is ambiguous) fall back to the directory path. Every
+	// table is marked as a directory import so write-back still rejects it.
+	fileSources := s.directoryTableFileSources(cleanPath)
+	for _, name := range remainingNames {
+		source := displayPath
+		if file, ok := fileSources[name]; ok {
+			source = file
+		}
+		s.recordTableSources([]string{name}, source)
+		s.markDirImported(name)
+	}
 
 	fmt.Fprintf(s.importStatusWriter(), "Successfully imported %d table(s) from directory %s: %v\n", len(remainingNames), displayPath, remainingNames)
 	return true, nil
+}
+
+// directoryTableFileSources walks dir and maps a candidate table name (the file
+// base name with compression and format extensions stripped) to its file path.
+// A name produced by more than one file is omitted as ambiguous, so the caller
+// falls back to the directory path rather than guessing.
+func (s *Shell) directoryTableFileSources(dir string) map[string]string {
+	candidates := map[string][]string{}
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil //nolint:nilerr // skip unreadable entries; import reports real errors
+		}
+		if !s.usecases.importer.IsSupportedFile(path) {
+			return nil
+		}
+		if name := baseTableName(path); name != "" {
+			candidates[name] = append(candidates[name], path)
+		}
+		return nil
+	})
+	result := make(map[string]string, len(candidates))
+	for name, paths := range candidates {
+		if len(paths) == 1 {
+			result[name] = paths[0]
+		}
+	}
+	return result
+}
+
+// markDirImported records that a table came from a directory import, so
+// write-back can reject it even when its source points at a single file.
+func (s *Shell) markDirImported(name string) {
+	if s.dirImported == nil {
+		s.dirImported = make(map[string]bool)
+	}
+	s.dirImported[name] = true
 }
 
 // importFile loads a single file into the database, applying --sheet filtering for Excel.

--- a/shell/inspect_test.go
+++ b/shell/inspect_test.go
@@ -222,10 +222,35 @@ func TestInspect_Directory(t *testing.T) {
 	if len(report.Tables) != 2 {
 		t.Fatalf("expected 2 tables from directory, got %d", len(report.Tables))
 	}
+	// Each table reports its real source file, not the directory path. Ref #326.
+	want := map[string]string{
+		"one": filepath.Join(sub, "one.csv"),
+		"two": filepath.Join(sub, "two.csv"),
+	}
 	for _, tbl := range report.Tables {
-		if tbl.Source != sub {
-			t.Errorf("table %q source = %q, want directory %q", tbl.Name, tbl.Source, sub)
+		if tbl.Source != want[tbl.Name] {
+			t.Errorf("table %q source = %q, want file %q", tbl.Name, tbl.Source, want[tbl.Name])
 		}
+	}
+}
+
+func TestWriteBack_RejectsDirectoryImport(t *testing.T) {
+	// Regression for #261/#326: a directory-imported table reports its per-file
+	// source in --inspect, but write-back must still reject it.
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	dir := t.TempDir()
+	writeCSV(t, dir, "one.csv", "a\n1\n")
+	if err := shell.commands.importCommand(context.Background(), shell, []string{dir}); err != nil {
+		t.Fatalf("directory import failed: %v", err)
+	}
+
+	if err := shell.writeBack(context.Background(), t.TempDir()); err == nil {
+		t.Fatal("write-back of a directory-imported table returned nil, want rejection")
 	}
 }
 

--- a/shell/save.go
+++ b/shell/save.go
@@ -124,6 +124,13 @@ func (s *Shell) writeBack(ctx context.Context, destDir string) error {
 			problems = append(problems, name+": came from --stdin and has no source file to write back to")
 			continue
 		}
+		// A directory import is not a single editable source the session owns, so
+		// reject it even though its source may point at a per-file path for
+		// --inspect provenance. Ref #326, #261.
+		if s.dirImported[name] {
+			problems = append(problems, fmt.Sprintf("%s: came from a directory import (%s)", name, source))
+			continue
+		}
 		if info, statErr := os.Stat(source); statErr == nil && info.IsDir() {
 			problems = append(problems, fmt.Sprintf("%s: came from a directory import (%s)", name, source))
 			continue

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -70,6 +70,11 @@ type Shell struct {
 	// It is populated on every import and used by the --inspect report and by
 	// write-back (.save) to map a table back to its source file.
 	tableSources map[string]string
+	// dirImported marks tables that came from a directory import. Their
+	// tableSources entry may point at the per-file source (for --inspect
+	// provenance), but write-back still rejects them because a directory import
+	// is not a single editable source the session owns. Ref #326, #261.
+	dirImported map[string]bool
 }
 
 type promptSession interface {

--- a/spec/inspect_spec.sh
+++ b/spec/inspect_spec.sh
@@ -34,6 +34,9 @@ Describe 'sqly --inspect (#259)'
     The line 1 should equal '{'
     The output should include '"name": "a"'
     The output should include '"name": "b"'
+    # Each table reports its real source file, not the directory path (#326).
+    The output should include '/a.csv'
+    The output should include '/b.csv'
     The stderr should include 'Successfully imported'
     rm -rf "$work_dir"
   End


### PR DESCRIPTION
For directory imports, `--inspect` recorded the directory path as the `source` of every table, losing the file-level provenance the report is meant to give.

`importDirectory` now matches each imported table back to its source file (by the file's base name with compression and format extensions stripped) and records that per-file path, so `--inspect` reports the real file. A table whose name cannot be uniquely matched (filesql sanitized it, or two files share a candidate name) falls back to the directory path. Directory-imported tables are tracked separately and still rejected by write-back (`.save`), preserving the #261 contract even though their source now points at a file.

Tests:
- Unit: `TestInspect_Directory` asserts per-file sources; `TestWriteBack_RejectsDirectoryImport` confirms directory-imported tables are still rejected for write-back.
- shellspec (`spec/inspect_spec.sh`): the directory inspect report includes `/a.csv` and `/b.csv`. Runs in the existing E2E CI job.

Closes #326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `--inspect` now reports each table's actual source file path when importing from a directory, rather than the directory path. Falls back to the directory when a table cannot be uniquely matched to a file.
  * Write-back operations continue to reject tables imported from directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->