### PR TITLE
docs(changelog): release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v0.18.0](https://github.com/nao1215/sqly/compare/v0.17.0...v0.18.0) (2026-05-31)
 
 ### Bug Fixes
 * Inspect Per-File Source For Directories: `--inspect` now reports each table's real source file for directory imports, instead of the directory path for every table, restoring file-level provenance. Tables whose names cannot be matched to a single file fall back to the directory path, and directory-imported tables are still rejected by write-back.


### PR DESCRIPTION
Release v0.18.0.

This stamps the accumulated `[Unreleased]` CHANGELOG section as `v0.18.0` with a compare link, ahead of tagging.

Highlights since v0.17.0:

New features:
- `--sql-file PATH`: run SQL from a file for non-interactive runs, freeing stdin to carry a piped `--stdin` dataset (#281).
- `--inspect-sample N`: control how many sample rows `--inspect` includes per table (#283).

Bug fixes: a broad hardening pass over the v0.17.0 binary surfaced by the roadmap (#148), covering stdout purity (status/banner/diagnostics to stderr, JSON NULL), batch fail-fast and empty-batch safety, flag and command-argument validation (`--sheet`, `--inspect`, `--output`, `--stdin-name`, empty/extra arguments), output path preservation and directory rejection, table-name collision detection, stdin dataset source/write-back safety, per-file `--inspect` provenance, input-path false positives, and Excel export permissions. See CHANGELOG.md for the full list.

After this merges, tag v0.18.0 to trigger the GoReleaser publish workflow. That resolves the published-binary mismatches #293 and #298.
