### PR TITLE
fix: resolve v0.21.0 binary bugs and prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,65 +1,79 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v0.22.0](https://github.com/nao1215/sqly/compare/v0.21.0...v0.22.0) (2026-06-01)
+
+### Breaking Changes
+* Direct --sql Runs One Statement: direct `--sql` (and `--sql --output`) now rejects multi-statement input instead of silently running every statement and keeping only the last result set.
+* Save Mode Rejects PRAGMA: a non-interactive `--save`/`--save-dir` run now rejects a setter, command, or rowset PRAGMA, since a PRAGMA side effect lives only in the in-memory session and has no file write-back representation.
+* Nested Compression Suffixes Rejected: `--output` and `.dump` reject a destination that stacks more than one compression suffix (for example `out.csv.gz.zst` or `fake.parquet.gz.zst`), instead of applying only the outermost codec and leaving a file whose name lies about its bytes.
+* END Rejected As Transaction Control: `END` and `END TRANSACTION` are rejected as unsupported transaction control across direct `--sql`, batch stdin, and `--sql-file`, matching `BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT`.
+
+### Bug Fixes
+* Helper Commands Resolve TEMP Before Main: `.schema` resolves an unqualified name against temp objects before main, so a TEMP table or view that shadows an imported table reports the live definition; `.tables` keeps both a main object and a same-named temp object instead of collapsing them.
+* Literal Dotted Table Names: `.schema`, `.describe`, `.header`, and `.dump` target a SQL-created table whose quoted literal name contains a dot (for example `"a.b"`); only `main` and `temp` are treated as schema qualifiers, since ATTACH is rejected and no other schema can exist.
+* TEMP Keyword Preserved: `.schema temp.NAME` emits `CREATE TEMP TABLE`/`CREATE TEMP VIEW`, re-inserting the TEMP keyword SQLite strips from the SQL it stores for a temp object.
+* Paste-Safe .tables Output: `.tables` quotes identifiers that need quoting and qualifies a temp object as `temp.NAME`, so its output pastes back into SQL and helper commands; `.header` keeps the full table name when it contains spaces.
+* Structured Output For .tables And .header: `.tables` and `.header` honor `.mode json` and `.mode ndjson`, emitting machine-readable rows instead of always printing an ASCII table.
+* Read-Only Interactive Save: interactive `.save --force` and `.save DIR` write nothing when the session changed no table data, so a read-only session no longer rewrites sources or emits fresh exports, matching the non-interactive `--save` contract.
 
 ### Documentation
-* README Version Refresh: Refresh the shell snippet and benchmark caption to the current release, correct the "not supported" list for v0.21.0 (DDL runs in-memory; transaction control, VACUUM, ATTACH/DETACH, and DCL are rejected), and add a Go test that fails when a README `sqly vX.Y.Z` string drifts from the latest CHANGELOG version (#454).
-* README Demos For Non-Interactive Flows: Add VHS demos and examples for `--inspect` (including `--inspect-sample 0` for a schema-only report), `--stdin` combined with `--sql-file`, and the write-back safety boundaries (`--save` requires `--force`; a schema change is rejected up front). The new example commands are exercised end-to-end by the shellspec suite (#455).
+* README Version Refresh: Refresh the shell snippet and benchmark caption to the current release, correct the "not supported" list for v0.21.0 (DDL runs in-memory; transaction control, VACUUM, ATTACH/DETACH, and DCL are rejected), and add a Go test that fails when a README `sqly vX.Y.Z` string drifts from the latest CHANGELOG version.
+* README Demos For Non-Interactive Flows: Add VHS demos and examples for `--inspect` (including `--inspect-sample 0` for a schema-only report), `--stdin` combined with `--sql-file`, and the write-back safety boundaries (`--save` requires `--force`; a schema change is rejected up front). The new example commands are exercised end-to-end by the shellspec suite.
 
 ## [v0.21.0](https://github.com/nao1215/sqly/compare/v0.20.0...v0.21.0) (2026-06-01)
 
 ### Breaking Changes
-* Unsupported Statements Rejected Clearly: Explicit transaction control (`BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT`/`RELEASE`), `VACUUM`/`VACUUM INTO`, and `ATTACH`/`DETACH DATABASE` are now rejected with a clear sqly error. sqly runs each statement in its own transaction on a single in-memory connection, so these cannot work across statements, and ATTACH would let a session read or write external SQLite files outside the import/save model (#441, #442, #443, #444, #457, #458, #463).
-* Write-Back Rejects Schema-Only Runs: A non-interactive `--save`/`--save-dir` run now fails up front when the SQL changes schema or runs a maintenance statement (ALTER, DROP, REINDEX, ANALYZE, CREATE/DROP of a table/view/index/trigger, including `CREATE TABLE AS SELECT`), since write-back can only persist `INSERT`/`UPDATE`/`DELETE` on imported tables. Previously such a run exited 0 and reported success while leaving the source unchanged (#433, #434, #435, #436, #437, #438, #469, #470, #471, #472, #473, #474, #475, #476, #477, #478, #479, #480, #481, #482, #483, #484).
+* Unsupported Statements Rejected Clearly: Explicit transaction control (`BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT`/`RELEASE`), `VACUUM`/`VACUUM INTO`, and `ATTACH`/`DETACH DATABASE` are now rejected with a clear sqly error. sqly runs each statement in its own transaction on a single in-memory connection, so these cannot work across statements, and ATTACH would let a session read or write external SQLite files outside the import/save model.
+* Write-Back Rejects Schema-Only Runs: A non-interactive `--save`/`--save-dir` run now fails up front when the SQL changes schema or runs a maintenance statement (ALTER, DROP, REINDEX, ANALYZE, CREATE/DROP of a table/view/index/trigger, including `CREATE TABLE AS SELECT`), since write-back can only persist `INSERT`/`UPDATE`/`DELETE` on imported tables. Previously such a run exited 0 and reported success while leaving the source unchanged.
 
 ### Bug Fixes
-* Neutral Result Message For Non-DML: A DDL, PRAGMA, or maintenance statement now reports `statement executed successfully` instead of a misleading `affected is N row(s)` count (#439).
-* PRAGMA On The Exec Path: A setter PRAGMA (`PRAGMA user_version = 1`) and a no-row command PRAGMA (`PRAGMA incremental_vacuum`) now run successfully instead of failing with a "no records" error (#440, #485).
-* Batch .import Under Save Flags: A batch or `--sql-file` script that imports its own input with `.import` and then modifies it is now allowed under `--save`/`--save-dir`; write-back is validated after the import runs (#456).
-* Schema-Qualified Helper Commands: `.schema`, `.describe`, `.header`, and `.dump` accept schema-qualified names such as `main.user` (#445, #446, #447, #448).
-* TEMP Tables And Views In Helper Commands: `.tables` lists session-created views and TEMP tables (#449, #450); `.schema` prints the real `CREATE VIEW` for a view (#451) and reads the stored definition for a constrained TEMP table instead of a lossy reconstruction (#464).
-* Empty Compressed JSON And JSONL: An empty compressed JSON array (`.json.gz`) and an empty compressed JSONL file now import as a zero-row table, matching the uncompressed inputs (#452, #453).
-* Output Destination Safety: `--output` and `.dump` strip every trailing compression suffix before checking for an input-only ACH/Fedwire extension, so a path like `out.ach.gz.zst` is rejected instead of receiving CSV bytes (#459, #460).
-* Pseudo-File Inputs: `/dev/stdin`, `/dev/stdout`, `/dev/stderr`, and the Linux `/proc/<pid|self>/fd/*` aliases pass input-path validation and import end-to-end. An extensionless pseudo-file is staged as CSV (use `--stdin FORMAT` for another format), matching the already-allowed `/dev/fd/*` (#461, #462).
-* LTSV Label Validation: LTSV output rejects a column name that is not a valid LTSV label (for example `foo:bar`) or that duplicates another, and LTSV import rejects a row that repeats a label, so LTSV stays round-trippable instead of silently losing values (#465, #466, #467).
-* Multiline CREATE TRIGGER: Batch and `--sql-file` parsing keeps a `CREATE TRIGGER ... BEGIN ... END` body as one statement instead of splitting it at the inner semicolons (#468).
+* Neutral Result Message For Non-DML: A DDL, PRAGMA, or maintenance statement now reports `statement executed successfully` instead of a misleading `affected is N row(s)` count.
+* PRAGMA On The Exec Path: A setter PRAGMA (`PRAGMA user_version = 1`) and a no-row command PRAGMA (`PRAGMA incremental_vacuum`) now run successfully instead of failing with a "no records" error.
+* Batch .import Under Save Flags: A batch or `--sql-file` script that imports its own input with `.import` and then modifies it is now allowed under `--save`/`--save-dir`; write-back is validated after the import runs.
+* Schema-Qualified Helper Commands: `.schema`, `.describe`, `.header`, and `.dump` accept schema-qualified names such as `main.user`.
+* TEMP Tables And Views In Helper Commands: `.tables` lists session-created views and TEMP tables; `.schema` prints the real `CREATE VIEW` for a view and reads the stored definition for a constrained TEMP table instead of a lossy reconstruction.
+* Empty Compressed JSON And JSONL: An empty compressed JSON array (`.json.gz`) and an empty compressed JSONL file now import as a zero-row table, matching the uncompressed inputs.
+* Output Destination Safety: `--output` and `.dump` strip every trailing compression suffix before checking for an input-only ACH/Fedwire extension, so a path like `out.ach.gz.zst` is rejected instead of receiving CSV bytes.
+* Pseudo-File Inputs: `/dev/stdin`, `/dev/stdout`, `/dev/stderr`, and the Linux `/proc/<pid|self>/fd/*` aliases pass input-path validation and import end-to-end. An extensionless pseudo-file is staged as CSV (use `--stdin FORMAT` for another format), matching the already-allowed `/dev/fd/*`.
+* LTSV Label Validation: LTSV output rejects a column name that is not a valid LTSV label (for example `foo:bar`) or that duplicates another, and LTSV import rejects a row that repeats a label, so LTSV stays round-trippable instead of silently losing values.
+* Multiline CREATE TRIGGER: Batch and `--sql-file` parsing keeps a `CREATE TRIGGER ... BEGIN ... END` body as one statement instead of splitting it at the inner semicolons.
 
 ### Dependencies
-* filesql: 0.13.0 → 0.14.0, which rejects a duplicate label within an LTSV record on import (the upstream root fix for #467, replacing the temporary sqly-side check) and pulls in fileparser 0.5.2.
+* filesql: 0.13.0 → 0.14.0, which rejects a duplicate label within an LTSV record on import (the upstream root fix, replacing the temporary sqly-side check) and pulls in fileparser 0.5.2.
 
 ## [v0.20.0](https://github.com/nao1215/sqly/compare/v0.19.0...v0.20.0) (2026-06-01)
 
 ### Bug Fixes
-* Valid Machine-Readable Output: `--csv` and `--tsv` stdout now go through a CSV/TSV writer, so values containing the delimiter, quotes, or newlines are quoted and stay valid when redirected or piped (#380, #381). `--ltsv` rejects values with a tab or newline, which LTSV cannot represent losslessly, and the LTSV file export no longer quotes the whole `label:value` token, so it round-trips (#382, #383). `--json` and `--ndjson` reject duplicate output column names instead of emitting ambiguous duplicate keys (#384, #385). `--markdown` renders an embedded newline as `<br>` so a row stays on one line (#426).
-* Direct --sql Accepts More SQLite: The direct `--sql` path strips a leading SQL comment or UTF-8 BOM before classifying a statement, matching the batch and `--sql-file` paths (#386, #387). It now runs `PRAGMA`, `VALUES`, `REPLACE`, transaction control (`BEGIN`/`COMMIT`/...), DDL (`CREATE`/`DROP`/...), `ATTACH`, and `ANALYZE` instead of rejecting them, and rewrites the `TABLE name` shorthand to `SELECT * FROM name` (#406, #407, #408, #409, #410, #411, #430, #431). A non-returning `WITH ... INSERT/UPDATE/DELETE` runs as DML instead of failing on the query path (#412, #413, #414).
-* Empty JSON And JSONL Inputs: An empty JSON array (`[]`), whitespace-only JSON, and an empty or blank-only JSONL file now import as a zero-row table with the `data` column instead of failing as an empty data source (#388, #389).
-* Inspect And Dependent-Flag Validation: `--inspect` rejects a conflicting output mode flag such as `--csv` or `--parquet` (#390). `--stdin-name` requires `--stdin` (#391), `--inspect-sample` requires `--inspect` (#392), and `--force` requires `--save`/`--save-dir` (#393), instead of being silently ignored. A `--stdin-name` that is a SQLite keyword is rejected since it is not queryable as a bare table name (#423), and an imported file whose name sanitizes to a keyword now warns that the table must be quoted (#424).
-* Output Destination Safety: `--output` and `.dump` resolve symlinks before comparing a destination to an imported source, so a symlink alias can no longer overwrite a source file (#394, #418). `.dump` now rejects a destination that aliases an imported source, pointing at `.save --force` (#398). A destination ending with a path separator is rejected instead of becoming a hidden `.csv` file (#419, #420), and ACH/Fedwire destination extensions (including compressed variants) are rejected instead of receiving CSV bytes (#421, #422).
-* Write-Back Semantics: An `EXPLAIN` of a DML statement (#402, #403) and a zero-row DML (#404, #405) no longer trigger write-back, since neither changes table data. A `.csv.bz2` source is rejected during preflight, before any file is truncated, because bzip2 has no writer (#395). A run that fails during write-back keeps stdout free of the DML success count (#396).
-* Directory Import And Collisions: Re-importing a directory-sourced file directly clears the directory marker so it becomes saveable (#415), a standalone `.import` can replace a directory-imported table (#416), a same-source symlink alias is treated as a harmless re-import rather than a collision (#417), and a directory re-import no longer mis-detects basename-prefix tables (for example `a.csv` and `a_b.csv`) as collisions (#429).
-* Batch Line-By-Line Parsing: A helper command after a terminated SQL statement or after a leading SQL comment is parsed and executed on its own line instead of being absorbed into the following statement (#397, #425).
-* Input Path Validation: User files under `/dev/shm` and process-substitution paths under `/dev/fd` are no longer rejected as system directories (#427, #428).
-* History Lock Contention: The session databases set `busy_timeout`, so two sqly processes sharing one history DB wait for a transient lock instead of disabling history with a misleading SQLITE_BUSY warning (#399).
+* Valid Machine-Readable Output: `--csv` and `--tsv` stdout now go through a CSV/TSV writer, so values containing the delimiter, quotes, or newlines are quoted and stay valid when redirected or piped. `--ltsv` rejects values with a tab or newline, which LTSV cannot represent losslessly, and the LTSV file export no longer quotes the whole `label:value` token, so it round-trips. `--json` and `--ndjson` reject duplicate output column names instead of emitting ambiguous duplicate keys. `--markdown` renders an embedded newline as `<br>` so a row stays on one line.
+* Direct --sql Accepts More SQLite: The direct `--sql` path strips a leading SQL comment or UTF-8 BOM before classifying a statement, matching the batch and `--sql-file` paths. It now runs `PRAGMA`, `VALUES`, `REPLACE`, transaction control (`BEGIN`/`COMMIT`/...), DDL (`CREATE`/`DROP`/...), `ATTACH`, and `ANALYZE` instead of rejecting them, and rewrites the `TABLE name` shorthand to `SELECT * FROM name`. A non-returning `WITH ... INSERT/UPDATE/DELETE` runs as DML instead of failing on the query path.
+* Empty JSON And JSONL Inputs: An empty JSON array (`[]`), whitespace-only JSON, and an empty or blank-only JSONL file now import as a zero-row table with the `data` column instead of failing as an empty data source.
+* Inspect And Dependent-Flag Validation: `--inspect` rejects a conflicting output mode flag such as `--csv` or `--parquet`. `--stdin-name` requires `--stdin`, `--inspect-sample` requires `--inspect`, and `--force` requires `--save`/`--save-dir`, instead of being silently ignored. A `--stdin-name` that is a SQLite keyword is rejected since it is not queryable as a bare table name, and an imported file whose name sanitizes to a keyword now warns that the table must be quoted.
+* Output Destination Safety: `--output` and `.dump` resolve symlinks before comparing a destination to an imported source, so a symlink alias can no longer overwrite a source file. `.dump` now rejects a destination that aliases an imported source, pointing at `.save --force`. A destination ending with a path separator is rejected instead of becoming a hidden `.csv` file, and ACH/Fedwire destination extensions (including compressed variants) are rejected instead of receiving CSV bytes.
+* Write-Back Semantics: An `EXPLAIN` of a DML statement and a zero-row DML no longer trigger write-back, since neither changes table data. A `.csv.bz2` source is rejected during preflight, before any file is truncated, because bzip2 has no writer. A run that fails during write-back keeps stdout free of the DML success count.
+* Directory Import And Collisions: Re-importing a directory-sourced file directly clears the directory marker so it becomes saveable, a standalone `.import` can replace a directory-imported table, a same-source symlink alias is treated as a harmless re-import rather than a collision, and a directory re-import no longer mis-detects basename-prefix tables (for example `a.csv` and `a_b.csv`) as collisions.
+* Batch Line-By-Line Parsing: A helper command after a terminated SQL statement or after a leading SQL comment is parsed and executed on its own line instead of being absorbed into the following statement.
+* Input Path Validation: User files under `/dev/shm` and process-substitution paths under `/dev/fd` are no longer rejected as system directories.
+* History Lock Contention: The session databases set `busy_timeout`, so two sqly processes sharing one history DB wait for a transient lock instead of disabling history with a misleading SQLITE_BUSY warning.
 
 ## [v0.19.0](https://github.com/nao1215/sqly/compare/v0.18.0...v0.19.0) (2026-06-01)
 
 ### New Features
-* DML RETURNING Support: `INSERT`, `UPDATE`, and `DELETE` statements with a `RETURNING` clause now print the returned rows instead of only an affected-row count, and those rows can be exported with `--output` (#363, #368).
+* DML RETURNING Support: `INSERT`, `UPDATE`, and `DELETE` statements with a `RETURNING` clause now print the returned rows instead of only an affected-row count, and those rows can be exported with `--output`.
 
 ### Bug Fixes
-* Explicit Empty Flag Values Rejected: `--output`, `--sql-file`, `--save-dir`, and `--stdin` now reject an explicit empty value instead of treating the flag as absent (#349, #350, #352, #353). `.import` likewise rejects an empty `--sheet`, in both the `--sheet ""` and `--sheet=` forms (#354, #355).
-* Comment-Only SQL Files Rejected: A `--sql-file` that contains only comments now fails like an empty file, since it has no executable SQL (#351).
-* Conflicting Output Mode Flags Rejected: Passing more than one output mode flag (for example `--csv --json`) now fails instead of applying an undocumented precedence (#365).
-* Output For Non-Rowset DML: `--output` is now rejected for a DML statement that produces no rows (an `INSERT`/`UPDATE`/`DELETE` without `RETURNING`), instead of being silently ignored (#364).
-* Save Flags With sql-file On A Terminal: `--save` and `--save-dir` now work with `--sql-file` even when stdin is a terminal (#366, #367).
-* Stdin Routing: `--sql-file` now rejects non-empty piped stdin instead of silently dropping it, pointing at `--stdin` for dataset input (#373). A `--stdin` dataset run with no query now fails instead of importing and discarding the data (#374).
-* UTF-8 BOM In Scripts: A leading UTF-8 BOM is now stripped from `--sql-file` scripts and batch stdin, so BOM-prefixed files from Windows editors and export tools parse like plain UTF-8 (#369).
-* Sheet Flag On Unreadable Directories: `--sheet` validation now surfaces the real directory access error instead of misclassifying an unreadable directory as a non-Excel input (#356).
-* Multi-Workbook Sheet Filter: In a multi-workbook or directory import, a workbook that lacks the requested `--sheet` is now skipped instead of failing the whole import, so matching workbooks still load. The run fails only when no workbook contains the sheet (#378).
-* Directory Import Provenance: Directory imports now record each table's source file even when the basename is sanitized or the file yields several tables (Excel, ACH, Fedwire), so `--inspect` reports the file rather than the directory path (#357, #358).
-* Directory Import Collisions: Two files in a directory tree that map to the same table name (duplicate basenames from different subdirectories, or sanitized-name collisions) are now rejected instead of one silently overwriting the other (#359, #360).
-* Directory Re-Import: Re-importing a directory that overwrites an existing table is now reported as a successful overwrite instead of `No supported files found`, and the table's source is re-pointed to the directory file so `.save --force` can no longer write the directory rows back into the original source file (#361, #362).
-* Write-Back Safety: `--save-dir` now rejects a destination that resolves to the source file (#370) or already exists in the destination directory (#372), and validates all targets before writing any, so a failure leaves no partial output (#377). `--output` now rejects a destination that aliases an imported source file (#371). A read-only query no longer triggers write-back under `--save`/`--save-dir` (#376), and a run that fails during write-back no longer prints a DML success count to stdout (#375).
+* Explicit Empty Flag Values Rejected: `--output`, `--sql-file`, `--save-dir`, and `--stdin` now reject an explicit empty value instead of treating the flag as absent. `.import` likewise rejects an empty `--sheet`, in both the `--sheet ""` and `--sheet=` forms.
+* Comment-Only SQL Files Rejected: A `--sql-file` that contains only comments now fails like an empty file, since it has no executable SQL.
+* Conflicting Output Mode Flags Rejected: Passing more than one output mode flag (for example `--csv --json`) now fails instead of applying an undocumented precedence.
+* Output For Non-Rowset DML: `--output` is now rejected for a DML statement that produces no rows (an `INSERT`/`UPDATE`/`DELETE` without `RETURNING`), instead of being silently ignored.
+* Save Flags With sql-file On A Terminal: `--save` and `--save-dir` now work with `--sql-file` even when stdin is a terminal.
+* Stdin Routing: `--sql-file` now rejects non-empty piped stdin instead of silently dropping it, pointing at `--stdin` for dataset input. A `--stdin` dataset run with no query now fails instead of importing and discarding the data.
+* UTF-8 BOM In Scripts: A leading UTF-8 BOM is now stripped from `--sql-file` scripts and batch stdin, so BOM-prefixed files from Windows editors and export tools parse like plain UTF-8.
+* Sheet Flag On Unreadable Directories: `--sheet` validation now surfaces the real directory access error instead of misclassifying an unreadable directory as a non-Excel input.
+* Multi-Workbook Sheet Filter: In a multi-workbook or directory import, a workbook that lacks the requested `--sheet` is now skipped instead of failing the whole import, so matching workbooks still load. The run fails only when no workbook contains the sheet.
+* Directory Import Provenance: Directory imports now record each table's source file even when the basename is sanitized or the file yields several tables (Excel, ACH, Fedwire), so `--inspect` reports the file rather than the directory path.
+* Directory Import Collisions: Two files in a directory tree that map to the same table name (duplicate basenames from different subdirectories, or sanitized-name collisions) are now rejected instead of one silently overwriting the other.
+* Directory Re-Import: Re-importing a directory that overwrites an existing table is now reported as a successful overwrite instead of `No supported files found`, and the table's source is re-pointed to the directory file so `.save --force` can no longer write the directory rows back into the original source file.
+* Write-Back Safety: `--save-dir` now rejects a destination that resolves to the source file or already exists in the destination directory, and validates all targets before writing any, so a failure leaves no partial output. `--output` now rejects a destination that aliases an imported source file. A read-only query no longer triggers write-back under `--save`/`--save-dir`, and a run that fails during write-back no longer prints a DML success count to stdout.
 
 ## [v0.18.0](https://github.com/nao1215/sqly/compare/v0.17.0...v0.18.0) (2026-05-31)
 
@@ -68,7 +82,7 @@
 * JSON/NDJSON Preserve NULL: `--json` and `--ndjson` now emit a SQL `NULL` as JSON `null` instead of collapsing it to an empty string, so `NULL` and `''` are distinguishable in machine-readable output. Query results carry per-cell NULL information (a NULL scans as a nil byte slice, an empty string as a non-nil empty one); text formats are unchanged.
 * Stdin Name Must Be Queryable: `--stdin-name` now requires a valid table identifier (letters, digits, and underscores, not starting with a digit) and rejects values such as `my data` or `2023-data` up front. Previously such names were silently sanitized (`my data` became `my_data`), leaving the advertised name unusable in SQL.
 * Table-Name Collision Detection: When two inputs sanitize to the same table name (for example `a-b.csv` and `a_b.csv`, both becoming `a_b`), sqly now fails with a clear collision error instead of letting the later import silently overwrite the earlier one while keeping the first file's source metadata.
-* Input Path Validation False Positives: Input path validation no longer rejects legitimate paths. The arbitrary 10-level directory-depth limit is removed, so deeply nested workspace paths import (#316), and the URL-encoded traversal patterns (`..%2f`, `..%5c`) are no longer matched, so a real filename that merely contains those bytes is accepted (#317). sqly runs locally with the user's own permissions, so these web-style traversal checks only produced false rejections.
+* Input Path Validation False Positives: Input path validation no longer rejects legitimate paths. The arbitrary 10-level directory-depth limit is removed, so deeply nested workspace paths import, and the URL-encoded traversal patterns (`..%2f`, `..%5c`) are no longer matched, so a real filename that merely contains those bytes is accepted. sqly runs locally with the user's own permissions, so these web-style traversal checks only produced false rejections.
 * Helper Commands Reject Extra Arguments: `.schema`, `.describe`, `.header`, `.mode`, `.tables`, and `.help` now reject unexpected trailing arguments with a clear error instead of silently ignoring them, so typos no longer pass unnoticed.
 * Output Requires SQL: `--output` is now rejected with a clear error when no `--sql` query is supplied (including batch stdin, `--sql-file`, and interactive runs), instead of being silently ignored while the command still exits successfully. `--output` is only honored by the single-result `--sql` path.
 * Empty Command Arguments Rejected: `.save ""`, `.dump TABLE ""`, and `.import ""` now fail with a clear error instead of being reinterpreted. `.save ""` no longer behaves like an in-place save (which bypassed `--force`), `.dump TABLE ""` no longer writes a file named `.csv`, and `.import ""` no longer imports the current working directory.
@@ -350,7 +364,7 @@
 ## [v0.12.2](https://github.com/nao1215/sqly/compare/v0.12.1...v0.12.2) (2025-09-17)
 
 ### Bug Fixes
-* **Table Names**: Fix SQL syntax errors caused by special characters in filenames ([#153](https://github.com/nao1215/sqly/pull/153))
+* **Table Names**: Fix SQL syntax errors caused by special characters in filenames ()
   - Automatically sanitize table names by replacing problematic characters (hyphens, dots, special chars) with underscores
   - Example: `bug-syntax-error.csv` now creates table `bug_syntax_error` instead of failing with syntax error
   - Added comprehensive test coverage for filename sanitization edge cases
@@ -463,154 +477,154 @@
 
 ## [v0.9.0](https://github.com/nao1215/sqly/compare/v0.8.1...v0.9.0) (2025-02-03)
 
-* Add architecture linter [#87](https://github.com/nao1215/sqly/pull/87) ([nao1215](https://github.com/nao1215))
-* Reduce dependency and add unit tests for interactor [#86](https://github.com/nao1215/sqly/pull/86) ([nao1215](https://github.com/nao1215))
-* Add usecase interface and mock code [#85](https://github.com/nao1215/sqly/pull/85) ([nao1215](https://github.com/nao1215))
-* Bump github.com/spf13/pflag from 1.0.5 to 1.0.6 [#84](https://github.com/nao1215/sqly/pull/84) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump golang.org/x/net from 0.30.0 to 0.33.0 [#83](https://github.com/nao1215/sqly/pull/83) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.34.4 to 1.34.5 [#82](https://github.com/nao1215/sqly/pull/82) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/mattn/go-colorable from 0.1.13 to 0.1.14 [#81](https://github.com/nao1215/sqly/pull/81) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.34.3 to 1.34.4 [#80](https://github.com/nao1215/sqly/pull/80) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump golang.org/x/crypto from 0.28.0 to 0.31.0 [#79](https://github.com/nao1215/sqly/pull/79) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.34.1 to 1.34.3 [#78](https://github.com/nao1215/sqly/pull/78) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.33.1 to 1.34.1 [#76](https://github.com/nao1215/sqly/pull/76) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/fatih/color from 1.17.0 to 1.18.0 [#75](https://github.com/nao1215/sqly/pull/75) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/mattn/go-sqlite3 from 1.14.23 to 1.14.24 [#73](https://github.com/nao1215/sqly/pull/73) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/xuri/excelize/v2 from 2.8.1 to 2.9.0 [#74](https://github.com/nao1215/sqly/pull/74) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/mattn/go-sqlite3 from 1.14.22 to 1.14.23 [#70](https://github.com/nao1215/sqly/pull/70) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.33.0 to 1.33.1 [#72](https://github.com/nao1215/sqly/pull/72) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.32.0 to 1.33.0 [#71](https://github.com/nao1215/sqly/pull/71) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Add go 1.23 in unit test coverage [#69](https://github.com/nao1215/sqly/pull/69) ([nao1215](https://github.com/nao1215))
-* Bump modernc.org/sqlite from 1.31.1 to 1.32.0 [#68](https://github.com/nao1215/sqly/pull/68) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.30.2 to 1.31.1 [#67](https://github.com/nao1215/sqly/pull/67) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.30.1 to 1.30.2 [#66](https://github.com/nao1215/sqly/pull/66) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.30.0 to 1.30.1 [#65](https://github.com/nao1215/sqly/pull/65) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump goreleaser/goreleaser-action from 5 to 6 [#64](https://github.com/nao1215/sqly/pull/64) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.29.10 to 1.30.0 [#63](https://github.com/nao1215/sqly/pull/63) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.29.9 to 1.29.10 [#62](https://github.com/nao1215/sqly/pull/62) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Update project config [#61](https://github.com/nao1215/sqly/pull/61) ([nao1215](https://github.com/nao1215))
-* Bump github.com/fatih/color from 1.16.0 to 1.17.0 [#60](https://github.com/nao1215/sqly/pull/60) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump modernc.org/sqlite from 1.29.8 to 1.29.9 [#59](https://github.com/nao1215/sqly/pull/59) ([dependabot[bot]](https://github.com/apps/dependabot))
+* Add architecture linter ([nao1215](https://github.com/nao1215))
+* Reduce dependency and add unit tests for interactor ([nao1215](https://github.com/nao1215))
+* Add usecase interface and mock code ([nao1215](https://github.com/nao1215))
+* Bump github.com/spf13/pflag from 1.0.5 to 1.0.6 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump golang.org/x/net from 0.30.0 to 0.33.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.34.4 to 1.34.5 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/mattn/go-colorable from 0.1.13 to 0.1.14 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.34.3 to 1.34.4 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump golang.org/x/crypto from 0.28.0 to 0.31.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.34.1 to 1.34.3 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.33.1 to 1.34.1 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/fatih/color from 1.17.0 to 1.18.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/mattn/go-sqlite3 from 1.14.23 to 1.14.24 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/xuri/excelize/v2 from 2.8.1 to 2.9.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/mattn/go-sqlite3 from 1.14.22 to 1.14.23 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.33.0 to 1.33.1 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.32.0 to 1.33.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Add go 1.23 in unit test coverage ([nao1215](https://github.com/nao1215))
+* Bump modernc.org/sqlite from 1.31.1 to 1.32.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.30.2 to 1.31.1 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.30.1 to 1.30.2 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.30.0 to 1.30.1 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump goreleaser/goreleaser-action from 5 to 6 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.29.10 to 1.30.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.29.9 to 1.29.10 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Update project config ([nao1215](https://github.com/nao1215))
+* Bump github.com/fatih/color from 1.16.0 to 1.17.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump modernc.org/sqlite from 1.29.8 to 1.29.9 ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v0.8.1](https://github.com/nao1215/sqly/compare/v0.8.0...v0.8.1) (2024-05-01)
 
-* Introduce homebrew [#58](https://github.com/nao1215/sqly/pull/58) ([nao1215](https://github.com/nao1215))
+* Introduce homebrew ([nao1215](https://github.com/nao1215))
 
 ## [v0.8.0](https://github.com/nao1215/sqly/compare/v0.7.0...v0.8.0) (2024-05-01)
 
-* Change SQLite3 driver from mattn/go-sqlite3 to modernc.org/sqlite [#57](https://github.com/nao1215/sqly/pull/57) ([nao1215](https://github.com/nao1215))
-* Add benchmark [#56](https://github.com/nao1215/sqly/pull/56) ([nao1215](https://github.com/nao1215))
-* Add unit test for excel [#55](https://github.com/nao1215/sqly/pull/55) ([nao1215](https://github.com/nao1215))
+* Change SQLite3 driver from mattn/go-sqlite3 to modernc.org/sqlite ([nao1215](https://github.com/nao1215))
+* Add benchmark ([nao1215](https://github.com/nao1215))
+* Add unit test for excel ([nao1215](https://github.com/nao1215))
 
 ## [v0.7.0](https://github.com/nao1215/sqly/compare/v0.6.5...v0.7.0) (2024-04-30)
 
-* Bump golang.org/x/net from 0.21.0 to 0.23.0 [#54](https://github.com/nao1215/sqly/pull/54) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Support Microsoft Excel™ (XLAM / XLSM / XLSX / XLTM / XLTX) [#53](https://github.com/nao1215/sqly/pull/53) ([nao1215](https://github.com/nao1215))
+* Bump golang.org/x/net from 0.21.0 to 0.23.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Support Microsoft Excel™ (XLAM / XLSM / XLSX / XLTM / XLTX) ([nao1215](https://github.com/nao1215))
 
 ## [v0.6.5](https://github.com/nao1215/sqly/compare/v0.6.4...v0.6.5) (2024-04-29)
 
 ## [v0.6.4](https://github.com/nao1215/sqly/compare/v0.5.2...v0.6.4) (2024-04-29)
 
-* Bump goreleaser/goreleaser-action from 2 to 5 [#50](https://github.com/nao1215/sqly/pull/50) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump actions/checkout from 3 to 4 [#52](https://github.com/nao1215/sqly/pull/52) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump actions/setup-go from 3 to 5 [#51](https://github.com/nao1215/sqly/pull/51) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Maintain dependencies for GitHub Actions [#49](https://github.com/nao1215/sqly/pull/49) ([nao1215](https://github.com/nao1215))
-* Introduce numerical sorting [#48](https://github.com/nao1215/sqly/pull/48) ([nao1215](https://github.com/nao1215))
-* Fix issue 43: Panic when importing json table with numeric field. [#47](https://github.com/nao1215/sqly/pull/47) ([nao1215](https://github.com/nao1215))
-* Fix issue 42 (bug): Panic when json field is null [#46](https://github.com/nao1215/sqly/pull/46) ([nao1215](https://github.com/nao1215))
-* Update project config [#45](https://github.com/nao1215/sqly/pull/45) ([nao1215](https://github.com/nao1215))
-* Introduce octocov [#44](https://github.com/nao1215/sqly/pull/44) ([nao1215](https://github.com/nao1215))
-* Bump github.com/google/wire from 0.5.0 to 0.6.0 [#41](https://github.com/nao1215/sqly/pull/41) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/mattn/go-sqlite3 from 1.14.19 to 1.14.22 [#40](https://github.com/nao1215/sqly/pull/40) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/mattn/go-sqlite3 from 1.14.18 to 1.14.19 [#37](https://github.com/nao1215/sqly/pull/37) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/fatih/color from 1.15.0 to 1.16.0 [#36](https://github.com/nao1215/sqly/pull/36) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/mattn/go-sqlite3 from 1.14.17 to 1.14.18 [#35](https://github.com/nao1215/sqly/pull/35) ([dependabot[bot]](https://github.com/apps/dependabot))
-* (auto merged) Bump github.com/google/go-cmp from 0.5.9 to 0.6.0 [#34](https://github.com/nao1215/sqly/pull/34) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Add automerged workflows [#33](https://github.com/nao1215/sqly/pull/33) ([nao1215](https://github.com/nao1215))
-* Bump github.com/mattn/go-sqlite3 from 1.14.16 to 1.14.17 [#32](https://github.com/nao1215/sqly/pull/32) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/nao1215/gorky from 0.2.0 to 0.2.1 [#31](https://github.com/nao1215/sqly/pull/31) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/fatih/color from 1.14.1 to 1.15.0 [#30](https://github.com/nao1215/sqly/pull/30) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Bump github.com/fatih/color from 1.13.0 to 1.14.1 [#29](https://github.com/nao1215/sqly/pull/29) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Change golden package import path [#28](https://github.com/nao1215/sqly/pull/28) ([nao1215](https://github.com/nao1215))
+* Bump goreleaser/goreleaser-action from 2 to 5 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump actions/checkout from 3 to 4 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump actions/setup-go from 3 to 5 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Maintain dependencies for GitHub Actions ([nao1215](https://github.com/nao1215))
+* Introduce numerical sorting ([nao1215](https://github.com/nao1215))
+* Fix issue 43: Panic when importing json table with numeric field. ([nao1215](https://github.com/nao1215))
+* Fix issue 42 (bug): Panic when json field is null ([nao1215](https://github.com/nao1215))
+* Update project config ([nao1215](https://github.com/nao1215))
+* Introduce octocov ([nao1215](https://github.com/nao1215))
+* Bump github.com/google/wire from 0.5.0 to 0.6.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/mattn/go-sqlite3 from 1.14.19 to 1.14.22 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/mattn/go-sqlite3 from 1.14.18 to 1.14.19 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/fatih/color from 1.15.0 to 1.16.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/mattn/go-sqlite3 from 1.14.17 to 1.14.18 ([dependabot[bot]](https://github.com/apps/dependabot))
+* (auto merged) Bump github.com/google/go-cmp from 0.5.9 to 0.6.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Add automerged workflows ([nao1215](https://github.com/nao1215))
+* Bump github.com/mattn/go-sqlite3 from 1.14.16 to 1.14.17 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/nao1215/gorky from 0.2.0 to 0.2.1 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/fatih/color from 1.14.1 to 1.15.0 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Bump github.com/fatih/color from 1.13.0 to 1.14.1 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Change golden package import path ([nao1215](https://github.com/nao1215))
 
 ## [v0.5.2](https://github.com/nao1215/sqly/compare/v0.5.1...v0.5.2) (2022-11-27)
 
-* add unit test for infra package [#27](https://github.com/nao1215/sqly/pull/27) ([nao1215](https://github.com/nao1215))
-* Add basic unit test for shell [#26](https://github.com/nao1215/sqly/pull/26) ([nao1215](https://github.com/nao1215))
-* Add unit test for model package [#24](https://github.com/nao1215/sqly/pull/24) ([nao1215](https://github.com/nao1215))
-* Bump github.com/google/go-cmp from 0.2.0 to 0.5.9 [#25](https://github.com/nao1215/sqly/pull/25) ([dependabot[bot]](https://github.com/apps/dependabot))
-* Change golden test package from goldie to golden and more [#23](https://github.com/nao1215/sqly/pull/23) ([nao1215](https://github.com/nao1215))
-* Add unit test for argument paser [#21](https://github.com/nao1215/sqly/pull/21) ([nao1215](https://github.com/nao1215))
+* add unit test for infra package ([nao1215](https://github.com/nao1215))
+* Add basic unit test for shell ([nao1215](https://github.com/nao1215))
+* Add unit test for model package ([nao1215](https://github.com/nao1215))
+* Bump github.com/google/go-cmp from 0.2.0 to 0.5.9 ([dependabot[bot]](https://github.com/apps/dependabot))
+* Change golden test package from goldie to golden and more ([nao1215](https://github.com/nao1215))
+* Add unit test for argument paser ([nao1215](https://github.com/nao1215))
 
 ## [v0.5.1](https://github.com/nao1215/sqly/compare/v0.5.0...v0.5.1) (2022-11-19)
 
-* Add sqlite3 syntax completion [#22](https://github.com/nao1215/sqly/pull/22) ([nao1215](https://github.com/nao1215))
+* Add sqlite3 syntax completion ([nao1215](https://github.com/nao1215))
 
 ## [v0.5.0](https://github.com/nao1215/sqly/compare/v0.4.0...v0.5.0) (2022-11-13)
 
-* Feat dump tsv ltsv json [#20](https://github.com/nao1215/sqly/pull/20) ([nao1215](https://github.com/nao1215))
-* Add featuer thar print date by markdown table format [#19](https://github.com/nao1215/sqly/pull/19) ([nao1215](https://github.com/nao1215))
-* Feat import ltsv [#18](https://github.com/nao1215/sqly/pull/18) ([nao1215](https://github.com/nao1215))
+* Feat dump tsv ltsv json ([nao1215](https://github.com/nao1215))
+* Add featuer thar print date by markdown table format ([nao1215](https://github.com/nao1215))
+* Feat import ltsv ([nao1215](https://github.com/nao1215))
 
 ## [v0.4.0](https://github.com/nao1215/sqly/compare/v0.3.1...v0.4.0) (2022-11-13)
 
-* Feat import tsv [#17](https://github.com/nao1215/sqly/pull/17) ([nao1215](https://github.com/nao1215))
+* Feat import tsv ([nao1215](https://github.com/nao1215))
 
 ## [v0.3.1](https://github.com/nao1215/sqly/compare/v0.3.0...v0.3.1) (2022-11-11)
 
-* Fix panic bug when import file that is without extension [#15](https://github.com/nao1215/sqly/pull/15) ([nao1215](https://github.com/nao1215))
+* Fix panic bug when import file that is without extension ([nao1215](https://github.com/nao1215))
 
 ## [v0.3.0](https://github.com/nao1215/sqly/compare/v0.2.1...v0.3.0) (2022-11-10)
 
-* Feat import json [#14](https://github.com/nao1215/sqly/pull/14) ([nao1215](https://github.com/nao1215))
-* Fix input delays when increasing records [#13](https://github.com/nao1215/sqly/pull/13) ([nao1215](https://github.com/nao1215))
+* Feat import json ([nao1215](https://github.com/nao1215))
+* Fix input delays when increasing records ([nao1215](https://github.com/nao1215))
 
 ## [v0.2.1](https://github.com/nao1215/sqly/compare/v0.2.0...v0.2.1) (2022-11-09)
 
-* Add header command [#12](https://github.com/nao1215/sqly/pull/12) ([nao1215](https://github.com/nao1215))
+* Add header command ([nao1215](https://github.com/nao1215))
 
 ## [v0.2.0](https://github.com/nao1215/sqly/compare/v0.1.1...v0.2.0) (2022-11-09)
 
-* Fixed a display collapse problem when multiple lines are entered [#11](https://github.com/nao1215/sqly/pull/11) ([nao1215](https://github.com/nao1215))
+* Fixed a display collapse problem when multiple lines are entered ([nao1215](https://github.com/nao1215))
 
 ## [v0.1.1](https://github.com/nao1215/sqly/compare/v0.1.0...v0.1.1) (2022-11-07)
 
-* Fixed a bug that caused SQL to fail if there was a trailing semicolon [#10](https://github.com/nao1215/sqly/pull/10) ([nao1215](https://github.com/nao1215))
+* Fixed a bug that caused SQL to fail if there was a trailing semicolon ([nao1215](https://github.com/nao1215))
 
 ## [v0.1.0](https://github.com/nao1215/sqly/compare/v0.0.11...v0.1.0) (2022-11-07)
 
-* Add move cursor function in intaractive shell [#9](https://github.com/nao1215/sqly/pull/9) ([nao1215](https://github.com/nao1215))
+* Add move cursor function in intaractive shell ([nao1215](https://github.com/nao1215))
 
 ## [v0.0.11](https://github.com/nao1215/sqly/compare/v0.0.10...v0.0.11) (2022-11-06)
 
-* Fixed a bug in which the wrong arguments were used [#8](https://github.com/nao1215/sqly/pull/8) ([nao1215](https://github.com/nao1215))
+* Fixed a bug in which the wrong arguments were used ([nao1215](https://github.com/nao1215))
 
 ## [v0.0.10](https://github.com/nao1215/sqly/compare/v0.0.9...v0.0.10) (2022-11-06)
 
-* Added CSV output mode [#7](https://github.com/nao1215/sqly/pull/7) ([nao1215](https://github.com/nao1215))
+* Added CSV output mode ([nao1215](https://github.com/nao1215))
 
 ## [v0.0.9](https://github.com/nao1215/sqly/compare/v0.0.7...v0.0.9) (2022-11-06)
 
 ## [v0.0.7](https://github.com/nao1215/sqly/compare/v0.0.6...v0.0.7) (2022-11-06)
 
-* Improve execute query [#6](https://github.com/nao1215/sqly/pull/6) ([nao1215](https://github.com/nao1215))
+* Improve execute query ([nao1215](https://github.com/nao1215))
 
 ## [v0.0.6](https://github.com/nao1215/sqly/compare/v0.0.5...v0.0.6) (2022-11-05)
 
 ## [v0.0.5](https://github.com/nao1215/sqly/compare/v0.0.4...v0.0.5) (2022-11-05)
 
-* Add history usecase, repository, infra. sqly manage history by sqlite3 [#5](https://github.com/nao1215/sqly/pull/5) ([nao1215](https://github.com/nao1215))
-* Add function that execute select query [#4](https://github.com/nao1215/sqly/pull/4) ([nao1215](https://github.com/nao1215))
+* Add history usecase, repository, infra. sqly manage history by sqlite3 ([nao1215](https://github.com/nao1215))
+* Add function that execute select query ([nao1215](https://github.com/nao1215))
 
 ## [v0.0.4](https://github.com/nao1215/sqly/compare/v0.0.3...v0.0.4) (2022-11-05)
 
 ## [v0.0.3](https://github.com/nao1215/sqly/compare/v0.0.2...v0.0.3) (2022-11-05)
 
-* Add import command [#3](https://github.com/nao1215/sqly/pull/3) ([nao1215](https://github.com/nao1215))
+* Add import command ([nao1215](https://github.com/nao1215))
 
 ## [v0.0.2](https://github.com/nao1215/sqly/compare/v0.0.1...v0.0.2) (2022-11-05)
 
-* Add .tables command [#2](https://github.com/nao1215/sqly/pull/2) ([nao1215](https://github.com/nao1215))
-* Add .exit/.help command and history manager [#1](https://github.com/nao1215/sqly/pull/1) ([nao1215](https://github.com/nao1215))
+* Add .tables command ([nao1215](https://github.com/nao1215))
+* Add .exit/.help command and history manager ([nao1215](https://github.com/nao1215))
 
 ## [v0.0.1](https://github.com/nao1215/sqly/compare/dbf99896449e...v0.0.1) (2022-11-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,7 +364,7 @@
 ## [v0.12.2](https://github.com/nao1215/sqly/compare/v0.12.1...v0.12.2) (2025-09-17)
 
 ### Bug Fixes
-* **Table Names**: Fix SQL syntax errors caused by special characters in filenames ()
+* **Table Names**: Fix SQL syntax errors caused by special characters in filenames
   - Automatically sanitize table names by replacing problematic characters (hyphens, dots, special chars) with underscores
   - Example: `bug-syntax-error.csv` now creates table `bug_syntax_error` instead of failing with syntax error
   - Added comprehensive test coverage for filename sanitization edge cases

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Run `sqly` without `--sql` to open the shell. It behaves like `sqlite3` or `mysq
 
 ```shell
 $ sqly testdata/user.csv
-sqly v0.21.0
+sqly v0.22.0
 
 enter "SQL query" or "sqly command that begins with a dot".
 .help print usage, .exit exit sqly.
@@ -400,7 +400,7 @@ SELECT * FROM `customers100000` WHERE `Index` BETWEEN 1000 AND 2000 ORDER BY `In
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.21.0. Run `make bench` to reproduce on your machine.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.22.0. Run `make bench` to reproduce on your machine.
 
 ## Comparison with similar tools
 

--- a/config/argument.go
+++ b/config/argument.go
@@ -82,7 +82,7 @@ type Arg struct {
 }
 
 // Output mode flag names, shared by the flag registration and the conflict
-// check so the strings are defined once. Ref #365.
+// check so the strings are defined once.
 const (
 	outCSV      = "csv"
 	outTSV      = "tsv"
@@ -108,7 +108,7 @@ type outputFlag struct {
 
 // selectedNames returns the names of the output mode flags that are set. More
 // than one means the user passed conflicting mode flags, which NewArg rejects
-// instead of silently applying a precedence. Ref #365.
+// instead of silently applying a precedence.
 func (of outputFlag) selectedNames() []string {
 	flags := []struct {
 		name string
@@ -149,7 +149,7 @@ func NewArg(args []string) (*Arg, error) {
 	// zero-value pflag.FlagSet disables this, which silently turns a misplaced
 	// flag (e.g. "sqly data.csv --output out") and its value into import paths
 	// that fail with "path does not exist". Interspersed parsing instead applies
-	// the flag, and an unknown flag fails fast with a clear parse error. Ref #264.
+	// the flag, and an unknown flag fails fast with a clear parse error.
 	flag.SetInterspersed(true)
 	flag.BoolVarP(&oFlag.csv, outCSV, "c", false, "change output format to csv (default: table)")
 	flag.BoolVarP(&oFlag.excel, outExcel, "e", false, "change output format to excel (default: table)")
@@ -178,14 +178,14 @@ func NewArg(args []string) (*Arg, error) {
 
 	// An explicit empty --sheet ("--sheet \"\"") is a mistake: the empty string
 	// is the "no sheet selected" sentinel, so accepting it would silently behave
-	// like the flag was never passed. Reject it so the error is visible. Ref #313.
+	// like the flag was never passed. Reject it so the error is visible.
 	if flag.Changed("sheet") && *sheetName == "" {
 		return nil, errEmptySheet
 	}
 
 	// Reject other flags given an explicit empty value for the same reason: each
 	// flag's empty string is the "flag absent" sentinel, so an explicit "" would
-	// otherwise be silently ignored. Ref #349, #350, #352, #353.
+	// otherwise be silently ignored.
 	if flag.Changed("output") && *output == "" {
 		return nil, errEmptyOutput
 	}
@@ -200,20 +200,20 @@ func NewArg(args []string) (*Arg, error) {
 	}
 
 	// --stdin-name only names the --stdin dataset, so it has no effect without
-	// --stdin. Reject it when set alone instead of silently ignoring it. Ref #391.
+	// --stdin. Reject it when set alone instead of silently ignoring it.
 	if flag.Changed("stdin-name") && *stdinFormat == "" {
 		return nil, errStdinNameWithoutStdin
 	}
 
 	// --inspect-sample only caps the rows --inspect samples, so it has no effect
 	// without --inspect. Reject it (including invalid values like -1) when set
-	// without --inspect instead of silently ignoring it. Ref #392.
+	// without --inspect instead of silently ignoring it.
 	if flag.Changed("inspect-sample") && !arg.InspectFlag {
 		return nil, errInspectSampleWithoutInspect
 	}
 
 	// --force only confirms the destructive --save write-back, so it has no effect
-	// without --save/--save-dir. Reject it when set alone. Ref #393.
+	// without --save/--save-dir. Reject it when set alone.
 	if arg.Force && !arg.SaveInPlace && *saveDir == "" {
 		return nil, errForceWithoutSave
 	}
@@ -221,7 +221,7 @@ func NewArg(args []string) (*Arg, error) {
 	// Validate --stdin-name so it cannot be empty or contain path separators.
 	// The name becomes a staging filename; a value like "" or "../escaped" would
 	// otherwise create odd hidden files or write outside the temp directory. Ref
-	// #305. Only meaningful with --stdin, so validate only when staging applies.
+	//. Only meaningful with --stdin, so validate only when staging applies.
 	if *stdinFormat != "" {
 		if err := validateStdinName(*stdinName); err != nil {
 			return nil, err
@@ -230,7 +230,7 @@ func NewArg(args []string) (*Arg, error) {
 
 	// Reject conflicting output mode flags (e.g. --csv --json) instead of
 	// silently applying an internal precedence, which would discard the other
-	// flags without warning. Ref #365.
+	// flags without warning.
 	if names := oFlag.selectedNames(); len(names) > 1 {
 		return nil, fmt.Errorf("conflicting output mode flags: %s; choose one", strings.Join(names, ", "))
 	}
@@ -252,7 +252,7 @@ func NewArg(args []string) (*Arg, error) {
 
 // validateStdinName rejects a --stdin-name that is empty or path-like. The name
 // is used as a staging file name, so path separators or "."/".." could escape
-// the temp directory or create surprising files. Ref #305.
+// the temp directory or create surprising files.
 func validateStdinName(name string) error {
 	if name == "" {
 		return errInvalidStdinName
@@ -265,13 +265,13 @@ func validateStdinName(name string) error {
 	}
 	// Require a bare-identifier name so the advertised --stdin-name is the exact
 	// queryable table name. Otherwise filesql sanitizes spaces and dashes (e.g.
-	// "my data" -> "my_data"), leaving the name the user gave unusable. Ref #289.
+	// "my data" -> "my_data"), leaving the name the user gave unusable.
 	if !isValidTableIdentifier(name) {
 		return errInvalidStdinName
 	}
 	// A SQLite keyword has a valid identifier shape but is not queryable as a bare
 	// table name (e.g. "SELECT * FROM select" is a syntax error), so reject it
-	// instead of advertising an unusable name. Ref #423.
+	// instead of advertising an unusable name.
 	if model.IsReservedSQLiteKeyword(name) {
 		return errStdinNameReserved
 	}

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -151,7 +151,7 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("--output after file path sets output destination, not an import path (#264)", func(t *testing.T) {
+	t.Run("--output after file path sets output destination, not an import path", func(t *testing.T) {
 		testFile := filepath.Join(t.TempDir(), "result.csv")
 		arg, err := NewArg([]string{"sqly", "--sql", "SELECT * FROM user", "testdata/user.csv", "--output", testFile})
 		if err != nil {
@@ -165,7 +165,7 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("output-mode flag after file path sets mode, not an import path (#264)", func(t *testing.T) {
+	t.Run("output-mode flag after file path sets mode, not an import path", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "--sql", "SELECT * FROM user", "testdata/user.csv", "--csv"})
 		if err != nil {
 			t.Fatal(err)
@@ -178,7 +178,7 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("flags interspersed among file paths are not imported as paths (#264)", func(t *testing.T) {
+	t.Run("flags interspersed among file paths are not imported as paths", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "testdata/user.csv", "--json", "testdata/identifier.csv", "--sql", "SELECT 1"})
 		if err != nil {
 			t.Fatal(err)
@@ -194,14 +194,14 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("unknown flag after file path returns a parse error (#264)", func(t *testing.T) {
+	t.Run("unknown flag after file path returns a parse error", func(t *testing.T) {
 		_, err := NewArg([]string{"sqly", "testdata/user.csv", "--nope"})
 		if err == nil {
 			t.Fatal("expected a parse error for an unknown flag, got nil")
 		}
 	})
 
-	t.Run("--sql-file sets the SQL file path (#281)", func(t *testing.T) {
+	t.Run("--sql-file sets the SQL file path", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "--sql-file", "query.sql", "testdata/user.csv"})
 		if err != nil {
 			t.Fatal(err)
@@ -214,7 +214,7 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("sql file path defaults to empty (#281)", func(t *testing.T) {
+	t.Run("sql file path defaults to empty", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "testdata/user.csv"})
 		if err != nil {
 			t.Fatal(err)
@@ -224,7 +224,7 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid --stdin-name values are rejected (#305)", func(t *testing.T) {
+	t.Run("invalid --stdin-name values are rejected", func(t *testing.T) {
 		for _, name := range []string{"", ".", "..", "a/b", "../escaped", `a\b`} {
 			if _, err := NewArg([]string{"sqly", "--stdin", "csv", "--stdin-name", name}); err == nil {
 				t.Errorf("NewArg accepted invalid --stdin-name %q, want error", name)
@@ -232,7 +232,7 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("non-identifier --stdin-name values are rejected (#289)", func(t *testing.T) {
+	t.Run("non-identifier --stdin-name values are rejected", func(t *testing.T) {
 		// These would be sanitized by filesql, leaving the advertised name
 		// unqueryable, so they are rejected up front.
 		for _, name := range []string{"my data", "2023-data", "a-b", "weird!"} {
@@ -242,48 +242,48 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("a normal --stdin-name is accepted (#305)", func(t *testing.T) {
+	t.Run("a normal --stdin-name is accepted", func(t *testing.T) {
 		if _, err := NewArg([]string{"sqly", "--stdin", "csv", "--stdin-name", "people"}); err != nil {
 			t.Errorf("NewArg rejected a valid --stdin-name: %v", err)
 		}
 	})
 
-	t.Run("explicit empty --sheet is rejected (#313)", func(t *testing.T) {
+	t.Run("explicit empty --sheet is rejected", func(t *testing.T) {
 		_, err := NewArg([]string{"sqly", "--sheet", "", "testdata/user.csv"})
 		if err == nil {
 			t.Fatal("expected an error for an explicit empty --sheet, got nil")
 		}
 	})
 
-	t.Run("explicit empty --output is rejected (#349)", func(t *testing.T) {
+	t.Run("explicit empty --output is rejected", func(t *testing.T) {
 		_, err := NewArg([]string{"sqly", "--sql", "SELECT 1 AS x", "--output", ""})
 		if err == nil {
 			t.Fatal("expected an error for an explicit empty --output, got nil")
 		}
 	})
 
-	t.Run("explicit empty --sql-file is rejected (#350)", func(t *testing.T) {
+	t.Run("explicit empty --sql-file is rejected", func(t *testing.T) {
 		_, err := NewArg([]string{"sqly", "--sql-file", ""})
 		if err == nil {
 			t.Fatal("expected an error for an explicit empty --sql-file, got nil")
 		}
 	})
 
-	t.Run("explicit empty --save-dir is rejected (#352)", func(t *testing.T) {
+	t.Run("explicit empty --save-dir is rejected", func(t *testing.T) {
 		_, err := NewArg([]string{"sqly", "--sql", "SELECT 1", "--save-dir", "", "testdata/user.csv"})
 		if err == nil {
 			t.Fatal("expected an error for an explicit empty --save-dir, got nil")
 		}
 	})
 
-	t.Run("explicit empty --stdin is rejected (#353)", func(t *testing.T) {
+	t.Run("explicit empty --stdin is rejected", func(t *testing.T) {
 		_, err := NewArg([]string{"sqly", "--stdin", "", "--sql", "SELECT 1 AS x"})
 		if err == nil {
 			t.Fatal("expected an error for an explicit empty --stdin, got nil")
 		}
 	})
 
-	t.Run("conflicting output mode flags are rejected (#365)", func(t *testing.T) {
+	t.Run("conflicting output mode flags are rejected", func(t *testing.T) {
 		for _, args := range [][]string{
 			{"sqly", "--csv", "--json", "--sql", "SELECT 1 AS x"},
 			{"sqly", "--tsv", "--json", "--sql", "SELECT 1 AS x"},
@@ -295,13 +295,13 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("a single output mode flag is accepted (#365)", func(t *testing.T) {
+	t.Run("a single output mode flag is accepted", func(t *testing.T) {
 		if _, err := NewArg([]string{"sqly", "--json", "--sql", "SELECT 1 AS x"}); err != nil {
 			t.Errorf("NewArg with a single output mode flag returned an error: %v", err)
 		}
 	})
 
-	t.Run("--inspect sets the inspect flag (#259)", func(t *testing.T) {
+	t.Run("--inspect sets the inspect flag", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "--inspect", "testdata/user.csv"})
 		if err != nil {
 			t.Fatal(err)
@@ -314,7 +314,7 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
-	t.Run("inspect flag defaults to false (#259)", func(t *testing.T) {
+	t.Run("inspect flag defaults to false", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "testdata/user.csv"})
 		if err != nil {
 			t.Fatal(err)
@@ -415,9 +415,8 @@ func getStdout(t *testing.T, f func()) string {
 }
 
 // TestNewArgDependentFlagValidation covers the v0.19.0 flag-dependency bugs:
-// --stdin-name without --stdin (#391), --inspect-sample without --inspect (#392),
-// --force without --save/--save-dir (#393), and a SQLite-keyword --stdin-name
-// (#423).
+// --stdin-name without --stdin, --inspect-sample without --inspect,
+// --force without --save/--save-dir, and a SQLite-keyword --stdin-name
 func TestNewArgDependentFlagValidation(t *testing.T) {
 	t.Parallel()
 

--- a/config/db.go
+++ b/config/db.go
@@ -93,7 +93,7 @@ func (d sqliteDriver) Open(name string) (driver.Conn, error) {
 	// SQLITE_BUSY. The history DB is a shared file, so two sqly processes can write
 	// it concurrently; without a busy timeout one process would disable history on
 	// transient lock contention and print a misleading "set a writable path"
-	// warning even though the path is writable. Ref #399.
+	// warning even though the path is writable.
 	if _, err := c.Exec("PRAGMA busy_timeout = 5000;", nil); err != nil {
 		if err := conn.Close(); err != nil {
 			return nil, fmt.Errorf("failed to close connection: %w", err)

--- a/config/errors.go
+++ b/config/errors.go
@@ -19,7 +19,7 @@ var errInvalidStdinName = errors.New("--stdin-name must be a valid table name: l
 // returned when their flag is given an explicit empty value. For each flag the
 // empty string is the "flag absent" sentinel, so accepting an explicit "" would
 // silently behave like the flag was never passed instead of surfacing the
-// malformed value. Ref #349, #350, #352, #353.
+// malformed value.
 var (
 	errEmptyOutput  = errors.New("--output requires a non-empty destination path")
 	errEmptySQLFile = errors.New("--sql-file requires a non-empty file path")
@@ -30,12 +30,12 @@ var (
 // errStdinNameReserved is returned when --stdin-name is a SQLite keyword. Such a
 // name is a valid identifier shape but is not queryable as a bare table name
 // (e.g. "SELECT * FROM select" is a syntax error), so it is rejected up front
-// instead of advertising an unusable table name. Ref #423.
+// instead of advertising an unusable table name.
 var errStdinNameReserved = errors.New("--stdin-name is a SQLite keyword and is not queryable as a bare table name; choose another name")
 
 // errStdinNameWithoutStdin and errInspectSampleWithoutInspect are returned when
 // a dependent flag is set without the flag that gives it meaning, so the flag is
-// not silently ignored. Ref #391, #392.
+// not silently ignored.
 var (
 	errStdinNameWithoutStdin       = errors.New("--stdin-name has no effect without --stdin FORMAT")
 	errInspectSampleWithoutInspect = errors.New("--inspect-sample has no effect without --inspect")
@@ -43,5 +43,5 @@ var (
 
 // errForceWithoutSave is returned when --force is set without --save or
 // --save-dir. --force only confirms the destructive in-place write-back, so it
-// is meaningless on its own and is rejected instead of silently ignored. Ref #393.
+// is meaningless on its own and is rejected instead of silently ignored.
 var errForceWithoutSave = errors.New("--force has no effect without --save or --save-dir")

--- a/domain/model/export.go
+++ b/domain/model/export.go
@@ -15,6 +15,12 @@ var ErrOutputFormatConflict = errors.New("output format conflicts with destinati
 // written for the chosen format (binary formats, or bzip2 which has no writer).
 var ErrCompressionUnsupported = errors.New("compression is not supported for this output")
 
+// ErrNestedCompression is returned when a destination path stacks more than one
+// trailing compression suffix (e.g. ".csv.gz.zst"). sqly applies only the
+// outermost codec, so accepting such a path would leave the inner suffix lying
+// about the bytes on disk.
+var ErrNestedCompression = errors.New("nested compression suffixes are not supported")
+
 // ExportFormat represents a file export format, separate from display modes.
 // This allows adding new export targets (e.g. Parquet, compressed formats)
 // without modifying the terminal display mode enum.
@@ -224,6 +230,14 @@ func CompressionFromExtension(ext string) (Compression, bool) {
 // Compression on a binary format, or bzip2 (no writer), returns
 // ErrCompressionUnsupported.
 func ResolveOutputTarget(path string, explicit ExportFormat, explicitSet bool) (ExportFormat, Compression, error) {
+	// Reject stacked compression suffixes up front. Only the outermost codec is
+	// applied, so a path like "out.csv.gz.zst" or "fake.parquet.gz.zst" would write
+	// a single-codec file under a name that advertises a different (or binary)
+	// format. Fail instead of producing a mislabeled artifact.
+	if hasNestedCompressionSuffix(path) {
+		return 0, CompressionNone, fmt.Errorf("%w: %q stacks multiple codecs; use a single compression suffix", ErrNestedCompression, path)
+	}
+
 	comp := CompressionNone
 	base := path
 	if c, ok := CompressionFromExtension(filepath.Ext(path)); ok {
@@ -291,7 +305,7 @@ func BuildOutputPath(path string, format ExportFormat, comp Compression) string 
 // compression suffixes are stripped first, so a path that hides the extension
 // behind several codecs (".ach.gz.zst", ".fed.gz.zst") is detected too. It lets
 // --output and .dump reject these destinations instead of silently writing CSV
-// bytes to a misleading path. Ref #421, #422, #459, #460.
+// bytes to a misleading path.
 func IsInputOnlyExtension(path string) bool {
 	switch strings.ToLower(filepath.Ext(stripCompressionSuffixes(path))) {
 	case ".ach", ".fed":
@@ -301,9 +315,20 @@ func IsInputOnlyExtension(path string) bool {
 	}
 }
 
+// hasNestedCompressionSuffix reports whether path ends in two or more stacked
+// compression suffixes (e.g. "out.csv.gz.zst" or "fake.parquet.gz.zst").
+func hasNestedCompressionSuffix(path string) bool {
+	if _, ok := CompressionFromExtension(filepath.Ext(path)); !ok {
+		return false
+	}
+	inner := strings.TrimSuffix(path, filepath.Ext(path))
+	_, ok := CompressionFromExtension(filepath.Ext(inner))
+	return ok
+}
+
 // stripCompressionSuffixes removes every trailing compression extension from a
 // path (e.g. "out.ach.gz.zst" -> "out.ach"), so a check on the remaining base
-// extension is not fooled by stacked codecs. Ref #459, #460.
+// extension is not fooled by stacked codecs.
 func stripCompressionSuffixes(path string) string {
 	for {
 		if _, ok := CompressionFromExtension(filepath.Ext(path)); !ok {

--- a/domain/model/export_test.go
+++ b/domain/model/export_test.go
@@ -394,8 +394,7 @@ func TestIsInputOnlyExtension(t *testing.T) {
 		{"out.ACH", true},
 		{"out.ach.gz", true},
 		{"out.fed.zst", true},
-		// Multiple stacked compression suffixes must still be seen through. Ref
-		//,.
+		// Multiple stacked compression suffixes must still be seen through.
 		{"out.ach.gz.zst", true},
 		{"out.fed.gz.zst", true},
 		{"out.ach.gz.gz.gz", true},

--- a/domain/model/export_test.go
+++ b/domain/model/export_test.go
@@ -221,13 +221,13 @@ func TestResolveOutputTarget(t *testing.T) {
 			wantComp:    CompressionNone,
 		},
 		{
-			name:       "unknown extension with no flag falls back to csv (#292)",
+			name:       "unknown extension with no flag falls back to csv",
 			path:       "result.txt",
 			wantFormat: ExportCSV,
 			wantComp:   CompressionNone,
 		},
 		{
-			name:        "unknown extension with an explicit format is kept (#292)",
+			name:        "unknown extension with an explicit format is kept",
 			path:        "result.txt",
 			explicit:    ExportCSV,
 			explicitSet: true,
@@ -251,6 +251,21 @@ func TestResolveOutputTarget(t *testing.T) {
 			explicitSet: true,
 			wantFormat:  ExportCSV,
 			wantComp:    CompressionGzip,
+		},
+		{
+			name:    "nested csv compression suffixes are rejected",
+			path:    "double.csv.gz.zst",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "nested parquet compression suffixes are rejected",
+			path:    "fake.parquet.gz.zst",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "nested xlsx compression suffixes are rejected",
+			path:    "fake.xlsx.gz.zst",
+			wantErr: ErrNestedCompression,
 		},
 	}
 	for _, tt := range tests {
@@ -292,8 +307,8 @@ func TestBuildOutputPath(t *testing.T) {
 		{name: "rebuilds base and appends gzip", path: "result.gz", format: ExportCSV, comp: CompressionGzip, want: "result.csv.gz"},
 		{name: "replaces mismatched extension", path: "data.json", format: ExportNDJSON, comp: CompressionNone, want: "data.ndjson"},
 		{name: "keeps ndjson.zst path", path: "out.ndjson.zst", format: ExportNDJSON, comp: CompressionZstd, want: "out.ndjson.zst"},
-		{name: "honors an unknown extension (#292)", path: "out.txt", format: ExportCSV, comp: CompressionNone, want: "out.txt"},
-		{name: "honors an unknown extension with compression (#292)", path: "out.txt.gz", format: ExportCSV, comp: CompressionGzip, want: "out.txt.gz"},
+		{name: "honors an unknown extension", path: "out.txt", format: ExportCSV, comp: CompressionNone, want: "out.txt"},
+		{name: "honors an unknown extension with compression", path: "out.txt.gz", format: ExportCSV, comp: CompressionGzip, want: "out.txt.gz"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -367,7 +382,7 @@ func TestExportFormatFromPrintMode(t *testing.T) {
 }
 
 // TestIsInputOnlyExtension covers rejecting ACH/Fedwire export destinations,
-// including compressed variants. Ref #421, #422.
+// including compressed variants.
 func TestIsInputOnlyExtension(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -380,7 +395,7 @@ func TestIsInputOnlyExtension(t *testing.T) {
 		{"out.ach.gz", true},
 		{"out.fed.zst", true},
 		// Multiple stacked compression suffixes must still be seen through. Ref
-		// #459, #460.
+		//,.
 		{"out.ach.gz.zst", true},
 		{"out.fed.gz.zst", true},
 		{"out.ach.gz.gz.gz", true},

--- a/domain/model/sqlkeyword.go
+++ b/domain/model/sqlkeyword.go
@@ -5,7 +5,7 @@ import "strings"
 // reservedSQLiteKeywords is the set of SQLite keywords that are not usable as a
 // bare table identifier in a query such as "SELECT * FROM <name>". A table whose
 // name is one of these must be quoted, so sqly rejects such a --stdin-name up
-// front (#423) and renames an imported file's table to a queryable form (#424).
+// front and renames an imported file's table to a queryable form.
 // Source: https://www.sqlite.org/lang_keywords.html.
 var reservedSQLiteKeywords = func() map[string]struct{} {
 	words := []string{

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -341,7 +341,6 @@ func (t *Table) printTable(out io.Writer) error {
 // markdownCell renders a cell for a Markdown table. A "|" is escaped so it does
 // not start a new column, and an embedded newline is replaced with "<br>" so a
 // multi-line value stays on one physical row instead of breaking the table. Ref
-// #426.
 func markdownCell(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.ReplaceAll(s, "\r", "\n")
@@ -378,14 +377,14 @@ func (t *Table) printMarkdownTable(out io.Writer) {
 // printCSV print all record with header; output format is csv. It uses a CSV
 // writer so values that contain commas, quotes, or newlines are quoted and
 // escaped, matching the --output file path and staying valid when redirected to
-// a file or piped to a CSV-aware tool. Ref #380.
+// a file or piped to a CSV-aware tool.
 func (t *Table) printCSV(out io.Writer) error {
 	return t.writeDelimited(out, ',')
 }
 
 // printTSV print all record with header; output format is tsv. Like printCSV it
 // uses a writer that quotes values containing the delimiter, quotes, or newlines,
-// so the stream stays a valid tabular record when redirected or piped. Ref #381.
+// so the stream stays a valid tabular record when redirected or piped.
 func (t *Table) printTSV(out io.Writer) error {
 	return t.writeDelimited(out, '\t')
 }
@@ -411,7 +410,7 @@ func (t *Table) writeDelimited(out io.Writer, comma rune) error {
 // escaping mechanism: a tab separates fields and a newline ends a record, so a
 // value containing either cannot be represented losslessly. Reject such a value
 // up front instead of emitting output that no longer round-trips as LTSV. Ref
-// #382, #383.
+// ,.
 func (t *Table) printLTSV(out io.Writer) error {
 	if err := EnsureLTSVHeaderWritable(t.Header()); err != nil {
 		return err
@@ -433,7 +432,7 @@ func (t *Table) printLTSV(out io.Writer) error {
 // [0-9A-Za-z_.-]+ (https://ltsv.org). A label outside this set — empty, or
 // containing ':', a space, a tab, or any other character — cannot be written as a
 // distinct "label:value" field that re-imports to the same column, so the LTSV
-// writers reject it. Ref #465.
+// writers reject it.
 func isValidLTSVLabel(label string) bool {
 	if label == "" {
 		return false
@@ -456,7 +455,6 @@ func isValidLTSVLabel(label string) bool {
 // column as a "label:value" field with no escaping, so an invalid label (e.g.
 // "foo:bar") is ambiguous on re-import and a duplicate label silently keeps only
 // the last value. Rejecting both up front keeps LTSV output round-trippable.
-// Ref #465, #466.
 func EnsureLTSVHeaderWritable(header Header) error {
 	seen := make(map[string]struct{}, len(header))
 	for _, label := range header {
@@ -473,7 +471,7 @@ func EnsureLTSVHeaderWritable(header Header) error {
 
 // ensureLTSVValueRepresentable reports an error when a value contains a byte LTSV
 // cannot represent (tab or newline), so the caller rejects it before writing
-// output that cannot be re-imported as LTSV. Ref #382, #383.
+// output that cannot be re-imported as LTSV.
 func ensureLTSVValueRepresentable(label, value string) error {
 	if strings.ContainsAny(value, "\t\n\r") {
 		return fmt.Errorf("ltsv: value for column %q contains a tab or newline, which LTSV cannot represent; use csv/tsv/json for such values", label)
@@ -530,7 +528,7 @@ func (t *Table) rowToJSONObject(row int, record Record) ([]byte, error) {
 // duplicateColumnName returns the first column name that appears more than once
 // in the header, or "" when all names are unique. JSON objects with duplicate
 // keys are ambiguous for downstream parsers, so the JSON/NDJSON writers reject
-// such a result instead of emitting it. Ref #384, #385.
+// such a result instead of emitting it.
 func (t *Table) duplicateColumnName() string {
 	seen := make(map[string]struct{}, len(t.header))
 	for _, h := range t.header {

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -453,7 +453,7 @@ aaa:777	bbb:888	ccc:999
 
 func TestTablePrintJSON_NullDistinctFromEmpty(t *testing.T) {
 	t.Parallel()
-	// Regression for/: a SQL NULL must render as JSON null, distinct
+	// Regression test: a SQL NULL must render as JSON null, distinct
 	// from an empty string. The null mask marks column 0 (n) as NULL; column 1
 	// (e) is a real empty string.
 	tbl := NewTable("t", Header{"n", "e", "x"}, []Record{{"", "", "1"}})
@@ -769,11 +769,11 @@ func TestIsAllNumeric(t *testing.T) {
 	}
 }
 
-// TestTablePrintEscaping covers the v0.19.0 output-format bugs: CSV/TSV stdout
-// must stay valid when values contain the delimiter, quotes, or newlines (,
-// ); LTSV must reject values it cannot represent losslessly;
-// JSON/NDJSON must reject duplicate column names; and Markdown must
-// keep a row on one physical line when a value contains a newline.
+// TestTablePrintEscaping covers the output-format bugs: CSV/TSV stdout must
+// stay valid when values contain the delimiter, quotes, or newlines; LTSV must
+// reject values it cannot represent losslessly; JSON/NDJSON must reject
+// duplicate column names; and Markdown must keep a row on one physical line
+// when a value contains a newline.
 func TestTablePrintEscaping(t *testing.T) {
 	t.Parallel()
 

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -453,7 +453,7 @@ aaa:777	bbb:888	ccc:999
 
 func TestTablePrintJSON_NullDistinctFromEmpty(t *testing.T) {
 	t.Parallel()
-	// Regression for #328/#329: a SQL NULL must render as JSON null, distinct
+	// Regression for/: a SQL NULL must render as JSON null, distinct
 	// from an empty string. The null mask marks column 0 (n) as NULL; column 1
 	// (e) is a real empty string.
 	tbl := NewTable("t", Header{"n", "e", "x"}, []Record{{"", "", "1"}})
@@ -770,10 +770,10 @@ func TestIsAllNumeric(t *testing.T) {
 }
 
 // TestTablePrintEscaping covers the v0.19.0 output-format bugs: CSV/TSV stdout
-// must stay valid when values contain the delimiter, quotes, or newlines (#380,
-// #381); LTSV must reject values it cannot represent losslessly (#382, #383);
-// JSON/NDJSON must reject duplicate column names (#384, #385); and Markdown must
-// keep a row on one physical line when a value contains a newline (#426).
+// must stay valid when values contain the delimiter, quotes, or newlines (,
+// ); LTSV must reject values it cannot represent losslessly;
+// JSON/NDJSON must reject duplicate column names; and Markdown must
+// keep a row on one physical line when a value contains a newline.
 func TestTablePrintEscaping(t *testing.T) {
 	t.Parallel()
 
@@ -873,7 +873,7 @@ func TestTablePrintEscaping(t *testing.T) {
 
 // TestEnsureLTSVHeaderWritable verifies that LTSV output rejects column names that
 // are not valid LTSV labels and rejects duplicate labels, so LTSV output stays
-// valid and round-trippable. Ref #465, #466.
+// valid and round-trippable.
 func TestEnsureLTSVHeaderWritable(t *testing.T) {
 	t.Parallel()
 
@@ -913,7 +913,6 @@ func TestEnsureLTSVHeaderWritable(t *testing.T) {
 
 // TestTablePrintLTSV_RejectsInvalidLabels verifies that printing a table as LTSV
 // fails for an invalid or duplicate label rather than emitting ambiguous output.
-// Ref #465, #466.
 func TestTablePrintLTSV_RejectsInvalidLabels(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/filesql/adapter.go
+++ b/infrastructure/filesql/adapter.go
@@ -77,7 +77,7 @@ func (f *FileSQLAdapter) LoadFiles(ctx context.Context, filePaths ...string) err
 	// An empty JSON array ("[]") or an empty JSONL file is valid JSON input but
 	// has no rows. filesql rejects it as an empty data source, so handle those
 	// files here as zero-row tables (a single "data" column, matching filesql's
-	// JSON schema) before delegating the rest to filesql. Ref #388, #389.
+	// JSON schema) before delegating the rest to filesql.
 	var toLoad []string
 	for _, path := range filePaths {
 		name, isEmpty := emptyJSONLikeTable(path)
@@ -112,8 +112,7 @@ const jsonDataColumn = "data"
 // JSON, or an empty/blank-only JSONL file), returning the table name to create for
 // it. The format is decided by the base extension after any compression suffix is
 // stripped, and the content is read through filesql's decompressor so a compressed
-// empty input is detected the same as an uncompressed one. Ref #388, #389, #452,
-// #453.
+// empty input is detected the same as an uncompressed one.,
 func emptyJSONLikeTable(path string) (string, bool) {
 	switch strings.ToLower(filepath.Ext(stripCompressionExt(path))) {
 	case model.ExtJSON:
@@ -160,7 +159,7 @@ func stripCompressionExt(path string) string {
 
 // readDecompressed reads the full content of path, transparently decompressing it
 // when its extension names a known codec. It backs the empty JSON/JSONL detection
-// for both plain and compressed inputs. Ref #452, #453.
+// for both plain and compressed inputs.
 func readDecompressed(path string) ([]byte, error) {
 	r, cleanup, err := NewDecompressingReaderForFile(path)
 	if err != nil {
@@ -172,7 +171,7 @@ func readDecompressed(path string) ([]byte, error) {
 
 // createEmptyJSONTable creates (last-wins) a zero-row table with filesql's JSON
 // "data" column, so an empty JSON/JSONL input imports as an empty table instead
-// of failing. Ref #388, #389.
+// of failing.
 func (f *FileSQLAdapter) createEmptyJSONTable(ctx context.Context, name string) error {
 	quoted := QuoteIdentifier(name)
 	if _, err := f.sharedDB.ExecContext(ctx, "DROP TABLE IF EXISTS "+quoted); err != nil {

--- a/infrastructure/filesql/adapter_test.go
+++ b/infrastructure/filesql/adapter_test.go
@@ -1562,7 +1562,7 @@ func BenchmarkAdapterLoadFiles(b *testing.B) {
 
 // TestFileSQLAdapter_EmptyJSONLikeInputs verifies that an empty JSON array and an
 // empty JSONL file import as zero-row tables (with filesql's "data" column)
-// instead of failing as an empty data source. Ref #388, #389.
+// instead of failing as an empty data source.
 func TestFileSQLAdapter_EmptyJSONLikeInputs(t *testing.T) {
 	t.Parallel()
 
@@ -1639,7 +1639,7 @@ func gzipFile(t *testing.T, path string, data []byte) {
 // TestFileSQLAdapter_EmptyCompressedJSONLike verifies that an empty compressed
 // JSON array (.json.gz) and an empty compressed JSONL file (.jsonl.gz) import as a
 // zero-row table with the single "data" column, matching the uncompressed empty
-// inputs. Ref #452, #453.
+// inputs.
 func TestFileSQLAdapter_EmptyCompressedJSONLike(t *testing.T) {
 	t.Parallel()
 
@@ -1694,7 +1694,7 @@ func TestFileSQLAdapter_EmptyCompressedJSONLike(t *testing.T) {
 
 // TestFileSQLAdapter_LTSVDuplicateLabelsRejected verifies that an LTSV input whose
 // row repeats a label is rejected rather than silently keeping only the last
-// value. Ref #467.
+// value.
 func TestFileSQLAdapter_LTSVDuplicateLabelsRejected(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/filesql/compression.go
+++ b/infrastructure/filesql/compression.go
@@ -40,7 +40,7 @@ func compressionToLib(c model.Compression) (libfilesql.CompressionType, error) {
 // uncompressed file it returns a plain file reader. It reuses filesql's codecs so
 // sqly does not depend on the compression libraries directly, and lets the adapter
 // inspect compressed JSON/JSONL inputs (e.g. an empty "[]") the same way it
-// inspects uncompressed ones. Ref #452, #453.
+// inspects uncompressed ones.
 func NewDecompressingReaderForFile(path string) (io.Reader, func() error, error) {
 	return libfilesql.NewCompressionFactory().CreateReaderForFile(path)
 }

--- a/infrastructure/filesql/issue218_test.go
+++ b/infrastructure/filesql/issue218_test.go
@@ -39,6 +39,6 @@ func TestIssue218LargeIntegerPreserved(t *testing.T) {
 		t.Fatalf("query failed: %v", err)
 	}
 	if want := "11040320260000000000"; got != want {
-		t.Errorf("ctsn = %q, want %q (scientific-notation regression of sqly#218)", got, want)
+		t.Errorf("ctsn = %q, want %q (scientific-notation regression of sqly)", got, want)
 	}
 }

--- a/infrastructure/filesql/parquet_test.go
+++ b/infrastructure/filesql/parquet_test.go
@@ -77,9 +77,9 @@ func TestDumpTableToParquet_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestDumpTableToParquet_EmptyResult covers the empty-result behavior required
-// by. Parquet needs at least one row to infer its schema, so exporting an
-// empty result returns a clear error rather than writing an unreadable file.
+// TestDumpTableToParquet_EmptyResult covers the empty-result behavior: Parquet
+// needs at least one row to infer its schema, so exporting an empty result
+// returns a clear error rather than writing an unreadable file.
 func TestDumpTableToParquet_EmptyResult(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/filesql/parquet_test.go
+++ b/infrastructure/filesql/parquet_test.go
@@ -28,7 +28,7 @@ func reimportRowCount(t *testing.T, parquetPath, tableName string) int {
 	return n
 }
 
-// TestDumpTableToParquet_RoundTrip locks the #241 export target: a table
+// TestDumpTableToParquet_RoundTrip locks the export target: a table
 // written to Parquet must re-import into sqly with the same rows and columns.
 func TestDumpTableToParquet_RoundTrip(t *testing.T) {
 	t.Parallel()
@@ -78,7 +78,7 @@ func TestDumpTableToParquet_RoundTrip(t *testing.T) {
 }
 
 // TestDumpTableToParquet_EmptyResult covers the empty-result behavior required
-// by #241. Parquet needs at least one row to infer its schema, so exporting an
+// by. Parquet needs at least one row to infer its schema, so exporting an
 // empty result returns a clear error rather than writing an unreadable file.
 func TestDumpTableToParquet_EmptyResult(t *testing.T) {
 	t.Parallel()

--- a/infrastructure/memory/sqlite3.go
+++ b/infrastructure/memory/sqlite3.go
@@ -82,7 +82,12 @@ func (r *sqlite3Repository) TablesName(ctx context.Context) ([]*model.Table, err
 // .tables, which should enumerate everything the user can query, not only the
 // file-imported base tables that write-back targets. Internal bookkeeping tables
 // (sqlite_* and query_result_*) are excluded, and names are sorted for stable
-// output. Ref #449, #450.
+// output.
+//
+// Each returned table carries the raw object name in Name() and the owning schema
+// ("main" or "temp") as the single Header entry, so .tables can disambiguate a
+// main object and a same-named temp object instead of collapsing them. UNION ALL
+// (not UNION) keeps both rows of such a collision.
 func (r *sqlite3Repository) SchemaObjects(ctx context.Context) ([]*model.Table, error) {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -90,10 +95,10 @@ func (r *sqlite3Repository) SchemaObjects(ctx context.Context) ([]*model.Table, 
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	const query = "SELECT name FROM sqlite_master " +
+	const query = "SELECT name, 'main' AS schema_name FROM sqlite_master " +
 		"WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'query_result_%' " +
-		"UNION " +
-		"SELECT name FROM sqlite_temp_master " +
+		"UNION ALL " +
+		"SELECT name, 'temp' AS schema_name FROM sqlite_temp_master " +
 		"WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'query_result_%' " +
 		"ORDER BY name"
 	rows, err := tx.QueryContext(ctx, query)
@@ -103,12 +108,12 @@ func (r *sqlite3Repository) SchemaObjects(ctx context.Context) ([]*model.Table, 
 	defer func() { _ = rows.Close() }()
 
 	tables := []*model.Table{}
-	var name string
+	var name, schemaName string
 	for rows.Next() {
-		if err := rows.Scan(&name); err != nil {
+		if err := rows.Scan(&name, &schemaName); err != nil {
 			return nil, err
 		}
-		tables = append(tables, model.NewTable(name, model.Header{}, []model.Record{}))
+		tables = append(tables, model.NewTable(name, model.Header{schemaName}, []model.Record{}))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -148,9 +153,15 @@ func (r *sqlite3Repository) List(ctx context.Context, tableName string) (*model.
 	return model.NewTable(tableName, table.Header(), table.Records()), nil
 }
 
-// Header get table header name.
+// Header get table header name. The result is re-wrapped with the requested table
+// name rather than the name extractTableName parses from the query, which would
+// truncate a name containing spaces (e.g. "two words" -> "two").
 func (r *sqlite3Repository) Header(ctx context.Context, tableName string) (*model.Table, error) {
-	return r.Query(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 1", infra.QuoteTableRef(tableName)))
+	table, err := r.Query(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 1", infra.QuoteTableRef(tableName)))
+	if err != nil {
+		return nil, err
+	}
+	return model.NewTable(tableName, table.Header(), table.Records()), nil
 }
 
 // Query execute "SELECT" or "EXPLAIN" query

--- a/infrastructure/memory/sqlite3_test.go
+++ b/infrastructure/memory/sqlite3_test.go
@@ -359,7 +359,7 @@ func TestSqlite3Repository_CreateTable_InvalidTableReturnsError(t *testing.T) {
 
 // TestSqlite3RepositorySchemaObjects verifies that SchemaObjects lists base
 // tables, views, and TEMP tables (so .tables can enumerate everything queryable),
-// while TablesName stays limited to base tables used by write-back.,
+// while TablesName stays limited to base tables used by write-back.
 func TestSqlite3RepositorySchemaObjects(t *testing.T) {
 	memoryDB, cleanup, err := config.NewInMemDB()
 	if err != nil {

--- a/infrastructure/memory/sqlite3_test.go
+++ b/infrastructure/memory/sqlite3_test.go
@@ -359,8 +359,7 @@ func TestSqlite3Repository_CreateTable_InvalidTableReturnsError(t *testing.T) {
 
 // TestSqlite3RepositorySchemaObjects verifies that SchemaObjects lists base
 // tables, views, and TEMP tables (so .tables can enumerate everything queryable),
-// while TablesName stays limited to base tables used by write-back. Ref #449,
-// #450.
+// while TablesName stays limited to base tables used by write-back.,
 func TestSqlite3RepositorySchemaObjects(t *testing.T) {
 	memoryDB, cleanup, err := config.NewInMemDB()
 	if err != nil {
@@ -409,7 +408,6 @@ func TestSqlite3RepositorySchemaObjects(t *testing.T) {
 
 // TestSqlite3RepositoryListSchemaQualified verifies that List accepts a
 // schema-qualified table name, so .dump and .header can target main.<table>.
-// Ref #445, #447, #448.
 func TestSqlite3RepositoryListSchemaQualified(t *testing.T) {
 	memoryDB, cleanup, err := config.NewInMemDB()
 	if err != nil {

--- a/infrastructure/persistence/excel_test.go
+++ b/infrastructure/persistence/excel_test.go
@@ -56,7 +56,7 @@ func TestExcelRepositoryDump(t *testing.T) {
 		}
 	})
 
-	t.Run("dumped excel file is not executable (#296)", func(t *testing.T) {
+	t.Run("dumped excel file is not executable", func(t *testing.T) {
 		t.Parallel()
 
 		r := NewExcelRepository()

--- a/infrastructure/persistence/ltsv.go
+++ b/infrastructure/persistence/ltsv.go
@@ -26,10 +26,10 @@ func NewLTSVRepository() repository.LTSVRepository {
 // containing a tab or newline cannot be represented losslessly and is rejected
 // before writing. Writing each token directly (rather than through a CSV writer
 // with a tab delimiter) keeps the output re-importable, since a CSV writer would
-// quote the whole "label:value" token and break the label/value split. Ref #383.
+// quote the whole "label:value" token and break the label/value split.
 func (lr *ltsvRepository) Dump(f io.Writer, table *model.Table) error {
 	// Reject invalid or duplicate LTSV labels before writing, so the exported file
-	// stays a valid, round-trippable LTSV record set. Ref #465, #466.
+	// stays a valid, round-trippable LTSV record set.
 	if err := model.EnsureLTSVHeaderWritable(table.Header()); err != nil {
 		return err
 	}

--- a/infrastructure/sql.go
+++ b/infrastructure/sql.go
@@ -29,13 +29,28 @@ func Quote(s string) string {
 // QuoteTableRef quotes a possibly schema-qualified table reference. A bare name
 // "user" becomes `user`; a qualified name "main.user" becomes `main`.`user`, so a
 // helper command can reference the same schema-qualified table SQLite accepts in a
-// query. The split is on the first dot, which sqly never produces inside an
-// imported table name (dots are sanitized to "_"). Ref #445, #446, #447, #448.
+// query. The split happens only when the prefix is a real SQLite schema (main or
+// temp); sqly rejects ATTACH/DETACH, so those are the only schemas a session can
+// have. Any other dotted name (e.g. "a.b") is a single literal identifier and is
+// quoted whole as `a.b`, matching `SELECT * FROM "a.b"`.
 func QuoteTableRef(name string) string {
-	if i := strings.IndexByte(name, '.'); i > 0 && i < len(name)-1 {
+	if i := strings.IndexByte(name, '.'); i > 0 && i < len(name)-1 && isSchemaName(name[:i]) {
 		return Quote(name[:i]) + "." + Quote(name[i+1:])
 	}
 	return Quote(name)
+}
+
+// isSchemaName reports whether prefix is a SQLite schema name a sqly session can
+// reference: only "main" or "temp" (case-insensitive), since ATTACH/DETACH is
+// rejected. A dotted prefix that is not one of these belongs to a literal table
+// name rather than a schema qualifier.
+func isSchemaName(prefix string) bool {
+	switch strings.ToLower(prefix) {
+	case "main", "temp":
+		return true
+	default:
+		return false
+	}
 }
 
 // SingleQuote returns single quoted string.

--- a/infrastructure/sql_test.go
+++ b/infrastructure/sql_test.go
@@ -83,7 +83,7 @@ func TestGenerateInsertStatement(t *testing.T) {
 
 // TestQuoteTableRef verifies that a bare name is backtick-quoted and a
 // schema-qualified name is quoted per part, so helper commands can reference
-// schema-qualified tables. Ref #445, #446, #447, #448.
+// schema-qualified tables.
 func TestQuoteTableRef(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -93,7 +93,11 @@ func TestQuoteTableRef(t *testing.T) {
 		{"user", "`user`"},
 		{"main.user", "`main`.`user`"},
 		{"temp.t", "`temp`.`t`"},
-		{"weird.name", "`weird`.`name`"},
+		{"TEMP.t", "`TEMP`.`t`"}, // schema name match is case-insensitive
+		// A dotted name whose prefix is not a real schema (main/temp) is a single
+		// literal identifier, since sqly rejects ATTACH so no other schema exists.
+		{"weird.name", "`weird.name`"},
+		{"a.b", "`a.b`"},
 		{".leadingdot", "`.leadingdot`"},
 		{"trailingdot.", "`trailingdot.`"},
 		{"has`tick", "`has``tick`"},

--- a/interactor/sql.go
+++ b/interactor/sql.go
@@ -22,6 +22,7 @@ const (
 	sqlREPLACE   = "REPLACE"
 	sqlBEGIN     = "BEGIN"
 	sqlCOMMIT    = "COMMIT"
+	sqlEND       = "END"
 	sqlROLLBACK  = "ROLLBACK"
 	sqlSAVEPOINT = "SAVEPOINT"
 	sqlRELEASE   = "RELEASE"
@@ -55,7 +56,7 @@ func NewSQL() *SQL {
 	return &SQL{
 		ddl: []string{sqlCREATE, sqlDROP, sqlALTER, sqlREINDEX},
 		dml: []string{sqlSELECT, sqlINSERT, sqlUPDATE, sqlDELETE, sqlEXPLAIN, sqlWITH},
-		tcl: []string{sqlBEGIN, sqlCOMMIT, sqlROLLBACK, sqlSAVEPOINT, sqlRELEASE},
+		tcl: []string{sqlBEGIN, sqlCOMMIT, sqlEND, sqlROLLBACK, sqlSAVEPOINT, sqlRELEASE},
 		dcl: []string{"GRANT", "REVOKE"},
 	}
 }
@@ -203,7 +204,7 @@ func trimWordGaps(s string) string {
 // ("/* */") comments plus surrounding whitespace, returning the first executable
 // portion. The batch and --sql-file paths already accept a BOM and leading
 // comments; the direct --sql path classifies a statement by its first keyword, so
-// it must strip the same noise to stay consistent. Ref #386, #387.
+// it must strip the same noise to stay consistent.
 func stripSQLNoise(s string) string {
 	s = strings.TrimPrefix(s, "\ufeff")
 	for {
@@ -245,7 +246,7 @@ func leadingKeyword(s string) string {
 // parenthesis depth 0, outside string literals, quoted identifiers, and comments.
 // The CTE bodies live inside parentheses (depth > 0), so this skips them and
 // returns the verb of the statement the CTEs feed. It lets a WITH ... UPDATE run
-// as DML and a WITH ... SELECT run as a query. Ref #412, #413, #414.
+// as DML and a WITH ... SELECT run as a query.
 func mainStatementVerb(stmt string) string {
 	runes := []rune(stmt)
 	var (
@@ -335,10 +336,12 @@ func mainStatementVerb(stmt string) string {
 // are rejected up front with a clear sqly-specific error instead of surfacing
 // SQLite's confusing internal message or silently escaping the session model.
 // The input must already be noise-stripped and normalized.
-// Ref #441, #442, #443, #457, #458.
 func unsupportedStatementReason(stmt string) string {
 	switch leadingKeyword(stmt) {
-	case sqlBEGIN, sqlCOMMIT, sqlROLLBACK, sqlSAVEPOINT, sqlRELEASE:
+	case sqlBEGIN, sqlCOMMIT, sqlEND, sqlROLLBACK, sqlSAVEPOINT, sqlRELEASE:
+		// END (and END TRANSACTION) is an alias for COMMIT, so it must be rejected
+		// with the same sqly-specific message rather than falling through to
+		// SQLite's "cannot commit - no transaction is active".
 		return "explicit transaction control is not supported; sqly runs each statement in its own transaction"
 	case sqlVACUUM:
 		return "VACUUM is not supported; sqly runs every statement inside a transaction, which SQLite forbids for VACUUM"
@@ -352,7 +355,6 @@ func unsupportedStatementReason(stmt string) string {
 // accept into an equivalent statement it does. The PostgreSQL-style "TABLE name"
 // shorthand (which the sqlite3 CLI accepts but modernc.org/sqlite rejects) is
 // rewritten to "SELECT * FROM name". The input must already be noise-stripped.
-// Ref #408.
 func normalizeStatement(stmt string) string {
 	if leadingKeyword(stmt) == sqlTABLE {
 		if rest := strings.TrimSpace(stmt[len(sqlTABLE):]); rest != "" {
@@ -369,7 +371,6 @@ func normalizeStatement(stmt string) string {
 // WITH that feeds a SELECT/VALUES produce rows, an INSERT/UPDATE/DELETE/REPLACE
 // produces rows only with RETURNING, and everything else (DDL, transaction
 // control, ATTACH, ANALYZE, ...) runs as a no-rowset statement.
-// Ref #406, #407, #408, #409, #410, #411, #412, #413, #414, #430, #431.
 func (sql *SQL) producesRowset(stmt string) bool {
 	switch leadingKeyword(stmt) {
 	case sqlSELECT, sqlVALUES, sqlTABLE, sqlEXPLAIN, sqlPRAGMA:

--- a/interactor/sql_test.go
+++ b/interactor/sql_test.go
@@ -646,7 +646,6 @@ func TestMainStatementVerb(t *testing.T) {
 // TestUnsupportedStatementReason verifies that statements sqly cannot run under
 // its per-statement transaction and in-memory model are flagged with a reason,
 // while statements it can run (DML, DDL, ANALYZE, PRAGMA, queries) are not.
-// Ref #441, #442, #443, #457, #458.
 func TestUnsupportedStatementReason(t *testing.T) {
 	t.Parallel()
 
@@ -655,6 +654,9 @@ func TestUnsupportedStatementReason(t *testing.T) {
 		"BEGIN IMMEDIATE",
 		"BEGIN EXCLUSIVE",
 		"COMMIT",
+		"END",             // END is an alias for COMMIT
+		"END TRANSACTION", // END TRANSACTION is an alias for COMMIT
+		"end",             // lowercase
 		"ROLLBACK",
 		"ROLLBACK TO sp",
 		"SAVEPOINT sp",

--- a/interactor/sqlite3.go
+++ b/interactor/sqlite3.go
@@ -103,18 +103,18 @@ func (si *SQLite3Interactor) Exec(ctx context.Context, statement string) (int64,
 // - For unsupported commands: (nil, 0, error)
 func (si *SQLite3Interactor) ExecSQL(ctx context.Context, statement string) (*model.Table, int64, error) {
 	// Strip a leading BOM and leading comments so the statement classifies and
-	// runs the same way it does on the batch and --sql-file paths. Ref #386, #387.
+	// runs the same way it does on the batch and --sql-file paths.
 	stmt := stripSQLNoise(statement)
 	if stmt == "" {
 		return nil, 0, errors.New("no executable SQL statement: " + color.CyanString(statement))
 	}
-	// Rewrite shorthands the engine does not accept (e.g. "TABLE name"). Ref #408.
+	// Rewrite shorthands the engine does not accept (e.g. "TABLE name").
 	stmt = normalizeStatement(stmt)
 
 	// Reject statements sqly cannot run safely or correctly under its per-statement
 	// transaction and in-memory session model (explicit transaction control,
 	// VACUUM, ATTACH/DETACH), with a clear error instead of SQLite's confusing
-	// internal message. Ref #441, #442, #443, #457, #458.
+	// internal message.
 	if reason := unsupportedStatementReason(stmt); reason != "" {
 		return nil, 0, fmt.Errorf("%s: %s", reason, color.CyanString(statement))
 	}
@@ -133,7 +133,7 @@ func (si *SQLite3Interactor) ExecSQL(ctx context.Context, statement string) (*mo
 		// like "PRAGMA incremental_vacuum") is routed here by keyword but yields no
 		// result columns, so the query path reports ErrNoRows. Re-run it on the exec
 		// path so it commits and reports neutral success instead of a misleading "no
-		// records" error. Ref #440, #485.
+		// records" error.
 		if !errors.Is(err, repository.ErrNoRows) || leadingKeyword(stmt) != sqlPRAGMA {
 			return nil, 0, fmt.Errorf("execute query error: %w: %s", err, color.CyanString(statement))
 		}

--- a/interactor/sqlite3_filesql_test.go
+++ b/interactor/sqlite3_filesql_test.go
@@ -176,10 +176,10 @@ func TestSQLite3Interactor_GetTableNameFromFilePath(t *testing.T) {
 }
 
 // TestSQLite3Interactor_LoadFiles_PreservesFilesqlSchema locks the integration
-// model for issue #244: filesql detects column types, and sqly copies the exact
+// model for issue: filesql detects column types, and sqly copies the exact
 // CREATE TABLE into the shared DB, so the detected types survive. This is the
-// schema fidelity that .schema/.describe (#238) and export/write-back (#241,
-// #242) depend on.
+// schema fidelity that .schema/.describe and export/write-back (,
+// ) depend on.
 func TestSQLite3Interactor_LoadFiles_PreservesFilesqlSchema(t *testing.T) {
 	t.Parallel()
 

--- a/interactor/sqlite3_test.go
+++ b/interactor/sqlite3_test.go
@@ -18,7 +18,7 @@ func TestSQLite3InteractorExecSQL(t *testing.T) {
 
 	// DDL and other no-rowset statements that sqly can run inside its per-statement
 	// transaction are routed to the exec path. SQLite remains the authority on
-	// validity. Ref #406, #409, #411, #431.
+	// validity.
 	execRouted := []struct {
 		name      string
 		statement string
@@ -47,7 +47,6 @@ func TestSQLite3InteractorExecSQL(t *testing.T) {
 	// Explicit transaction control, VACUUM, and ATTACH/DETACH cannot run correctly
 	// under sqly's per-statement transaction and in-memory session model, so they
 	// are rejected up front with a clear error and never reach the repository.
-	// Ref #441, #442, #443, #457, #458.
 	rejected := []struct {
 		name      string
 		statement string
@@ -78,12 +77,12 @@ func TestSQLite3InteractorExecSQL(t *testing.T) {
 	}
 
 	// PRAGMA, VALUES, and the TABLE shorthand return a result set, so they run on
-	// the query path. Ref #406, #407, #408.
+	// the query path.
 	queryRouted := []struct {
 		name      string
 		statement string
 		// queried is the statement the repository receives; it differs from
-		// statement when sqly rewrites a shorthand (TABLE name). Ref #408.
+		// statement when sqly rewrites a shorthand (TABLE name).
 		queried string
 	}{
 		{"PRAGMA routes to query", "PRAGMA table_info(test)", "PRAGMA table_info(test)"},
@@ -108,7 +107,6 @@ func TestSQLite3InteractorExecSQL(t *testing.T) {
 	// "PRAGMA incremental_vacuum") is routed to the query path by keyword but yields
 	// no result columns, so the query path returns ErrNoRows. ExecSQL must re-run it
 	// on the exec path and report neutral success instead of a "no records" error.
-	// Ref #440, #485.
 	pragmaSetters := []string{"PRAGMA user_version = 1", "PRAGMA incremental_vacuum"}
 	for _, stmt := range pragmaSetters {
 		t.Run("no-rowset PRAGMA falls through to exec: "+stmt, func(t *testing.T) {
@@ -147,7 +145,6 @@ func TestSQLite3InteractorExecSQL(t *testing.T) {
 
 	// A leading comment or UTF-8 BOM is stripped before classification, so the
 	// statement runs the same way the batch and --sql-file paths run it.
-	// Ref #386, #387.
 	t.Run("leading line comment is stripped and SELECT runs on query path", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -173,7 +170,7 @@ func TestSQLite3InteractorExecSQL(t *testing.T) {
 	})
 
 	// A non-returning WITH ... UPDATE/INSERT/DELETE is DML, so it runs on the exec
-	// path instead of the query path. Ref #412, #413, #414.
+	// path instead of the query path.
 	t.Run("WITH ... UPDATE without RETURNING routes to exec", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
@@ -400,7 +397,7 @@ func TestSQLite3InteractorExecSQL(t *testing.T) {
 		}
 	})
 
-	t.Run("DML with RETURNING routes to Query and returns rows (#363)", func(t *testing.T) {
+	t.Run("DML with RETURNING routes to Query and returns rows", func(t *testing.T) {
 		t.Parallel()
 		for _, statement := range []string{
 			"UPDATE test SET name = 'X' WHERE id = 1 RETURNING id, name",

--- a/main_test.go
+++ b/main_test.go
@@ -70,7 +70,7 @@ func Test_run(t *testing.T) {
 		g.Assert(t, "excel_to_csv", got)
 	})
 
-	t.Run("--sql-file runs a multiline query loaded from a file (#281)", func(t *testing.T) {
+	t.Run("--sql-file runs a multiline query loaded from a file", func(t *testing.T) {
 		sqlPath := filepath.Join(t.TempDir(), "query.sql")
 		query := "-- top actor by name\nSELECT actor\nFROM actor\nORDER BY actor ASC\nLIMIT 1;\n"
 		if err := os.WriteFile(sqlPath, []byte(query), 0o600); err != nil {

--- a/readme_version_test.go
+++ b/readme_version_test.go
@@ -10,7 +10,7 @@ import (
 // the README: every "sqly vX.Y.Z" string (the shell welcome snippet and the
 // benchmark caption) must match the latest version heading in CHANGELOG.md. When a
 // release bumps the changelog, this fails until the README is refreshed too, so
-// stale version strings cannot silently linger. Ref #454.
+// stale version strings cannot silently linger.
 func TestREADMEVersionMatchesChangelog(t *testing.T) {
 	t.Parallel()
 

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -29,7 +29,7 @@ const (
 )
 
 // utf8BOM is the UTF-8 byte order mark stripped from the start of batch input
-// and --sql-file scripts so BOM-prefixed files parse like plain UTF-8. Ref #369.
+// and --sql-file scripts so BOM-prefixed files parse like plain UTF-8.
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 // runBatchReader executes SQL statements and helper commands read from r. It is
@@ -45,13 +45,13 @@ var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 // Execution is fail-fast: the first failed statement or helper command stops
 // the run and returns an error, so later statements never execute and their
 // output cannot leak into a pipeline that the process then reports as failed
-// (Ref #308). A ".exit" command stops early with success, mirroring the
+// (). A ".exit" command stops early with success, mirroring the
 // interactive shell. ranAny reports whether at least one statement or command
 // was executed, so callers can skip post-run side effects (e.g. --save
-// write-back) for an empty batch (Ref #330).
+// write-back) for an empty batch ().
 func (s *Shell) runBatchReader(ctx context.Context, r io.Reader) (ranAny bool, err error) {
 	// Strip a leading UTF-8 BOM so a BOM-prefixed batch stream (common from
-	// Windows editors and export tools) parses the same as plain UTF-8. Ref #369.
+	// Windows editors and export tools) parses the same as plain UTF-8.
 	br := bufio.NewReader(r)
 	if prefix, perr := br.Peek(len(utf8BOM)); perr == nil && bytes.Equal(prefix, utf8BOM) {
 		_, _ = br.Discard(len(utf8BOM))
@@ -90,7 +90,7 @@ scan:
 		// terminated statement, or a standalone (closed) leading comment. Checking
 		// the boundary (rather than pending.Len() == 0) lets helper commands and SQL
 		// alternate line-by-line after a ";" or a leading comment, while a dot-line
-		// inside an open block comment stays part of the comment. Ref #397, #425.
+		// inside an open block comment stays part of the comment.
 		if atStatementBoundary(pending.String()) {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" {
@@ -182,7 +182,7 @@ func splitSQLStatements(s string) (stmts []string, remainder string) {
 	// A CREATE TRIGGER ... BEGIN ... END statement contains inner ";" that must not
 	// split it. trig tracks whether the current statement is a CREATE TRIGGER and
 	// how deep its BEGIN/CASE ... END nesting is, so a ";" only terminates once the
-	// body's END has balanced its BEGIN. It resets after each split. Ref #468.
+	// body's END has balanced its BEGIN. It resets after each split.
 	var trig triggerState
 	for i := 0; i < len(runes); i++ {
 		c := runes[i]
@@ -257,7 +257,7 @@ func splitSQLStatements(s string) (stmts []string, remainder string) {
 
 // triggerState tracks whether the current statement is a CREATE TRIGGER and the
 // depth of its BEGIN/CASE ... END nesting, so splitSQLStatements does not split a
-// trigger body at its inner semicolons. Ref #468.
+// trigger body at its inner semicolons.
 type triggerState struct {
 	tokens    int  // significant word tokens observed from the statement start
 	isTrigger bool // statement starts with CREATE [TEMP|TEMPORARY] TRIGGER
@@ -317,7 +317,6 @@ const sqlCreate = "CREATE"
 // unterminated block comment. At a boundary the next line may start a new
 // statement or a helper command. An unterminated block comment is not a boundary,
 // because following lines (including dot-lines) are still inside the comment.
-// Ref #397, #425.
 func atStatementBoundary(pending string) bool {
 	if strings.TrimSpace(stripLeadingSQLComments(pending)) != "" {
 		return false
@@ -394,7 +393,7 @@ func endsInsideBlockComment(s string) bool {
 // ".mode csv\nUPDATE t SET x=1;" would hide the UPDATE behind the dot-line.
 // Classification is per statement so an EXPLAIN of a DML statement counts as
 // read-only. It lets a non-interactive run skip write-back preflight for a
-// read-only script. Ref #376, #402, #403. Whether write-back actually runs is
+// read-only script. Whether write-back actually runs is
 // decided dynamically by the rows a statement changes (see Shell.dataChanged).
 func scriptModifiesData(script string) bool {
 	for _, stmt := range scriptSQLStatements(script) {
@@ -425,19 +424,38 @@ func scriptSQLStatements(script string) []string {
 	return stmts
 }
 
+// countSQLStatements returns the number of complete SQL statements in s, counting
+// a trailing statement that is not terminated by ";". It is quote-, comment-, and
+// CREATE TRIGGER-aware (via splitSQLStatements), so semicolons inside string
+// literals, identifiers, comments, and trigger bodies do not inflate the count. It
+// backs the direct --sql single-statement guard.
+func countSQLStatements(s string) int {
+	stmts, remainder := splitSQLStatements(s)
+	count := len(stmts)
+	if stripLeadingSQLComments(remainder) != "" {
+		count++
+	}
+	return count
+}
+
 // statementSaveCompatible reports whether a non-interactive --save/--save-dir run
 // can handle a statement: a read-only query (which skips write-back) or a
 // row-modifying DML on an imported table (which write-back persists). Any other
 // statement — DDL (CREATE/DROP/ALTER/REINDEX and CREATE VIEW/INDEX/TRIGGER),
 // ANALYZE, or other schema/maintenance work — has no file write-back
 // representation, so it is save-incompatible and the run must fail loudly instead
-// of exiting 0 while leaving the source unchanged. Ref #433-#437, #469-#484.
+// of exiting 0 while leaving the source unchanged.
+//
+// PRAGMA is save-incompatible too: a setter (PRAGMA user_version=1), command
+// (PRAGMA incremental_vacuum), or rowset (PRAGMA journal_mode=OFF) PRAGMA only
+// changes the transient in-memory session, with no file representation, so a save
+// run that includes one must fail rather than imply a durable effect.
 func statementSaveCompatible(stmt string) bool {
 	if statementModifiesData(stmt) {
 		return true
 	}
 	switch leadingSQLKeyword(stmt) {
-	case kwSelect, kwValues, "WITH", "EXPLAIN", "TABLE", "PRAGMA":
+	case kwSelect, kwValues, "WITH", "EXPLAIN", "TABLE":
 		return true
 	default:
 		return false
@@ -446,7 +464,7 @@ func statementSaveCompatible(stmt string) bool {
 
 // firstSaveIncompatibleStatement returns the first statement a non-interactive
 // save run cannot persist, or "" when every statement is a read-only query or a
-// row-modifying DML. Ref #433-#437, #469-#484.
+// row-modifying DML.
 func firstSaveIncompatibleStatement(script string) string {
 	for _, stmt := range scriptSQLStatements(script) {
 		if !statementSaveCompatible(stmt) {
@@ -459,7 +477,7 @@ func firstSaveIncompatibleStatement(script string) string {
 // scriptImportsInput reports whether a batch or --sql-file script imports its own
 // input with a ".import" helper command. Such a script creates its tables while it
 // runs, so save preflight cannot list them up front and instead defers write-back
-// validation until after the run. Ref #456.
+// validation until after the run.
 func scriptImportsInput(script string) bool {
 	var sql strings.Builder
 	for _, line := range strings.Split(script, "\n") {
@@ -484,7 +502,7 @@ func scriptImportsInput(script string) bool {
 // statementModifiesData reports whether a single statement changes table data:
 // an INSERT/UPDATE/DELETE/REPLACE, or a WITH whose main statement is one of those.
 // An EXPLAIN of such a statement is read-only and reports false, so it never
-// triggers write-back. Ref #402, #403.
+// triggers write-back.
 func statementModifiesData(stmt string) bool {
 	switch leadingSQLKeyword(stmt) {
 	case kwInsert, kwUpdate, kwDelete, kwReplace:
@@ -503,7 +521,6 @@ func statementModifiesData(stmt string) bool {
 // reports its affected-row count; any other no-rowset statement (DDL, PRAGMA,
 // maintenance) reports neutral success, because an "affected is N row(s)" line for
 // a CREATE VIEW, PRAGMA, or ANALYZE implies a row change that did not happen.
-// Ref #439.
 func statementResultMessage(stmt string, affected int64) string {
 	if statementModifiesData(stmt) {
 		return fmt.Sprintf("affected is %d row(s)\n", affected)
@@ -512,7 +529,7 @@ func statementResultMessage(stmt string, affected int64) string {
 }
 
 // msgStatementExecuted is the neutral stdout line printed for a no-rowset
-// statement that does not change table data (DDL, PRAGMA, maintenance). Ref #439.
+// statement that does not change table data (DDL, PRAGMA, maintenance).
 const msgStatementExecuted = "statement executed successfully\n"
 
 // leadingSQLKeyword returns the upper-cased first keyword of a statement after
@@ -620,7 +637,7 @@ func readSQLFile(path string) (string, error) {
 		return "", fmt.Errorf("failed to read --sql-file %q: %w", path, err)
 	}
 	// Strip a leading UTF-8 BOM so a BOM-prefixed script (common from Windows
-	// editors and export tools) parses the same as plain UTF-8. Ref #369.
+	// editors and export tools) parses the same as plain UTF-8.
 	content := strings.TrimPrefix(string(data), "\ufeff")
 	if strings.TrimSpace(content) == "" {
 		return "", fmt.Errorf("--sql-file %q is empty", path)
@@ -628,7 +645,7 @@ func readSQLFile(path string) (string, error) {
 	// A comment-only script has no executable SQL, which is the same failure as
 	// an empty file: splitting yields no terminated statements and the remainder
 	// strips down to nothing once leading comments are removed. Reject it instead
-	// of silently running nothing. Ref #351.
+	// of silently running nothing.
 	stmts, remainder := splitSQLStatements(content)
 	if len(stmts) == 0 && stripLeadingSQLComments(remainder) == "" {
 		return "", fmt.Errorf("--sql-file %q contains no executable SQL statements", path)

--- a/shell/batch_test.go
+++ b/shell/batch_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // TestRunBatchReaderLineByLine covers the batch parsing bugs where a helper
-// command after a terminated SQL statement (#397) or after a leading SQL comment
-// (#425) was absorbed into a pending SQL buffer instead of running as its own
+// command after a terminated SQL statement or after a leading SQL comment
+// was absorbed into a pending SQL buffer instead of running as its own
 // statement.
 func TestRunBatchReaderLineByLine(t *testing.T) {
 	cases := []struct {
@@ -33,7 +33,7 @@ func TestRunBatchReaderLineByLine(t *testing.T) {
 	}
 
 	// A dot-line inside an open block comment must stay part of the comment, not be
-	// executed as a helper command. Ref CodeRabbit review of #425.
+	// executed as a helper command. Ref CodeRabbit review of.
 	t.Run("dot line inside an open block comment is not executed as a command", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly"})
 		if err != nil {
@@ -88,7 +88,7 @@ func TestRunBatchReaderLineByLine(t *testing.T) {
 }
 
 // TestScriptModifiesData verifies that write-back intent detection is statement
-// aware: an EXPLAIN of a DML statement is read-only (#402, #403), while a real
+// aware: an EXPLAIN of a DML statement is read-only, while a real
 // DML or a WITH that feeds one is data-modifying.
 func TestScriptModifiesData(t *testing.T) {
 	t.Parallel()
@@ -111,7 +111,7 @@ func TestScriptModifiesData(t *testing.T) {
 		{"multiple statements, one modifies", "SELECT 1;\nUPDATE t SET x=1;", true},
 		{"explain then select stays read-only", "EXPLAIN UPDATE t SET x=1;\nSELECT 1;", false},
 		// A helper command line is not SQL, so it must not hide a following DML. Ref
-		// CodeRabbit review of #397.
+		// CodeRabbit review of.
 		{"helper command before UPDATE still detects modification", ".mode csv\nUPDATE t SET x=1;", true},
 		{"helper command before SELECT stays read-only", ".mode csv\nSELECT 1;", false},
 	}
@@ -128,7 +128,7 @@ func TestScriptModifiesData(t *testing.T) {
 
 // TestSplitSQLStatements_TriggerBody verifies that a CREATE TRIGGER definition is
 // kept as a single statement even though its BEGIN ... END body contains inner
-// semicolons, while ordinary semicolon-terminated statements still split. Ref #468.
+// semicolons, while ordinary semicolon-terminated statements still split.
 func TestSplitSQLStatements_TriggerBody(t *testing.T) {
 	t.Parallel()
 
@@ -202,7 +202,7 @@ func TestSplitSQLStatements_TriggerBody(t *testing.T) {
 
 // TestStatementResultMessage verifies that only a data-modifying statement reports
 // an affected-row count; a no-rowset DDL/PRAGMA/maintenance statement reports
-// neutral success instead of a misleading row count. Ref #439.
+// neutral success instead of a misleading row count.
 func TestStatementResultMessage(t *testing.T) {
 	t.Parallel()
 
@@ -236,8 +236,7 @@ func TestStatementResultMessage(t *testing.T) {
 // TestFirstSaveIncompatibleStatement verifies that a non-interactive save run is
 // allowed only for read-only queries and row-modifying DML; any DDL, schema, or
 // maintenance statement is reported as save-incompatible so the run fails loudly
-// instead of exiting 0 while leaving the source unchanged. Ref #433-#437,
-// #469-#484.
+// instead of exiting 0 while leaving the source unchanged.,
 func TestFirstSaveIncompatibleStatement(t *testing.T) {
 	t.Parallel()
 
@@ -271,6 +270,9 @@ func TestFirstSaveIncompatibleStatement(t *testing.T) {
 		"DROP INDEX idx",
 		"REINDEX",
 		"ANALYZE",
+		"PRAGMA user_version = 1",   // setter PRAGMA
+		"PRAGMA incremental_vacuum", // command PRAGMA
+		"PRAGMA journal_mode = OFF", // rowset PRAGMA
 		"CREATE TRIGGER tg AFTER UPDATE ON user BEGIN UPDATE user SET x=1; END;",
 		"CREATE TABLE backup AS SELECT * FROM user;\nUPDATE user SET first_name='Z' WHERE id=1;",
 	}
@@ -286,7 +288,6 @@ func TestFirstSaveIncompatibleStatement(t *testing.T) {
 
 // TestScriptImportsInput verifies detection of a .import helper command, which
 // lets save preflight defer write-back validation until after the import runs.
-// Ref #456.
 func TestScriptImportsInput(t *testing.T) {
 	t.Parallel()
 

--- a/shell/clear_test.go
+++ b/shell/clear_test.go
@@ -11,9 +11,11 @@ import (
 )
 
 // Test_clearCommand tests the clearCommand registration and metadata.
+//
+// Not parallel at the top level: the ANSI-output subtest swaps the package-global
+// config.Stdout, so running concurrently with other parallel package tests would
+// race. Keeping the parent serial confines that swap to the sequential phase.
 func Test_clearCommand(t *testing.T) {
-	t.Parallel()
-
 	t.Run("clear command is registered", func(t *testing.T) {
 		t.Parallel()
 

--- a/shell/clear_test.go
+++ b/shell/clear_test.go
@@ -38,7 +38,7 @@ func Test_clearCommand(t *testing.T) {
 	})
 
 	t.Run("writes ANSI clear sequence to stdout in-process", func(t *testing.T) {
-		// Regression for #236: .clear must clear the screen in-process via ANSI
+		// Regression for: .clear must clear the screen in-process via ANSI
 		// escapes instead of shelling out to clear/cls.
 		c := NewCommands()
 

--- a/shell/commands_test.go
+++ b/shell/commands_test.go
@@ -289,7 +289,7 @@ func TestCommandList_lsCommand(t *testing.T) {
 }
 
 func TestCommandList_lsCommand_Output(t *testing.T) {
-	// Regression for #236: .ls must list directory contents in-process with
+	// Regression for: .ls must list directory contents in-process with
 	// deterministic, OS-independent output instead of shelling out to ls/dir.
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "b.csv"), []byte("x\n"), 0o600); err != nil {
@@ -321,7 +321,7 @@ func TestCommandList_lsCommand_Output(t *testing.T) {
 }
 
 func TestCommandList_cdCommand_StoresAbsolutePath(t *testing.T) {
-	// Regression for #236: .cd must store a normalized absolute path so the
+	// Regression for: .cd must store a normalized absolute path so the
 	// prompt stays correct after a relative move.
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "sub")
@@ -535,7 +535,11 @@ func TestCommandList_tablesCommand_dependsOnMetadataUsecase(t *testing.T) {
 		model.NewTable("orders", nil, nil),
 	}, nil)
 
-	s := &Shell{usecases: Usecases{metadata: metadata}}
+	st, err := newState(&config.Arg{Output: &config.Output{Mode: model.PrintModeTable}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Shell{usecases: Usecases{metadata: metadata}, state: st}
 	out := captureStdout(t, func() {
 		if err := NewCommands().tablesCommand(context.Background(), s, nil); err != nil {
 			t.Fatalf("tablesCommand returned error: %v", err)
@@ -557,7 +561,11 @@ func TestCommandList_headerCommand_dependsOnMetadataUsecase(t *testing.T) {
 	metadata.EXPECT().Header(gomock.Any(), "users").Return(
 		model.NewTable("users", model.NewHeader([]string{"id", "name"}), nil), nil)
 
-	s := &Shell{usecases: Usecases{metadata: metadata}}
+	st, err := newState(&config.Arg{Output: &config.Output{Mode: model.PrintModeTable}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Shell{usecases: Usecases{metadata: metadata}, state: st}
 	out := captureStdout(t, func() {
 		if err := NewCommands().headerCommand(context.Background(), s, []string{"users"}); err != nil {
 			t.Fatalf("headerCommand returned error: %v", err)
@@ -605,7 +613,7 @@ func TestShell_execSQL_dependsOnQueryUsecase(t *testing.T) {
 }
 
 func TestCommandList_dumpCommand_RejectsDirectoryTarget(t *testing.T) {
-	// Regression for #303: a directory destination must be rejected, not
+	// Regression for: a directory destination must be rejected, not
 	// rewritten to a sibling .csv file.
 	ctrl := gomock.NewController(t)
 	metadata := mock.NewMockMetadataUsecase(ctrl)
@@ -641,7 +649,7 @@ func TestCommandList_dumpCommand_dependsOnMetadataAndExportUsecases(t *testing.T
 		export:   exporter,
 	})
 
-	// The dump status line is control-plane output and goes to stderr (#309).
+	// The dump status line is control-plane output and goes to stderr.
 	out := captureStderr(t, func() {
 		if err := NewCommands().dumpCommand(context.Background(), s, []string{"users", outputPath}); err != nil {
 			t.Fatalf("dumpCommand returned error: %v", err)

--- a/shell/describe.go
+++ b/shell/describe.go
@@ -37,7 +37,7 @@ func (c CommandList) describeCommand(ctx context.Context, s *Shell, argv []strin
 // empty record set means the table does not exist (PRAGMA returns no rows).
 func (s *Shell) tableColumns(ctx context.Context, tableName string) (*model.Table, error) {
 	// A schema-qualified name (main.user, temp.t) is inspected against that schema
-	// via "PRAGMA schema.table_info(table)", matching the SQL surface. Ref #446.
+	// via "PRAGMA schema.table_info(table)", matching the SQL surface.
 	schema, object := splitTableQualifier(tableName)
 	pragma := "PRAGMA "
 	if schema != "" {

--- a/shell/dump.go
+++ b/shell/dump.go
@@ -32,7 +32,7 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 	userPath := argv[1]
 
 	// Reject an empty destination so `.dump table ""` does not write a file
-	// named ".csv" into the current directory. Ref #324.
+	// named ".csv" into the current directory.
 	if strings.TrimSpace(userPath) == "" {
 		return errors.New(".dump requires a non-empty destination path")
 	}
@@ -41,7 +41,6 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 	// formats require multi-record coordination that .dump cannot provide.
 	// Exporting ACH/Fedwire tables to CSV/TSV/etc via .dump is fine. The check
 	// strips any compression suffix, so .ach.gz and .fed.gz are rejected too.
-	// Ref #422.
 	if model.IsInputOnlyExtension(userPath) {
 		return fmt.Errorf(".dump does not support ACH/Fedwire format output; use csv/tsv/xlsx instead (e.g., .dump %s %s.csv)", tableName, strings.TrimSuffix(userPath, filepath.Ext(userPath)))
 	}
@@ -68,7 +67,7 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 	// Refuse a destination that aliases an imported source file, including symlink
 	// aliases. A destructive source overwrite must go through .save --force, not
 	// .dump, so a stray .dump cannot silently rewrite the dataset in another
-	// format. Ref #398, #418.
+	// format.
 	if name, aliased := s.outputAliasesImportedSource(filePath); aliased {
 		return fmt.Errorf(".dump destination %s is the source file for table %q; use .save --force to overwrite a source", filePath, name)
 	}

--- a/shell/extension_test.go
+++ b/shell/extension_test.go
@@ -108,7 +108,7 @@ func TestValidatePath(t *testing.T) {
 		// unixOnly marks a case that depends on the Unix system-directory block,
 		// which keys on Unix absolute paths (e.g. "/etc"). On Windows filepath.Abs
 		// rewrites such a path (e.g. "C:\\etc\\passwd"), so the block does not apply
-		// and the case is skipped. Ref #427, #428.
+		// and the case is skipped.
 		unixOnly bool
 	}{
 		{name: "Normal file path", path: "test.csv", shouldError: false},
@@ -118,11 +118,11 @@ func TestValidatePath(t *testing.T) {
 		{name: "Dangerous path traversal", path: "../../../etc/passwd", shouldError: true},
 		{name: "Clean path functionality", path: "./test/../test.csv", shouldError: false},
 		// /dev/shm and /dev/fd hold legitimate user inputs and are accepted, while
-		// other system directories stay blocked. Ref #427, #428.
+		// other system directories stay blocked.
 		{name: "dev shm user file is allowed", path: "/dev/shm/sqly/user.csv", shouldError: false},
 		{name: "dev fd descriptor is allowed", path: "/dev/fd/63", shouldError: false},
 		// Standard stream pseudo-files and the Linux /proc fd aliases are allowed
-		// too, so streamed and fd-backed inputs import. Ref #461, #462.
+		// too, so streamed and fd-backed inputs import.
 		{name: "dev stdin is allowed", path: "/dev/stdin", shouldError: false},
 		{name: "dev stdout is allowed", path: "/dev/stdout", shouldError: false},
 		{name: "proc self fd is allowed", path: "/proc/self/fd/0", shouldError: false},

--- a/shell/header.go
+++ b/shell/header.go
@@ -26,6 +26,19 @@ func (c CommandList) headerCommand(ctx context.Context, s *Shell, argv []string)
 	if err != nil {
 		return err
 	}
+
+	// In a structured mode emit one machine-readable {column} object per column so
+	// automation can consume the header after selecting json/ndjson, instead of an
+	// ASCII table that ignores the mode.
+	if isStructuredMode(s.state.mode.PrintMode) {
+		records := make([]model.Record, 0, len(table.Header()))
+		for _, col := range table.Header() {
+			records = append(records, model.Record{col})
+		}
+		out := model.NewTable(table.Name(), model.Header{"column"}, records)
+		return out.Print(config.Stdout, s.state.mode.PrintMode)
+	}
+
 	if err := printHeader(config.Stdout, table); err != nil {
 		return fmt.Errorf("failed to print header: %w", err)
 	}

--- a/shell/import.go
+++ b/shell/import.go
@@ -31,7 +31,6 @@ var errPartialImport = errors.New("one or more inputs failed to import")
 // errSheetNotFound marks a --sheet filter that matched no sheet in a particular
 // workbook. In a multi-workbook import it is downgraded to a non-fatal skip so a
 // single non-matching workbook cannot suppress the workbooks that do match.
-// Ref #378.
 var errSheetNotFound = errors.New("requested sheet not found in workbook")
 
 // validateSheetFlag rejects the CLI --sheet option when no input can be an
@@ -66,7 +65,7 @@ func (s *Shell) sheetAppliesTo(paths []string) bool {
 				// The directory exists but cannot be traversed (e.g. permission
 				// denied), so whether it holds an Excel file is unknown. Defer to the
 				// import step, which surfaces the real access error instead of this
-				// validation misattributing it to --sheet. Ref #356.
+				// validation misattributing it to --sheet.
 				return true
 			}
 			if contains {
@@ -84,7 +83,7 @@ func (s *Shell) sheetAppliesTo(paths []string) bool {
 // dirContainsExcel reports whether dir contains at least one Excel file,
 // searched recursively. It returns a non-nil error when the directory cannot be
 // traversed (e.g. permission denied), so callers can distinguish "no Excel
-// match" from "could not determine" and defer to the import step. Ref #356.
+// match" from "could not determine" and defer to the import step.
 func (s *Shell) dirContainsExcel(dir string) (bool, error) {
 	found := false
 	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
@@ -135,7 +134,7 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 
 	// Reject an explicit empty helper --sheet value (separated `--sheet ""` or
 	// joined `--sheet=`) before any file/Excel checks, so it is not silently
-	// treated as "no sheet filter". Ref #354, #355.
+	// treated as "no sheet filter".
 	if helperSheetExplicitlyEmpty(argv) {
 		return errors.New("--sheet requires a non-empty sheet name")
 	}
@@ -146,14 +145,14 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 	}
 
 	// Reject --sheet when none of the inputs is an Excel file (or a directory
-	// containing one), so the flag is not silently ignored. Ref #312.
+	// containing one), so the flag is not silently ignored.
 	if sheetName != "" && !s.sheetAppliesTo(importPaths(argv)) {
 		return errors.New("--sheet is only valid for Excel (.xlsx) inputs")
 	}
 
 	// A --sheet filter that misses one workbook must not fail a multi-workbook
 	// import: count the Excel workbooks targeted so a miss can be downgraded to a
-	// non-fatal skip when more than one workbook is involved. Ref #378.
+	// non-fatal skip when more than one workbook is involved.
 	multiWorkbook := sheetName != "" && s.countExcelWorkbooks(importPaths(argv)) > 1
 
 	var errorMessages []string
@@ -177,7 +176,7 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 		}
 
 		// Reject an empty path so `.import ""` does not silently import the
-		// current working directory. Ref #325.
+		// current working directory.
 		if strings.TrimSpace(path) == "" {
 			errorMessages = append(errorMessages, "empty import path")
 			continue
@@ -215,7 +214,7 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 		} else {
 			if err := s.importFile(ctx, cleanPath, path, sheetName); err != nil {
 				// In a multi-workbook import, a workbook that lacks the requested
-				// sheet is skipped rather than failing the whole run. Ref #378.
+				// sheet is skipped rather than failing the whole run.
 				if multiWorkbook && errors.Is(err, errSheetNotFound) {
 					fmt.Fprintf(s.importStatusWriter(), "Skipped %s: %v\n", path, err)
 					skippedSheet++
@@ -230,7 +229,7 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 
 	// Every workbook was skipped because none contained the requested sheet, and
 	// nothing else imported. Fail loudly instead of succeeding with no tables so
-	// a wrong --sheet value is visible. Ref #378.
+	// a wrong --sheet value is visible.
 	if successCount == 0 && skippedSheet > 0 && len(errorMessages) == 0 {
 		return fmt.Errorf("sheet %q not found in any of the imported workbooks", sheetName)
 	}
@@ -250,7 +249,7 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 		}
 		// An explicitly requested input failed even though others succeeded.
 		// Return a partial-failure error so non-interactive runs exit non-zero
-		// (Ref #297, #300, #302); the interactive shell tolerates it and starts
+		// (); the interactive shell tolerates it and starts
 		// with the tables that did load.
 		return errPartialImport
 	}
@@ -262,18 +261,18 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 // one file at a time, so each table can be mapped back to the exact file that
 // produced it. Returns imported=true when at least one table was loaded or
 // overwritten, plus the number of workbooks skipped because they lacked the
-// requested --sheet (Ref #378).
+// requested --sheet ().
 //
 // Importing per file (rather than handing the whole directory to filesql) lets
 // importDirectory:
 //   - record each table's real source file even when the basename is sanitized
 //     or the file yields several tables (Excel/ACH/Fedwire), so --inspect reports
-//     per-file provenance (Ref #357, #358);
+//     per-file provenance ();
 //   - reject two files in the tree that map to the same table name instead of
-//     silently overwriting one with the other (Ref #359, #360);
+//     silently overwriting one with the other ();
 //   - treat re-importing over an existing table as a reported overwrite, not "no
 //     supported files", and re-point that table's source so write-back targets
-//     the directory file rather than the original (Ref #361, #362).
+//     the directory file rather than the original ().
 //
 // Every imported table is marked as a directory import so write-back still
 // rejects it: a directory is not a single editable source the session owns.
@@ -288,7 +287,7 @@ func (s *Shell) importDirectory(ctx context.Context, cleanPath, displayPath, she
 
 	// producedHere maps a table name to the file in this directory import that
 	// produced it, so a later file mapping to the same name is a collision rather
-	// than a silent overwrite. Ref #359, #360.
+	// than a silent overwrite.
 	producedHere := make(map[string]string)
 	var importedTables []string
 
@@ -304,7 +303,7 @@ func (s *Shell) importDirectory(ctx context.Context, cleanPath, displayPath, she
 		}
 
 		// Apply --sheet filtering to Excel workbooks. A workbook that lacks the
-		// requested sheet is skipped in a multi-workbook import (Ref #378);
+		// requested sheet is skipped in a multi-workbook import ();
 		// filterExcelSheets has already dropped its tables before returning.
 		if sheetName != "" && s.usecases.importer.IsExcelFile(file) {
 			if ferr := s.filterExcelSheets(ctx, file, sheetName, nil); ferr != nil {
@@ -391,7 +390,7 @@ func (s *Shell) supportedFilesInDir(dir string) ([]string, error) {
 // table name derived from its path. The "<base>_" prefix is matched only for
 // multi-table formats (Excel sheets, ACH, Fedwire), where one file produces
 // "<base>_<sheet>" tables. Without that restriction a file like "a.csv" would
-// spuriously claim unrelated tables such as "a_b". Ref #429. It is used to
+// spuriously claim unrelated tables such as "a_b". It is used to
 // identify which existing tables a re-imported file overwrote.
 func (s *Shell) tablesMatchingFile(file string, names map[string]struct{}) []string {
 	base := s.usecases.importer.GetTableNameFromFilePath(file)
@@ -414,7 +413,7 @@ func (s *Shell) tablesMatchingFile(file string, names map[string]struct{}) []str
 // paths: a path that is itself an Excel file counts as one, and a directory is
 // walked to count the Excel files it contains. It is used to decide whether a
 // --sheet miss in one workbook should be a non-fatal skip (more than one
-// workbook) or a hard error (a single workbook). Ref #378.
+// workbook) or a hard error (a single workbook).
 func (s *Shell) countExcelWorkbooks(paths []string) int {
 	count := 0
 	for _, path := range paths {
@@ -446,7 +445,7 @@ func (s *Shell) countExcelWorkbooks(paths []string) int {
 // identifier ("SELECT * FROM select" is a syntax error); it must be quoted
 // ("SELECT * FROM \"select\""). Warning at import time documents the gotcha
 // instead of leaving the user with a table that silently fails in bare SQL. The
-// table is still imported and is fully usable when quoted. Ref #424.
+// table is still imported and is fully usable when quoted.
 func (s *Shell) warnKeywordTableNames(names []string) {
 	for _, name := range names {
 		if model.IsReservedSQLiteKeyword(name) {
@@ -470,7 +469,7 @@ func (s *Shell) markDirImported(name string) {
 func (s *Shell) importFile(ctx context.Context, cleanPath, displayPath, sheetName string) error {
 	// loadPath is the path actually handed to filesql. It differs from cleanPath
 	// only for an extensionless pseudo-file (e.g. /dev/stdin, /proc/self/fd/0),
-	// which is staged to a temporary CSV so it imports end-to-end. Ref #461, #462.
+	// which is staged to a temporary CSV so it imports end-to-end.
 	loadPath := cleanPath
 	if !s.usecases.importer.IsSupportedFile(cleanPath) {
 		staged, cleanup, ok := s.stagePseudoFileAsCSV(cleanPath)
@@ -518,14 +517,13 @@ func (s *Shell) importFile(ctx context.Context, cleanPath, displayPath, sheetNam
 			// Re-import of the same source path (including a symlink alias) is a
 			// harmless last-wins overwrite. Take clean ownership so a table first
 			// seen via a directory import becomes a normal file-backed table that
-			// write-back accepts. Ref #415, #417.
+			// write-back accepts.
 			s.clearDirImported(owned)
 			return nil
 		case s.anyDirImported(owned):
 			// A deliberate single-file .import replaces directory-sourced data of the
 			// same name: re-point the table to this standalone file and drop the
 			// directory marker so write-back targets the file the user named. Ref
-			// #416.
 			s.recordTableSources(owned, displayPath)
 			s.clearDirImported(owned)
 			s.warnKeywordTableNames(owned)
@@ -535,7 +533,6 @@ func (s *Shell) importFile(ctx context.Context, cleanPath, displayPath, sheetNam
 			// example "a-b.csv" and "a_b.csv" both becoming "a_b"). filesql overwrote
 			// the earlier table, which would leave the first file's source mapped to
 			// the second file's rows, so fail instead of silently overwriting. Ref
-			// #286.
 			return fmt.Errorf("table-name collision: %s sanitizes to a table name already imported from another input; rename the file to disambiguate", displayPath)
 		}
 	}
@@ -548,7 +545,7 @@ func (s *Shell) importFile(ctx context.Context, cleanPath, displayPath, sheetNam
 // isRecordedSource reports whether path is already the source of an imported
 // table. Paths are compared with symlink resolution, so a symlink alias of an
 // imported source is recognized as the same source and re-importing through it is
-// a harmless last-wins overwrite rather than a table-name collision. Ref #417.
+// a harmless last-wins overwrite rather than a table-name collision.
 func (s *Shell) isRecordedSource(path string) bool {
 	for _, src := range s.tableSources {
 		if src == stdinTableSource {
@@ -564,7 +561,6 @@ func (s *Shell) isRecordedSource(path string) bool {
 // clearDirImported removes the directory-import marker from the given tables, so
 // a table first seen via a directory import becomes a normal file-backed table
 // that write-back accepts once it is re-imported directly from a single file.
-// Ref #415, #416.
 func (s *Shell) clearDirImported(names []string) {
 	for _, name := range names {
 		delete(s.dirImported, name)
@@ -574,7 +570,7 @@ func (s *Shell) clearDirImported(names []string) {
 // anyDirImported reports whether any of the given tables came from a directory
 // import. It lets a deliberate single-file .import replace directory-sourced data
 // of the same name, while two distinct plain-file inputs that collide are still
-// rejected. Ref #416, #286.
+// rejected.
 func (s *Shell) anyDirImported(names []string) bool {
 	for _, name := range names {
 		if s.dirImported[name] {
@@ -605,7 +601,7 @@ func (s *Shell) recordTableSources(tableNames []string, source string) {
 // importStatusWriter returns where import progress and error messages go.
 // Import diagnostics are control-plane output, so they always go to stderr.
 // This keeps stdout reserved for query results and the --inspect JSON report,
-// so machine-readable output is never mixed with import banners. Ref #306.
+// so machine-readable output is never mixed with import banners.
 func (s *Shell) importStatusWriter() io.Writer {
 	return config.Stderr
 }
@@ -705,13 +701,11 @@ func validatePath(path string) (string, error) {
 
 	// No directory-depth limit: sqly is a local CLI run with the user's own
 	// permissions, so legitimate deeply nested workspace paths must import. Ref
-	// #316.
 
 	// Check for dangerous patterns that could indicate path traversal attacks.
 	// URL-encoded sequences (..%2f, ..%5c) are intentionally NOT matched: the
 	// filesystem never URL-decodes a path, so those bytes only ever appear in a
 	// legitimate literal filename, and matching them rejected real files. Ref
-	// #317.
 	dangerousPatterns := []string{
 		"../../../",    // Multiple levels up
 		"..\\..\\..\\", // Windows path traversal
@@ -744,7 +738,7 @@ func validatePath(path string) (string, error) {
 // file by its name, and these pseudo-files carry no format extension, so their
 // content is copied to "<table>.csv" and read as CSV (sqly's default text format);
 // use --stdin FORMAT for a non-CSV stream. Only the allowed pseudo-files are
-// staged, so an ordinary unsupported path still fails as before. Ref #461, #462.
+// staged, so an ordinary unsupported path still fails as before.
 func (s *Shell) stagePseudoFileAsCSV(path string) (stagedPath string, cleanup func(), ok bool) {
 	abs := path
 	if a, err := filepath.Abs(path); err == nil {
@@ -775,10 +769,10 @@ func (s *Shell) stagePseudoFileAsCSV(path string) (stagedPath string, cleanup fu
 // isAllowedPseudoFile reports whether an absolute path is a standard Unix
 // pseudo-file that holds legitimate, user-controlled input even though it lives
 // under a system directory. These are exempt from the system-directory guard:
-//   - /dev/shm/*            tmpfs for user data (Ref #427)
-//   - /dev/fd/*             open file descriptors, process substitution (Ref #428)
-//   - /dev/stdin, /dev/stdout, /dev/stderr  standard stream pseudo-files (Ref #461)
-//   - /proc/<pid|self>/fd/* the Linux fd aliases behind many fd-based workflows (Ref #462)
+//   - /dev/shm/*            tmpfs for user data ()
+//   - /dev/fd/*             open file descriptors, process substitution ()
+//   - /dev/stdin, /dev/stdout, /dev/stderr  standard stream pseudo-files ()
+//   - /proc/<pid|self>/fd/* the Linux fd aliases behind many fd-based workflows ()
 func isAllowedPseudoFile(absPath string) bool {
 	switch absPath {
 	case "/dev/stdin", "/dev/stdout", "/dev/stderr":
@@ -844,7 +838,7 @@ func extractSheetNameFromArgs(argv []string) string {
 // or the joined form (`--sheet=`). An empty value is the "no sheet" sentinel, so
 // accepting it would silently import every sheet; the caller rejects it instead.
 // A bare trailing --sheet with no value at all is left to the main loop, which
-// reports it as a missing value. Ref #354, #355.
+// reports it as a missing value.
 func helperSheetExplicitlyEmpty(argv []string) bool {
 	for i := 0; i < len(argv); i++ {
 		a := argv[i]

--- a/shell/import_collision_test.go
+++ b/shell/import_collision_test.go
@@ -28,14 +28,14 @@ func runBatchShell(t *testing.T, args []string, stdin string) error {
 }
 
 // TestImportCollisionRegressions covers the v0.19.0 directory-import collision
-// bugs (#415, #416, #417, #429): re-importing a directory-sourced file directly
+// bugs: re-importing a directory-sourced file directly
 // should clear the directory marker, a standalone file should be able to replace
 // a directory-imported table, a same-source symlink alias is not a collision, and
 // directory re-imports must not mis-detect basename-prefix tables as collisions.
 func TestImportCollisionRegressions(t *testing.T) {
 	const csv = "id,name\n1,a\n"
 
-	t.Run("re-importing a directory-sourced file directly makes it saveable (#415)", func(t *testing.T) {
+	t.Run("re-importing a directory-sourced file directly makes it saveable", func(t *testing.T) {
 		dir := t.TempDir()
 		sub := filepath.Join(dir, "sub")
 		if err := os.Mkdir(sub, 0o750); err != nil {
@@ -49,7 +49,7 @@ func TestImportCollisionRegressions(t *testing.T) {
 		}
 	})
 
-	t.Run("standalone file replaces a directory-imported table (#416)", func(t *testing.T) {
+	t.Run("standalone file replaces a directory-imported table", func(t *testing.T) {
 		dir := t.TempDir()
 		sub := filepath.Join(dir, "sub")
 		if err := os.Mkdir(sub, 0o750); err != nil {
@@ -64,7 +64,7 @@ func TestImportCollisionRegressions(t *testing.T) {
 		}
 	})
 
-	t.Run("same-source symlink alias is not a collision (#417)", func(t *testing.T) {
+	t.Run("same-source symlink alias is not a collision", func(t *testing.T) {
 		dir := t.TempDir()
 		src := writeCSV(t, dir, "user.csv", csv)
 		aliasDir := filepath.Join(dir, "alias")
@@ -82,7 +82,7 @@ func TestImportCollisionRegressions(t *testing.T) {
 		}
 	})
 
-	t.Run("directory re-import does not mis-detect basename-prefix tables (#429)", func(t *testing.T) {
+	t.Run("directory re-import does not mis-detect basename-prefix tables", func(t *testing.T) {
 		dir := t.TempDir()
 		sub := filepath.Join(dir, "d")
 		if err := os.Mkdir(sub, 0o750); err != nil {

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -70,13 +70,12 @@ func TestImportDirectory_ReimportSameDir_ReportsOverwrite(t *testing.T) {
 	// Re-importing the same directory overwrites the existing table. The
 	// directory still contains a supported file, so the import is reported as
 	// successful (it overwrote data) rather than as "No supported files". Ref
-	// #361.
 	imported, _, err = s.importDirectory(ctx, dir, dir, "", false)
 	if err != nil {
 		t.Fatalf("second import: %v", err)
 	}
 	if !imported {
-		t.Error("expected re-import of a directory with a supported file to report imported=true (#361)")
+		t.Error("expected re-import of a directory with a supported file to report imported=true")
 	}
 }
 
@@ -95,8 +94,8 @@ func copyTestFile(t *testing.T, name, dst string) {
 
 func TestImportDirectory_RecordsPerFileSource(t *testing.T) {
 	// Directory --inspect must report each table's real source file, even when
-	// the basename is sanitized (#357) or the file produces multiple tables such
-	// as Excel/ACH/Fedwire (#358). The directory path must never be used as a
+	// the basename is sanitized or the file produces multiple tables such
+	// as Excel/ACH/Fedwire. The directory path must never be used as a
 	// table source.
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {
@@ -144,7 +143,7 @@ func TestImportDirectory_RecordsPerFileSource(t *testing.T) {
 
 func TestImportDirectory_RejectsDuplicateBasenameCollision(t *testing.T) {
 	// Two files that map to the same table name from different subdirectories must
-	// be rejected instead of one silently overwriting the other. Ref #359.
+	// be rejected instead of one silently overwriting the other.
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {
 		t.Fatal(err)
@@ -176,7 +175,6 @@ func TestImportDirectory_RejectsDuplicateBasenameCollision(t *testing.T) {
 
 func TestImportDirectory_RejectsSanitizedCollision(t *testing.T) {
 	// Two files whose names sanitize to the same table name must be rejected. Ref
-	// #360.
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {
 		t.Fatal(err)
@@ -204,7 +202,7 @@ func TestImportDirectory_ReimportOverFileImport_UpdatesSourceAndBlocksSave(t *te
 	// A directory import that overwrites a table previously loaded from a file
 	// argument must update the table's source to the directory file and mark it as
 	// a directory import, so later .save --force cannot write the directory rows
-	// back into the original file. Ref #361, #362.
+	// back into the original file.
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {
 		t.Fatal(err)
@@ -242,19 +240,19 @@ func TestImportDirectory_ReimportOverFileImport_UpdatesSourceAndBlocksSave(t *te
 		t.Fatalf("importDirectory re-import: %v", err)
 	}
 	if !imported {
-		t.Error("expected the directory re-import to report imported=true (#361)")
+		t.Error("expected the directory re-import to report imported=true")
 	}
 	if !s.dirImported["user"] {
-		t.Error("user must be marked as a directory import after re-import (#362)")
+		t.Error("user must be marked as a directory import after re-import")
 	}
 	absDirFile, _ := filepath.Abs(dirFile)
 	if got := s.tableSources["user"]; got != absDirFile {
-		t.Errorf("user source = %q, want the directory file %q (#362)", got, absDirFile)
+		t.Errorf("user source = %q, want the directory file %q", got, absDirFile)
 	}
 
 	// .save --force must now refuse to write back, leaving the original untouched.
 	if err := s.writeBack(ctx, ""); err == nil {
-		t.Error("expected .save --force to be rejected for a directory-imported table (#362)")
+		t.Error("expected .save --force to be rejected for a directory-imported table")
 	}
 	after, err := os.ReadFile(orig) //nolint:gosec // test path
 	if err != nil {
@@ -296,7 +294,7 @@ func TestShell_importDirectory_importsAndReportsTables(t *testing.T) {
 	}
 
 	var imported bool
-	// Import progress goes to stderr (#306), so capture stderr here.
+	// Import progress goes to stderr, so capture stderr here.
 	out := captureStderr(t, func() {
 		imported, _, err = s.importDirectory(context.Background(), dir, "fixtures", "", false)
 	})
@@ -731,7 +729,7 @@ func TestImportDirectory_WithCSVFiles(t *testing.T) {
 }
 
 func TestImportCommand_TableNameCollision(t *testing.T) {
-	// Regression for #286: two inputs that sanitize to the same table name must
+	// Regression for: two inputs that sanitize to the same table name must
 	// fail instead of one silently overwriting the other.
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {
@@ -757,7 +755,7 @@ func TestImportCommand_TableNameCollision(t *testing.T) {
 
 func TestImportCommand_ReimportSameFileIsNotACollision(t *testing.T) {
 	// Re-importing the same source path is a harmless last-wins overwrite, not a
-	// collision; it must not be rejected by the #286 collision check.
+	// collision; it must not be rejected by the collision check.
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {
 		t.Fatal(err)
@@ -793,7 +791,7 @@ func TestImportCommand_PartialSuccess(t *testing.T) {
 	ctx := context.Background()
 	// One valid file + one missing file → partial failure. The valid table is
 	// still loaded, but importCommand returns errPartialImport so non-interactive
-	// runs exit non-zero (#297). The loaded table remains queryable.
+	// runs exit non-zero. The loaded table remains queryable.
 	err = s.commands.importCommand(ctx, s, []string{csvPath, "missing.csv"})
 	if !errors.Is(err, errPartialImport) {
 		t.Errorf("expected errPartialImport for partial failure, got: %v", err)
@@ -852,7 +850,7 @@ func TestImportCommand_MissingSheetValueErrors(t *testing.T) {
 func TestSheetAppliesTo_UnreadableDirectoryDefersToImport(t *testing.T) {
 	// An unreadable directory cannot be proven to lack Excel files, so --sheet
 	// validation must defer to the import step (which reports the real access
-	// error) instead of misclassifying it as a non-Excel input. Ref #356.
+	// error) instead of misclassifying it as a non-Excel input.
 	if runtime.GOOS == "windows" {
 		t.Skip("directory permission bits behave differently on Windows")
 	}
@@ -885,7 +883,7 @@ func TestSheetAppliesTo_UnreadableDirectoryDefersToImport(t *testing.T) {
 func TestImportCommand_SheetSkipsWorkbooksMissingSheet(t *testing.T) {
 	// A multi-workbook import with --sheet must skip workbooks that lack the
 	// requested sheet instead of failing the whole import, so matching workbooks
-	// still load. Ref #378.
+	// still load.
 	s, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {
 		t.Fatal(err)
@@ -933,14 +931,13 @@ func TestImportCommand_EmptySheetValueRejected(t *testing.T) {
 	// An explicit empty helper --sheet value (separated "" or joined "--sheet=")
 	// must be rejected instead of silently importing every sheet. The rejection
 	// must happen before file/Excel checks, so it surfaces even for a CSV input.
-	// Ref #354, #355.
 	csv := filepath.Join("testdata", "sample.csv")
 	tests := []struct {
 		name string
 		argv []string
 	}{
-		{"separated empty sheet value (#354)", []string{"--sheet", "", csv}},
-		{"joined empty sheet value (#355)", []string{"--sheet=", csv}},
+		{"separated empty sheet value", []string{"--sheet", "", csv}},
+		{"joined empty sheet value", []string{"--sheet=", csv}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -974,9 +971,9 @@ func TestValidatePath_Import(t *testing.T) {
 		{"relative path", "./foo/bar.csv", false, false},
 		{"path traversal", "../../../etc/passwd", true, false},
 		// A literal filename containing "..%2f" is not traversal: the filesystem
-		// never URL-decodes it, so it must be accepted. Ref #317.
+		// never URL-decodes it, so it must be accepted.
 		{"literal ..%2f filename", "data/..%2fuser.csv", false, false},
-		// Deep paths must import regardless of nesting depth. Ref #316.
+		// Deep paths must import regardless of nesting depth.
 		{"deep path", "a/b/c/d/e/f/g/h/i/j/k/user.csv", false, false},
 		{"system dir /etc", "/etc/hosts", true, true},
 		{"system dir /proc", "/proc/cpuinfo", true, true},
@@ -1034,9 +1031,9 @@ func TestTableNameSet(t *testing.T) {
 }
 
 // TestStagePseudoFileScopedToPseudoFiles verifies that the pseudo-file CSV
-// staging added for #461/#462 is scoped to the allowed Unix pseudo-files only: a
+// staging added for/ is scoped to the allowed Unix pseudo-files only: a
 // normal extensionless file is not silently treated as CSV but still fails as an
-// unsupported format. Ref #461, #462.
+// unsupported format.
 func TestStagePseudoFileScopedToPseudoFiles(t *testing.T) {
 	shell, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {

--- a/shell/inspect.go
+++ b/shell/inspect.go
@@ -58,7 +58,7 @@ func (s *Shell) validateInspectFlags() error {
 	// An output mode flag (--csv, --tsv, --ltsv, --json, --ndjson, --markdown,
 	// --excel, --parquet) selects a result format, but --inspect always emits its
 	// own JSON report. Reject the conflicting flag instead of silently discarding
-	// it, matching the other --inspect conflict checks. Ref #390.
+	// it, matching the other --inspect conflict checks.
 	case s.argument.Output != nil && s.argument.Output.Mode != model.PrintModeTable:
 		return fmt.Errorf("--inspect cannot be combined with an output mode flag (--%s)", s.argument.Output.Mode.String())
 	}

--- a/shell/inspect_test.go
+++ b/shell/inspect_test.go
@@ -57,7 +57,7 @@ func writeCSV(t *testing.T, dir, name, content string) string {
 }
 
 func TestInspect_RejectsConflictingFlags(t *testing.T) {
-	// Regression for #288: --inspect must reject other effectful flags instead
+	// Regression for: --inspect must reject other effectful flags instead
 	// of silently discarding them.
 	dir := t.TempDir()
 	csv := writeCSV(t, dir, "people.csv", "name,age\nAlice,30\n")
@@ -222,7 +222,7 @@ func TestInspect_Directory(t *testing.T) {
 	if len(report.Tables) != 2 {
 		t.Fatalf("expected 2 tables from directory, got %d", len(report.Tables))
 	}
-	// Each table reports its real source file, not the directory path. Ref #326.
+	// Each table reports its real source file, not the directory path.
 	want := map[string]string{
 		"one": filepath.Join(sub, "one.csv"),
 		"two": filepath.Join(sub, "two.csv"),
@@ -235,7 +235,7 @@ func TestInspect_Directory(t *testing.T) {
 }
 
 func TestWriteBack_RejectsDirectoryImport(t *testing.T) {
-	// Regression for #261/#326: a directory-imported table reports its per-file
+	// Regression for/: a directory-imported table reports its per-file
 	// source in --inspect, but write-back must still reject it.
 	shell, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {

--- a/shell/output_safety_test.go
+++ b/shell/output_safety_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestEnsureNotDirectory covers rejecting directory-like output destinations:
-// an existing directory and a path ending with a path separator (#419, #420).
+// an existing directory and a path ending with a path separator.
 func TestEnsureNotDirectory(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -35,7 +35,7 @@ func TestEnsureNotDirectory(t *testing.T) {
 }
 
 // TestSameFilePathSymlink verifies that a symlink alias to a file is recognized
-// as the same file, so the overwrite guard cannot be bypassed. Ref #394, #418.
+// as the same file, so the overwrite guard cannot be bypassed.
 func TestSameFilePathSymlink(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/shell/save.go
+++ b/shell/save.go
@@ -27,13 +27,23 @@ func (c CommandList) saveCommand(ctx context.Context, s *Shell, argv []string) e
 		fmt.Fprintln(config.Stdout, "  Only csv/tsv/ltsv/parquet sources are written; compression is preserved.")
 		return nil
 	}
+	// Reject an empty destination so `.save ""` is not treated as an in-place
+	// save, which would bypass the --force safeguard.
+	if argv[0] != forceArg && strings.TrimSpace(argv[0]) == "" {
+		return errors.New(".save requires a non-empty directory; use .save --force to overwrite sources in place")
+	}
+	// A read-only session changed no table data, so there is nothing to persist.
+	// Writing here would rewrite source files (or emit fresh directory exports)
+	// with no logical change, normalizing bytes (e.g. the trailing newline) and
+	// producing surprising diffs and checksum churn. This mirrors the
+	// non-interactive --save/--save-dir contract, which also skips write-back for
+	// a read-only run.
+	if !s.dataChanged {
+		fmt.Fprintln(config.Stderr, "no table data changed in this session; nothing to save")
+		return nil
+	}
 	if argv[0] == forceArg {
 		return s.writeBack(ctx, "")
-	}
-	// Reject an empty destination so `.save ""` is not treated as an in-place
-	// save, which would bypass the --force safeguard. Ref #323.
-	if strings.TrimSpace(argv[0]) == "" {
-		return errors.New(".save requires a non-empty directory; use .save --force to overwrite sources in place")
 	}
 	return s.writeBack(ctx, argv[0])
 }
@@ -54,8 +64,7 @@ func (s *Shell) validateSaveFlags() error {
 	}
 	// --sql-file is a non-interactive execution path just like --sql and piped
 	// input, so it may carry write-back even when stdin is a TTY. Reject the save
-	// flags only for a genuinely interactive run with no query source. Ref #366,
-	// #367.
+	// flags only for a genuinely interactive run with no query source.,
 	if s.argument.Query == "" && s.argument.SQLFilePath == "" && s.isTTY() {
 		return errors.New("--save/--save-dir require --sql, --sql-file, or piped input; use the .save command in the interactive shell")
 	}
@@ -90,9 +99,9 @@ func (s *Shell) maybeSave(ctx context.Context) error {
 }
 
 // preflightSave validates write-back before the SQL runs, so a run that cannot
-// persist fails before any query output reaches stdout (#375) and before any
-// file is written (#370, #372, #377). It is a no-op when no save flag is set or
-// when the SQL is read-only, because a read-only run skips write-back (#376).
+// persist fails before any query output reaches stdout and before any
+// file is written. It is a no-op when no save flag is set or
+// when the SQL is read-only, because a read-only run skips write-back.
 func (s *Shell) preflightSave(ctx context.Context, script string) error {
 	if !s.saveRequested() {
 		return nil
@@ -100,8 +109,7 @@ func (s *Shell) preflightSave(ctx context.Context, script string) error {
 	// Reject a statement whose effect write-back cannot represent (DDL, schema
 	// changes, ANALYZE, maintenance). Only read-only queries and row-modifying DML
 	// on imported tables are persisted, so a schema-only run must fail loudly here
-	// instead of exiting 0 while leaving the source unchanged. Ref #433-#437,
-	// #469-#484.
+	// instead of exiting 0 while leaving the source unchanged.,
 	if stmt := firstSaveIncompatibleStatement(script); stmt != "" {
 		return fmt.Errorf(
 			"--save/--save-dir cannot persist %q: it changes schema or runs a maintenance statement that has no file write-back; only INSERT/UPDATE/DELETE on imported tables are saved",
@@ -109,7 +117,7 @@ func (s *Shell) preflightSave(ctx context.Context, script string) error {
 	}
 	// A script that imports its own input with .import creates its tables while it
 	// runs, so they cannot be listed up front. Defer write-back validation to the
-	// post-run save, which sees the imported tables. Ref #456.
+	// post-run save, which sees the imported tables.
 	if scriptImportsInput(script) {
 		return nil
 	}
@@ -123,17 +131,17 @@ func (s *Shell) preflightSave(ctx context.Context, script string) error {
 // finishNonInteractive runs write-back after a non-interactive run, but only when
 // a save flag is set and the run actually changed data. A read-only run, an
 // EXPLAIN, or a zero-row DML leaves the imported tables unchanged, so write-back
-// is skipped to avoid rewriting source files. Ref #376, #402, #403, #404, #405.
+// is skipped to avoid rewriting source files.
 func (s *Shell) finishNonInteractive(ctx context.Context) error {
 	if s.saveRequested() && s.dataChanged {
 		// Run write-back first. If it fails, return before flushing the buffered
-		// affected counts so stdout stays free of success text. Ref #396.
+		// affected counts so stdout stays free of success text.
 		if err := s.maybeSave(ctx); err != nil {
 			return err
 		}
 	}
 	// The run succeeded (write-back ran, or there was nothing to write back), so
-	// flush the buffered affected counts to stdout now. Ref #396.
+	// flush the buffered affected counts to stdout now.
 	for _, msg := range s.pendingAffected {
 		fmt.Fprint(config.Stdout, msg)
 	}
@@ -171,9 +179,9 @@ func (s *Shell) writeBack(ctx context.Context, destDir string) error {
 
 // planWriteBack validates that every current table can be written and returns the
 // resolved write targets. It reports all problems at once and writes nothing, so
-// a session is never partially saved (Ref #377). For --save-dir it also rejects a
-// destination that resolves to the source file (Ref #370) and a destination that
-// already exists (Ref #372).
+// a session is never partially saved (). For --save-dir it also rejects a
+// destination that resolves to the source file () and a destination that
+// already exists ().
 func (s *Shell) planWriteBack(ctx context.Context, destDir string) ([]writeTarget, error) {
 	tables, err := s.usecases.metadata.TablesName(ctx)
 	if err != nil {
@@ -212,7 +220,7 @@ func (s *Shell) planWriteBack(ctx context.Context, destDir string) ([]writeTarge
 		}
 		// A directory import is not a single editable source the session owns, so
 		// reject it even though its source may point at a per-file path for
-		// --inspect provenance. Ref #326, #261.
+		// --inspect provenance.
 		if s.dirImported[name] {
 			problems = append(problems, fmt.Sprintf("%s: came from a directory import (%s)", name, source))
 			continue
@@ -236,13 +244,13 @@ func (s *Shell) planWriteBack(ctx context.Context, destDir string) ([]writeTarge
 			dest = filepath.Join(destDir, filepath.Base(source))
 			// A --save-dir destination that resolves to the source file would
 			// overwrite it in place without --force, defeating the "originals
-			// untouched" contract. Ref #370.
+			// untouched" contract.
 			if sameFilePath(dest, source) {
 				problems = append(problems, fmt.Sprintf("%s: --save-dir destination %s is the source file; use --save --force to overwrite it in place", name, dest))
 				continue
 			}
 			// Refuse to overwrite a pre-existing destination so --save-dir never
-			// silently clobbers an unrelated file. Ref #372, #377. An in-place
+			// silently clobbers an unrelated file. An in-place
 			// --save intentionally overwrites its own source, so this check is
 			// scoped to --save-dir.
 			if info, statErr := os.Stat(dest); statErr == nil {
@@ -295,7 +303,7 @@ func (s *Shell) executeWriteBack(ctx context.Context, destDir string, targets []
 // sameFilePath reports whether two paths resolve to the same file location. It
 // resolves symlinks and, when both paths exist, compares file identity, so a
 // symlink (or hardlink) alias to an imported source is recognized as the source
-// file and cannot bypass the overwrite guard. Ref #394, #418. A non-existent
+// file and cannot bypass the overwrite guard. A non-existent
 // path falls back to its cleaned absolute form.
 func sameFilePath(a, b string) bool {
 	if resolveFilePath(a) == resolveFilePath(b) {
@@ -340,7 +348,7 @@ func writableExportTarget(source string) (model.ExportFormat, model.Compression,
 	}
 	// bzip2 has no writer, so a .bz2 source cannot be written back. Reject it here
 	// during preflight, before any destination file is created or truncated, so a
-	// failed write-back never leaves an empty or corrupted file behind. Ref #395.
+	// failed write-back never leaves an empty or corrupted file behind.
 	if comp == model.CompressionBzip2 {
 		return 0, model.CompressionNone, false
 	}

--- a/shell/save_test.go
+++ b/shell/save_test.go
@@ -125,6 +125,177 @@ func TestWriteBack_SaveInPlaceWithForce(t *testing.T) {
 	}
 }
 
+// TestRunSaveRejectsPragma verifies that a non-interactive --save/--save-dir run
+// rejects a side-effecting PRAGMA before execution, so it never implies a durable
+// effect or prints a rowset that cannot be written back.
+func TestRunSaveRejectsPragma(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"setter PRAGMA with --save --force", []string{"sqly", "--sql", "PRAGMA user_version=1", "--save", "--force"}},
+		{"command PRAGMA with --save --force", []string{"sqly", "--sql", "PRAGMA incremental_vacuum", "--save", "--force"}},
+		{"rowset PRAGMA with --save --force", []string{"sqly", "--sql", "PRAGMA journal_mode=OFF", "--save", "--force"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			src := writeCSV(t, dir, "psample.csv", "user_name,identifier\na,1\n")
+			args := append(append([]string{}, tc.args...), src)
+
+			shell, cleanup, err := newShell(t, args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+			shell.isTTY = func() bool { return true }
+
+			backup := config.Stdout
+			var buf strings.Builder
+			config.Stdout = &buf
+			defer func() { config.Stdout = backup }()
+
+			if runErr := shell.Run(context.Background()); runErr == nil {
+				t.Fatal("expected a PRAGMA save-incompatibility error, got nil")
+			}
+			if buf.Len() != 0 {
+				t.Errorf("stdout should stay empty on rejection, got %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestRunSaveDirRejectsPragma covers the --save-dir variant of the PRAGMA
+// save-incompatibility rejection.
+func TestRunSaveDirRejectsPragma(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"setter PRAGMA with --save-dir", "PRAGMA user_version=1"},
+		{"command PRAGMA with --save-dir", "PRAGMA incremental_vacuum"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			src := writeCSV(t, dir, "psample.csv", "user_name,identifier\na,1\n")
+			outDir := filepath.Join(dir, "out")
+
+			shell, cleanup, err := newShell(t, []string{"sqly", "--sql", tc.query, "--save-dir", outDir, src})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+			shell.isTTY = func() bool { return true }
+
+			if runErr := shell.Run(context.Background()); runErr == nil {
+				t.Fatal("expected a PRAGMA save-incompatibility error, got nil")
+			}
+			if _, statErr := os.Stat(outDir); statErr == nil {
+				t.Errorf("save directory %s should not be created on rejection", outDir)
+			}
+		})
+	}
+}
+
+// TestSaveCommandReadOnlySessionLeavesSourceUntouched verifies that interactive
+// .save --force after a read-only session does not rewrite the source file (which
+// would normalize its bytes), and .save DIR writes no export.
+func TestSaveCommandReadOnlySessionLeavesSourceUntouched(t *testing.T) {
+	// No trailing newline, so any rewrite that normalizes it is detectable.
+	const content = "user_name,identifier\nalice,1"
+
+	setup := func(t *testing.T, name string) (*Shell, func(), string) {
+		t.Helper()
+		dir := t.TempDir()
+		src := filepath.Join(dir, name)
+		if err := os.WriteFile(src, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		shell, cleanup, err := newShell(t, []string{"sqly"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := shell.commands.importCommand(context.Background(), shell, []string{src}); err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+		// A read-only query must not mark the session as changed.
+		if _, err := getExecStdOutput(t, shell.exec, "SELECT * FROM "+strings.TrimSuffix(name, ".csv")); err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+		return shell, cleanup, src
+	}
+
+	t.Run(".save --force does not rewrite an unchanged source", func(t *testing.T) {
+		shell, cleanup, src := setup(t, "readonly.csv")
+		defer cleanup()
+
+		backup := config.Stderr
+		config.Stderr = &strings.Builder{}
+		defer func() { config.Stderr = backup }()
+
+		if err := shell.commands.saveCommand(context.Background(), shell, []string{forceArg}); err != nil {
+			t.Fatalf(".save --force returned error: %v", err)
+		}
+		after, _ := os.ReadFile(src) //nolint:gosec // test path
+		if string(after) != content {
+			t.Errorf("read-only .save --force rewrote the source:\n got %q\nwant %q", after, content)
+		}
+	})
+
+	t.Run(".save DIR writes no export for an unchanged session", func(t *testing.T) {
+		shell, cleanup, src := setup(t, "readonly2.csv")
+		defer cleanup()
+		outDir := filepath.Join(filepath.Dir(src), "out")
+
+		backup := config.Stderr
+		config.Stderr = &strings.Builder{}
+		defer func() { config.Stderr = backup }()
+
+		if err := shell.commands.saveCommand(context.Background(), shell, []string{outDir}); err != nil {
+			t.Fatalf(".save DIR returned error: %v", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(outDir, "readonly2.csv")); statErr == nil {
+			t.Error("read-only .save DIR wrote an export when no data changed")
+		}
+	})
+}
+
+// TestSaveCommandPersistsAfterDataChange guards that the read-only no-op does not
+// also suppress a legitimate save after the session modified table data.
+func TestSaveCommandPersistsAfterDataChange(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "changed.csv")
+	if err := os.WriteFile(src, []byte("user_name,identifier\nalice,1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if err := shell.commands.importCommand(context.Background(), shell, []string{src}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getExecStdOutput(t, shell.exec, "UPDATE changed SET identifier=2 WHERE user_name='alice'"); err != nil {
+		t.Fatal(err)
+	}
+
+	backup := config.Stderr
+	config.Stderr = &strings.Builder{}
+	defer func() { config.Stderr = backup }()
+
+	if err := shell.commands.saveCommand(context.Background(), shell, []string{forceArg}); err != nil {
+		t.Fatalf(".save --force after a change returned error: %v", err)
+	}
+	after, _ := os.ReadFile(src) //nolint:gosec // test path
+	if !strings.Contains(string(after), "alice,2") {
+		t.Errorf(".save --force did not persist the change; got %q", after)
+	}
+}
+
 func TestWriteBack_UnsupportedSourceErrors(t *testing.T) {
 	dir := t.TempDir()
 	// JSON loads into a single data column and does not round-trip, so write-back
@@ -135,7 +306,7 @@ func TestWriteBack_UnsupportedSourceErrors(t *testing.T) {
 	}
 
 	// A modifying statement triggers write-back (a read-only query would skip it,
-	// Ref #376), so the unsupported-source rejection is exercised.
+	//), so the unsupported-source rejection is exercised.
 	shell, cleanup, err := newShell(t, []string{"sqly", "--sql", "DELETE FROM data WHERE 1=0", "--save", "--force", jsonPath})
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +321,7 @@ func TestWriteBack_UnsupportedSourceErrors(t *testing.T) {
 func TestWriteBack_SaveDirRejectsSourceParent(t *testing.T) {
 	// --save-dir pointed at the source's own directory resolves the destination to
 	// the source file, which would overwrite it in place without --force. Reject
-	// it and leave the source untouched. Ref #370.
+	// it and leave the source untouched.
 	dir := t.TempDir()
 	src := writeCSV(t, dir, "user.csv", "user_name,identifier,first_name,last_name\na,1,A,One\n")
 	orig, _ := os.ReadFile(src) //nolint:gosec // test path
@@ -173,7 +344,7 @@ func TestWriteBack_SaveDirRejectsSourceParent(t *testing.T) {
 
 func TestWriteBack_OutputRejectsSourceAlias(t *testing.T) {
 	// --output that aliases an imported source file would destroy the dataset
-	// without --save --force. Reject it and leave the source untouched. Ref #371.
+	// without --save --force. Reject it and leave the source untouched.
 	dir := t.TempDir()
 	src := writeCSV(t, dir, "user.csv", "user_name,identifier,first_name,last_name\na,1,A,One\n")
 	orig, _ := os.ReadFile(src) //nolint:gosec // test path
@@ -200,7 +371,7 @@ func TestWriteBack_OutputRejectsSourceAlias(t *testing.T) {
 
 func TestWriteBack_SaveDirRejectsExistingDestination(t *testing.T) {
 	// --save-dir must not silently overwrite a pre-existing file in the
-	// destination directory. Ref #372.
+	// destination directory.
 	dir := t.TempDir()
 	src := writeCSV(t, dir, "user.csv", "user_name,identifier,first_name,last_name\na,1,A,One\n")
 	out := filepath.Join(dir, "out")
@@ -232,7 +403,6 @@ func TestWriteBack_SaveDirRejectsExistingDestination(t *testing.T) {
 func TestWriteBack_FailedWriteBackKeepsStdoutClean(t *testing.T) {
 	// When a run ultimately fails during write-back, stdout must stay free of the
 	// DML success count so scripts do not treat it as partially successful. Ref
-	// #375.
 	dir := t.TempDir()
 	src := writeCSV(t, dir, "user.csv", "user_name,identifier,first_name,last_name\na,1,A,One\n")
 	xlsx := filepath.Join(dir, "sample.xlsx")
@@ -257,7 +427,6 @@ func TestWriteBack_FailedWriteBackKeepsStdoutClean(t *testing.T) {
 
 func TestWriteBack_ReadOnlyQuerySkipsWriteBack(t *testing.T) {
 	// A read-only query under --save --force must not rewrite the source file. Ref
-	// #376.
 	dir := t.TempDir()
 	src := writeCSV(t, dir, "user.csv", "user_name,identifier,first_name,last_name\na,1,A,One\n")
 	orig, _ := os.ReadFile(src) //nolint:gosec // test path
@@ -280,7 +449,7 @@ func TestWriteBack_ReadOnlyQuerySkipsWriteBack(t *testing.T) {
 
 func TestWriteBack_SaveDirIsAllOrNothing(t *testing.T) {
 	// --save-dir must validate every target before writing any, so one bad target
-	// cannot leave partial output behind. Ref #377.
+	// cannot leave partial output behind.
 	dir := t.TempDir()
 	idSrc := writeCSV(t, dir, "identifier.csv", "identifier\n1\n2\n")
 	userSrc := writeCSV(t, dir, "user.csv", "user_name,identifier,first_name,last_name\na,1,A,One\n")

--- a/shell/save_test.go
+++ b/shell/save_test.go
@@ -305,8 +305,8 @@ func TestWriteBack_UnsupportedSourceErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// A modifying statement triggers write-back (a read-only query would skip it,
-	//), so the unsupported-source rejection is exercised.
+	// A modifying statement triggers write-back (a read-only query would skip it),
+	// so the unsupported-source rejection is exercised.
 	shell, cleanup, err := newShell(t, []string{"sqly", "--sql", "DELETE FROM data WHERE 1=0", "--save", "--force", jsonPath})
 	if err != nil {
 		t.Fatal(err)
@@ -402,7 +402,7 @@ func TestWriteBack_SaveDirRejectsExistingDestination(t *testing.T) {
 
 func TestWriteBack_FailedWriteBackKeepsStdoutClean(t *testing.T) {
 	// When a run ultimately fails during write-back, stdout must stay free of the
-	// DML success count so scripts do not treat it as partially successful. Ref
+	// DML success count so scripts do not treat it as partially successful.
 	dir := t.TempDir()
 	src := writeCSV(t, dir, "user.csv", "user_name,identifier,first_name,last_name\na,1,A,One\n")
 	xlsx := filepath.Join(dir, "sample.xlsx")
@@ -426,7 +426,7 @@ func TestWriteBack_FailedWriteBackKeepsStdoutClean(t *testing.T) {
 }
 
 func TestWriteBack_ReadOnlyQuerySkipsWriteBack(t *testing.T) {
-	// A read-only query under --save --force must not rewrite the source file. Ref
+	// A read-only query under --save --force must not rewrite the source file.
 	dir := t.TempDir()
 	src := writeCSV(t, dir, "user.csv", "user_name,identifier,first_name,last_name\na,1,A,One\n")
 	orig, _ := os.ReadFile(src) //nolint:gosec // test path

--- a/shell/schema.go
+++ b/shell/schema.go
@@ -51,14 +51,20 @@ func isStructuredMode(m model.PrintMode) bool {
 // instead of a lossy reconstruction. Only when no stored SQL is found does it fall
 // back to synthesizing from column metadata. A schema-qualified name (main.user,
 // temp.t) is resolved against that schema. Returns an error when the object does
-// not exist. Ref #445, #451, #463, #464.
+// not exist.
 func (s *Shell) tableCreateStatement(ctx context.Context, tableName string) (string, error) {
 	schema, object := splitTableQualifier(tableName)
-	stored, err := s.storedCreateSQL(ctx, schema, object)
+	stored, isTemp, err := s.storedCreateSQL(ctx, schema, object)
 	if err != nil {
 		return "", err
 	}
 	if stored != "" {
+		// SQLite stores a temp object's SQL with the TEMP keyword removed, so
+		// re-insert it for a temp object to keep the reported schema faithful and
+		// round-trippable to the same kind of object.
+		if isTemp {
+			stored = injectTempKeyword(stored)
+		}
 		return stored, nil
 	}
 
@@ -74,42 +80,91 @@ func (s *Shell) tableCreateStatement(ctx context.Context, tableName string) (str
 }
 
 // storedCreateSQL returns the CREATE statement SQLite stored for a table or view,
-// or "" when none is found. It reads the schema's sqlite_master (or, for a TEMP
-// object or an unqualified name, sqlite_temp_master) so the real definition wins
-// over the synthesized fallback: a view yields its CREATE VIEW, and a constrained
-// or TEMP table yields its original DDL including UNIQUE/CHECK constraints the
-// fallback cannot reconstruct. Ref #451, #463, #464.
-func (s *Shell) storedCreateSQL(ctx context.Context, schema, object string) (string, error) {
-	masters := []string{"sqlite_master", "sqlite_temp_master"}
-	if schema != "" {
-		masters = []string{s.usecases.importer.QuoteIdentifier(schema) + ".sqlite_master"}
+// whether the matched object is a TEMP object, or "" when none is found. It reads
+// the right master table so the real definition wins over the synthesized
+// fallback: a view yields its CREATE VIEW, and a constrained or TEMP table yields
+// its original DDL including UNIQUE/CHECK constraints the fallback cannot
+// reconstruct.
+//
+// An unqualified name is resolved against sqlite_temp_master before sqlite_master,
+// matching SQLite's own temp-before-main lookup, so a TEMP object shadowing an
+// imported main table reports the temp definition the session will actually query.
+// A "temp."/"main."-qualified name is resolved against just that schema.
+func (s *Shell) storedCreateSQL(ctx context.Context, schema, object string) (sqlText string, isTemp bool, err error) {
+	type masterSource struct {
+		table string
+		temp  bool
+	}
+	var sources []masterSource
+	switch {
+	case schema == "":
+		sources = []masterSource{{"sqlite_temp_master", true}, {"sqlite_master", false}}
+	case strings.EqualFold(schema, "temp"):
+		sources = []masterSource{{"sqlite_temp_master", true}}
+	default: // main
+		sources = []masterSource{{"sqlite_master", false}}
 	}
 	// String literal: escape single quotes to query the master tables safely.
 	literal := "'" + strings.ReplaceAll(object, "'", "''") + "'"
-	for _, master := range masters {
+	for _, src := range sources {
 		res, err := s.usecases.query.Query(ctx,
-			"SELECT sql FROM "+master+" WHERE name = "+literal+" AND type IN ('table', 'view') AND sql IS NOT NULL")
+			"SELECT sql FROM "+src.table+" WHERE name = "+literal+" AND type IN ('table', 'view') AND sql IS NOT NULL")
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 		if recs := res.Records(); len(recs) > 0 && len(recs[0]) > 0 && recs[0][0] != "" {
-			return recs[0][0], nil
+			return recs[0][0], src.temp, nil
 		}
 	}
-	return "", nil
+	return "", false, nil
+}
+
+// injectTempKeyword re-inserts the TEMP keyword after CREATE, because SQLite
+// strips TEMP/TEMPORARY from the SQL it stores for a temp object. The guard
+// clauses make it a no-op for a non-CREATE or already temp-qualified statement.
+func injectTempKeyword(createSQL string) string {
+	i := 0
+	for i < len(createSQL) && (createSQL[i] == ' ' || createSQL[i] == '\t' || createSQL[i] == '\n' || createSQL[i] == '\r') {
+		i++
+	}
+	const kw = "CREATE"
+	if !strings.HasPrefix(strings.ToUpper(createSQL[i:]), kw) {
+		return createSQL
+	}
+	after := createSQL[i+len(kw):]
+	upperAfter := strings.ToUpper(strings.TrimLeft(after, " \t\r\n"))
+	if strings.HasPrefix(upperAfter, "TEMP") {
+		return createSQL // already temp-qualified (TEMP or TEMPORARY)
+	}
+	return createSQL[:i+len(kw)] + " TEMP" + after
 }
 
 // splitTableQualifier splits a possibly schema-qualified table reference such as
 // "main.user" or "temp.t" into its schema and object name. A bare name yields an
-// empty schema. The split is on the first dot, which sqly never produces inside an
-// imported table name (dots are sanitized to "_"), so a dot signals a schema
-// qualifier. SQLite accepts a schema-qualified name in SQL, so the helper commands
-// accept it too. Ref #445, #446, #447, #448.
+// empty schema. The split happens only when the prefix before the first dot is a
+// real SQLite schema (main or temp); sqly rejects ATTACH/DETACH, so those are the
+// only schemas a session can have. Any other dotted name (e.g. "a.b") is a literal
+// table identifier and is returned whole, matching `SELECT * FROM "a.b"`. This is
+// why `.schema "a.b"` reaches its table instead of querying a non-existent
+// "a.sqlite_master".
 func splitTableQualifier(name string) (schema, object string) {
-	if i := strings.IndexByte(name, '.'); i > 0 && i < len(name)-1 {
+	if i := strings.IndexByte(name, '.'); i > 0 && i < len(name)-1 && isSchemaName(name[:i]) {
 		return name[:i], name[i+1:]
 	}
 	return "", name
+}
+
+// isSchemaName reports whether prefix is a SQLite schema name a sqly session can
+// reference. Only "main" and "temp" (case-insensitive) qualify: ATTACH/DETACH are
+// rejected, so no other database can be attached. A dotted prefix that is not one
+// of these is therefore part of a literal table name, not a schema qualifier.
+func isSchemaName(prefix string) bool {
+	switch strings.ToLower(prefix) {
+	case "main", "temp":
+		return true
+	default:
+		return false
+	}
 }
 
 // buildCreateStatement assembles a CREATE TABLE statement from PRAGMA

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -74,18 +74,18 @@ type Shell struct {
 	// dirImported marks tables that came from a directory import. Their
 	// tableSources entry may point at the per-file source (for --inspect
 	// provenance), but write-back still rejects them because a directory import
-	// is not a single editable source the session owns. Ref #326, #261.
+	// is not a single editable source the session owns.
 	dirImported map[string]bool
 	// dataChanged is set when an executed statement actually changed table data
 	// (a DML that affected at least one row, or a DML RETURNING that returned at
 	// least one row). A non-interactive run only writes back when data changed, so
-	// an EXPLAIN or a zero-row DML leaves source files untouched. Ref #402, #403,
-	// #404, #405.
+	// an EXPLAIN or a zero-row DML leaves source files untouched.,
+	//,.
 	dataChanged bool
 	// pendingAffected holds "affected is N row(s)" lines produced during a
 	// write-back run. They are buffered rather than printed immediately and flushed
 	// to stdout only after write-back succeeds, so a run that fails during
-	// write-back leaves stdout free of success counts. Ref #396.
+	// write-back leaves stdout free of success counts.
 	pendingAffected []string
 }
 
@@ -161,7 +161,6 @@ func (s *Shell) Run(ctx context.Context) error {
 	// --output is only honored by the --sql path (a single result written to one
 	// file). Without --sql (no query, batch stdin, --sql-file, or interactive)
 	// the flag was silently ignored, so reject it instead of looking successful.
-	// Ref #318, #319.
 	if s.argument.Output.FilePath != "" && s.argument.Query == "" {
 		return errors.New("--output requires --sql")
 	}
@@ -181,7 +180,7 @@ func (s *Shell) Run(ctx context.Context) error {
 	// --stdin stages piped stdin as a dataset, which consumes stdin entirely, so
 	// nothing remains to carry a query. Require an explicit query source;
 	// otherwise the dataset is imported and immediately discarded with a success
-	// exit code. Ref #374.
+	// exit code.
 	if s.argument.StdinFormat != "" && s.argument.Query == "" && s.argument.SQLFilePath == "" && !s.argument.InspectFlag {
 		return errors.New("--stdin provides a dataset but no query was given; add --sql, --sql-file, or --inspect")
 	}
@@ -197,7 +196,7 @@ func (s *Shell) Run(ctx context.Context) error {
 		// --sql-file takes its query from the file, not stdin. Without --stdin to
 		// route piped stdin to a dataset, non-empty piped stdin would be silently
 		// dropped, so reject it and point the user at --stdin. Empty stdin (e.g.
-		// CI redirecting /dev/null) is fine. Ref #373.
+		// CI redirecting /dev/null) is fine.
 		if s.argument.StdinFormat == "" && !s.isTTY() && s.pipedStdinHasData() {
 			return errors.New("--sql-file does not read SQL from stdin; piped stdin would be ignored. Use --stdin FORMAT to load it as a dataset, or remove the pipe")
 		}
@@ -207,7 +206,7 @@ func (s *Shell) Run(ctx context.Context) error {
 		// A partial import (some inputs loaded, some failed) keeps the loaded
 		// tables usable, so the interactive shell still starts after a warning.
 		// Non-interactive modes (--sql, --sql-file, --inspect, batch) treat it as
-		// a hard failure so automation sees a non-zero exit. Ref #297, #300, #302.
+		// a hard failure so automation sees a non-zero exit.
 		if errors.Is(err, errPartialImport) && s.startsInteractiveShell() {
 			fmt.Fprintf(config.Stderr, "%v\n", err)
 		} else {
@@ -227,8 +226,15 @@ func (s *Shell) Run(ctx context.Context) error {
 	}
 
 	if s.argument.Query != "" {
+		// Direct --sql runs exactly one statement and prints (or exports) its single
+		// result. Multiple statements separated by ";" would silently drop every
+		// result but the last, so reject them up front instead of running the input
+		// and discarding output.
+		if n := countSQLStatements(s.argument.Query); n > 1 {
+			return fmt.Errorf("--sql accepts a single SQL statement, but got %d; run one statement per invocation or use --sql-file for a multi-statement script", n)
+		}
 		// Validate write-back before running, so a run that cannot persist fails
-		// before any query output reaches stdout. Ref #375.
+		// before any query output reaches stdout.
 		if err := s.preflightSave(ctx, s.argument.Query); err != nil {
 			return err
 		}
@@ -258,7 +264,7 @@ func (s *Shell) Run(ctx context.Context) error {
 	// Without a terminal (e.g. piped stdin) the interactive prompt cannot
 	// initialize, so read SQL and helper commands from stdin in batch mode. The
 	// whole script is read up front so write-back can be validated before the
-	// first statement runs (#375) and skipped for a read-only script (#376).
+	// first statement runs and skipped for a read-only script.
 	if !s.isTTY() {
 		data, err := io.ReadAll(s.stdin)
 		if err != nil {
@@ -273,7 +279,7 @@ func (s *Shell) Run(ctx context.Context) error {
 			return err
 		}
 		// Skip write-back when nothing ran (e.g. empty stdin), so an empty batch
-		// does not trigger --save/--save-dir side effects. Ref #330, #331.
+		// does not trigger --save/--save-dir side effects.
 		if !ranAny {
 			return nil
 		}
@@ -396,9 +402,9 @@ func (s *Shell) init(ctx context.Context) error {
 	}
 	importErr := s.commands.importCommand(ctx, s, paths)
 	// Re-point any stdin-derived table's source from the ephemeral temp path to
-	// a stable "stdin" marker, so --inspect does not leak the temp path (#290)
+	// a stable "stdin" marker, so --inspect does not leak the temp path
 	// and write-back can reject stdin-backed tables instead of writing to a
-	// deleted temp file (#291).
+	// deleted temp file.
 	if stdinAbsPath != "" {
 		s.remapStdinTableSources(stdinAbsPath)
 	}
@@ -744,8 +750,8 @@ func (s *Shell) execSQL(ctx context.Context, req string) error {
 		return err
 	}
 	// Track whether this statement actually changed data, so write-back runs only
-	// for a run that modified a table (not an EXPLAIN or a zero-row DML). Ref #402,
-	// #403, #404, #405.
+	// for a run that modified a table (not an EXPLAIN or a zero-row DML).,
+	//,,.
 	if statementModifiesData(req) {
 		if table != nil {
 			if len(table.Records()) > 0 {
@@ -758,14 +764,14 @@ func (s *Shell) execSQL(ctx context.Context, req string) error {
 	if table == nil {
 		// --output is only meaningful for a statement that produces a rowset. An
 		// INSERT/UPDATE/DELETE without RETURNING produces only an affected-row
-		// count, so reject --output instead of silently ignoring it. Ref #364.
+		// count, so reject --output instead of silently ignoring it.
 		if s.argument.NeedsOutputToFile() {
 			return errors.New("--output requires a statement that returns rows; an INSERT/UPDATE/DELETE without RETURNING produces none")
 		}
 		msg := statementResultMessage(req, affectedRows)
 		// When a write-back is requested, buffer the result line instead of printing
 		// it now: it is flushed to stdout only after write-back succeeds, so a run
-		// that fails during write-back leaves stdout clean. Ref #396.
+		// that fails during write-back leaves stdout clean.
 		if s.saveRequested() {
 			s.pendingAffected = append(s.pendingAffected, msg)
 			return nil
@@ -790,7 +796,7 @@ func (s *Shell) execSQL(ctx context.Context, req string) error {
 func (s *Shell) outputToFile(table *model.Table) error {
 	// ACH and Fedwire are input-only formats: sqly can read them but cannot
 	// produce them, so reject such a destination instead of silently writing CSV
-	// bytes to a misleading .ach/.fed path. Ref #421.
+	// bytes to a misleading .ach/.fed path.
 	if model.IsInputOnlyExtension(s.argument.Output.FilePath) {
 		return fmt.Errorf("--output destination %q uses an input-only format (ACH/Fedwire); export to csv/tsv/json/parquet instead", s.argument.Output.FilePath)
 	}
@@ -803,7 +809,7 @@ func (s *Shell) outputToFile(table *model.Table) error {
 	filePath := model.BuildOutputPath(s.argument.Output.FilePath, exportFmt, compression)
 	// Refuse an --output destination that aliases an imported source file. A
 	// destructive source write must go through --save --force, not a one-off
-	// export, so a stray --output cannot silently destroy the dataset. Ref #371.
+	// export, so a stray --output cannot silently destroy the dataset.
 	if name, aliased := s.outputAliasesImportedSource(filePath); aliased {
 		return fmt.Errorf("--output destination %s is the source file for table %q; use --save --force to overwrite a source", filePath, name)
 	}
@@ -838,7 +844,7 @@ func (s *Shell) outputAliasesImportedSource(path string) (string, bool) {
 // silently writing to a sibling file (e.g. "out" -> "out.csv") or, for a
 // directory-like path ending in a separator, a hidden file ("outdir/" ->
 // "outdir/.csv"). A path ending in a path separator is rejected up front (Ref
-// #419, #420), as is an existing directory. A plain non-existent path is fine; it
+// ,), as is an existing directory. A plain non-existent path is fine; it
 // is created on write.
 func ensureNotDirectory(path string) error {
 	if path == "" {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1795,7 +1795,7 @@ func TestSplitArgs(t *testing.T) {
 }
 
 func TestShellRun_BatchModeReadsStdin(t *testing.T) {
-	// Regression for issue #246: without a TTY, sqly reads SQL and helper
+	// Regression for issue: without a TTY, sqly reads SQL and helper
 	// commands from stdin instead of failing on prompt initialization.
 	shell, cleanup, err := newShell(t, []string{"sqly", filepath.Join("testdata", "actor.csv")})
 	if err != nil {
@@ -1850,7 +1850,7 @@ func TestShellRunBatch_ReturnsErrorOnCommandFailure(t *testing.T) {
 }
 
 func TestShellRunBatch_FailFast(t *testing.T) {
-	// Regression for #308: the first failed statement stops the batch, so later
+	// Regression for: the first failed statement stops the batch, so later
 	// statements do not run and cannot leak output into a failed pipeline.
 	t.Run("a SQL failure stops a later statement", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly", "--csv"})
@@ -1898,7 +1898,7 @@ func TestShellRunBatch_FailFast(t *testing.T) {
 }
 
 func TestShellRunBatch_EmptyStdinSkipsSave(t *testing.T) {
-	// Regression for #330/#331: empty batch stdin must not trigger --save
+	// Regression for/: empty batch stdin must not trigger --save
 	// write-back, which would rewrite source files even though nothing ran.
 	dir := t.TempDir()
 	src := filepath.Join(dir, "u.csv")
@@ -1932,7 +1932,7 @@ func TestShellRunBatch_EmptyStdinSkipsSave(t *testing.T) {
 }
 
 func TestShellRunBatch_MultilineStatements(t *testing.T) {
-	// Regression for #263: batch mode parses statements, so SQL can span lines.
+	// Regression for: batch mode parses statements, so SQL can span lines.
 	newBatchShell := func(t *testing.T, stdin string) (*Shell, func()) {
 		t.Helper()
 		shell, cleanup, err := newShell(t, []string{"sqly", "--csv"})
@@ -1993,7 +1993,7 @@ func TestShellRunBatch_MultilineStatements(t *testing.T) {
 		}
 	})
 
-	t.Run("semicolon inside a bracket-quoted identifier does not split (#314)", func(t *testing.T) {
+	t.Run("semicolon inside a bracket-quoted identifier does not split", func(t *testing.T) {
 		shell, cleanup := newBatchShell(t, "SELECT 'v' AS [a;b];\n")
 		defer cleanup()
 		got := string(getStdoutForRunFunc(t, shell.Run))
@@ -2002,7 +2002,7 @@ func TestShellRunBatch_MultilineStatements(t *testing.T) {
 		}
 	})
 
-	t.Run("semicolon inside a backtick-quoted identifier does not split (#315)", func(t *testing.T) {
+	t.Run("semicolon inside a backtick-quoted identifier does not split", func(t *testing.T) {
 		shell, cleanup := newBatchShell(t, "SELECT 'v' AS `a;b`;\n")
 		defer cleanup()
 		got := string(getStdoutForRunFunc(t, shell.Run))
@@ -2011,7 +2011,7 @@ func TestShellRunBatch_MultilineStatements(t *testing.T) {
 		}
 	})
 
-	t.Run("semicolon inside a line comment does not split (#299)", func(t *testing.T) {
+	t.Run("semicolon inside a line comment does not split", func(t *testing.T) {
 		shell, cleanup := newBatchShell(t, "-- comment ;\nSELECT 'v' AS x;\n")
 		defer cleanup()
 		got := string(getStdoutForRunFunc(t, shell.Run))
@@ -2020,7 +2020,7 @@ func TestShellRunBatch_MultilineStatements(t *testing.T) {
 		}
 	})
 
-	t.Run("semicolon inside a block comment does not split (#299)", func(t *testing.T) {
+	t.Run("semicolon inside a block comment does not split", func(t *testing.T) {
 		shell, cleanup := newBatchShell(t, "/* comment ; */\nSELECT 'v' AS x;\n")
 		defer cleanup()
 		got := string(getStdoutForRunFunc(t, shell.Run))
@@ -2029,7 +2029,7 @@ func TestShellRunBatch_MultilineStatements(t *testing.T) {
 		}
 	})
 
-	t.Run("semicolon inside a trailing line comment does not split (#299)", func(t *testing.T) {
+	t.Run("semicolon inside a trailing line comment does not split", func(t *testing.T) {
 		shell, cleanup := newBatchShell(t, "SELECT 'first' AS x; -- trailing ; comment\nSELECT 'second' AS y;\n")
 		defer cleanup()
 		got := string(getStdoutForRunFunc(t, shell.Run))
@@ -2122,7 +2122,7 @@ func TestShellRunBatch_QuotedSheetArgument(t *testing.T) {
 }
 
 func TestShellRun_JSONOutputFromCLI(t *testing.T) {
-	// Regression for #237: --json renders query results as a JSON array that
+	// Regression for: --json renders query results as a JSON array that
 	// decodes with the expected column names and values.
 	shell, cleanup, err := newShell(t, []string{"sqly", "--json", "--sql", "SELECT actor FROM actor ORDER BY actor ASC LIMIT 2", filepath.Join("testdata", "actor.csv")})
 	if err != nil {
@@ -2148,7 +2148,7 @@ func TestShellRun_JSONOutputFromCLI(t *testing.T) {
 }
 
 func TestShellExec_NDJSONModeSwitch(t *testing.T) {
-	// Regression for #237: .mode ndjson makes shell query output emit one JSON
+	// Regression for: .mode ndjson makes shell query output emit one JSON
 	// object per line.
 	shell, cleanup, err := newShell(t, []string{"sqly", filepath.Join("testdata", "actor.csv")})
 	if err != nil {
@@ -2184,7 +2184,7 @@ func TestShellExec_NDJSONModeSwitch(t *testing.T) {
 }
 
 func TestShellExec_SchemaAndDescribe(t *testing.T) {
-	// Regression for #238: schema inspection commands over an imported CSV.
+	// Regression for: schema inspection commands over an imported CSV.
 	newImportedShell := func(t *testing.T) (*Shell, func()) {
 		t.Helper()
 		shell, cleanup, err := newShell(t, []string{"sqly"})
@@ -2345,7 +2345,7 @@ func TestShell_buildCreateStatement(t *testing.T) {
 }
 
 func TestShellRun_StdinDataset(t *testing.T) {
-	// Regression for #258: --stdin treats piped stdin as an input dataset.
+	// Regression for: --stdin treats piped stdin as an input dataset.
 	t.Run("queries piped CSV through the default stdin table", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "csv", "--csv", "--sql", "SELECT name FROM stdin ORDER BY id"})
 		if err != nil {
@@ -2400,7 +2400,7 @@ func TestShellRun_StdinDataset(t *testing.T) {
 		}
 	})
 
-	t.Run("inspect reports a stable stdin source, not a temp path (#290)", func(t *testing.T) {
+	t.Run("inspect reports a stable stdin source, not a temp path", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly", "--inspect", "--stdin", "csv"})
 		if err != nil {
 			t.Fatal(err)
@@ -2418,7 +2418,7 @@ func TestShellRun_StdinDataset(t *testing.T) {
 		}
 	})
 
-	t.Run("save is rejected for a stdin-backed table (#291)", func(t *testing.T) {
+	t.Run("save is rejected for a stdin-backed table", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "csv", "--sql", "UPDATE stdin SET name = 'x'", "--save", "--force"})
 		if err != nil {
 			t.Fatal(err)
@@ -2478,7 +2478,7 @@ func TestShellRun_StdinDataset(t *testing.T) {
 }
 
 func TestShellRun_SQLFile(t *testing.T) {
-	// Regression for #281: --sql-file loads SQL from a file for non-interactive
+	// Regression for: --sql-file loads SQL from a file for non-interactive
 	// runs, freeing stdin to carry a piped dataset.
 	t.Run("runs a multiline SQL file against a file input", func(t *testing.T) {
 		dir := t.TempDir()
@@ -2606,7 +2606,7 @@ func TestShellRun_SQLFile(t *testing.T) {
 		}
 	})
 
-	t.Run("returns an error for a comment-only SQL file (#351)", func(t *testing.T) {
+	t.Run("returns an error for a comment-only SQL file", func(t *testing.T) {
 		dir := t.TempDir()
 		sqlPath := filepath.Join(dir, "comments.sql")
 		if err := os.WriteFile(sqlPath, []byte("-- header only\n/* block */\n"), 0o600); err != nil {
@@ -2631,13 +2631,13 @@ func TestShellRun_SQLFile(t *testing.T) {
 
 func TestValidateSaveFlags_SQLFileAllowedOnTTY(t *testing.T) {
 	// --sql-file is a non-interactive execution path, so --save/--save-dir must be
-	// allowed with it even when stdin is a TTY. Ref #366, #367.
+	// allowed with it even when stdin is a TTY.
 	cases := []struct {
 		name string
 		args []string
 	}{
-		{"save-dir with sql-file (#366)", []string{"sqly", "--sql-file", "q.sql", "--save-dir", "out", "f.csv"}},
-		{"save --force with sql-file (#367)", []string{"sqly", "--sql-file", "q.sql", "--save", "--force", "f.csv"}},
+		{"save-dir with sql-file", []string{"sqly", "--sql-file", "q.sql", "--save-dir", "out", "f.csv"}},
+		{"save --force with sql-file", []string{"sqly", "--sql-file", "q.sql", "--save", "--force", "f.csv"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2656,7 +2656,7 @@ func TestValidateSaveFlags_SQLFileAllowedOnTTY(t *testing.T) {
 }
 
 func TestShellRun_SQLFileRejectsPipedStdin(t *testing.T) {
-	// Regression for #373: when --sql-file is used without --stdin, non-empty
+	// Regression for: when --sql-file is used without --stdin, non-empty
 	// piped stdin must be rejected instead of silently discarded.
 	dir := t.TempDir()
 	sqlPath := filepath.Join(dir, "q.sql")
@@ -2682,7 +2682,7 @@ func TestShellRun_SQLFileRejectsPipedStdin(t *testing.T) {
 
 func TestShellRun_SQLFileWithEmptyStdinIsAllowed(t *testing.T) {
 	// A non-TTY run with empty stdin (e.g. CI redirecting /dev/null) must still
-	// work with --sql-file; only non-empty piped stdin is rejected. Ref #373.
+	// work with --sql-file; only non-empty piped stdin is rejected.
 	dir := t.TempDir()
 	sqlPath := filepath.Join(dir, "q.sql")
 	if err := os.WriteFile(sqlPath, []byte("SELECT 1 AS x;\n"), 0o600); err != nil {
@@ -2703,7 +2703,7 @@ func TestShellRun_SQLFileWithEmptyStdinIsAllowed(t *testing.T) {
 }
 
 func TestShellRun_StdinDatasetWithoutQueryFails(t *testing.T) {
-	// Regression for #374: a --stdin dataset run with no query must fail loudly
+	// Regression for: a --stdin dataset run with no query must fail loudly
 	// instead of importing the data and discarding it.
 	shell, cleanup, err := newShell(t, []string{"sqly", "--stdin", "csv"})
 	if err != nil {
@@ -2723,7 +2723,7 @@ func TestShellRun_StdinDatasetWithoutQueryFails(t *testing.T) {
 }
 
 func TestShellRun_BOMStrippedInSQLFile(t *testing.T) {
-	// Regression for #369: a UTF-8 BOM at the start of a --sql-file script must be
+	// Regression for: a UTF-8 BOM at the start of a --sql-file script must be
 	// stripped so the first statement parses.
 	dir := t.TempDir()
 	sqlPath := filepath.Join(dir, "q.sql")
@@ -2744,7 +2744,7 @@ func TestShellRun_BOMStrippedInSQLFile(t *testing.T) {
 }
 
 func TestShellRun_BOMStrippedInBatchStdin(t *testing.T) {
-	// Regression for #369: a UTF-8 BOM at the start of batch stdin must be
+	// Regression for: a UTF-8 BOM at the start of batch stdin must be
 	// stripped so the first statement parses.
 	shell, cleanup, err := newShell(t, []string{"sqly", "--csv", filepath.Join("testdata", "actor.csv")})
 	if err != nil {
@@ -2761,7 +2761,7 @@ func TestShellRun_BOMStrippedInBatchStdin(t *testing.T) {
 }
 
 func TestShellRun_OutputToDirectoryIsRejected(t *testing.T) {
-	// Regression for #303: --output to an existing directory must be rejected,
+	// Regression for: --output to an existing directory must be rejected,
 	// not rewritten to a sibling .csv file.
 	dir := t.TempDir()
 	shell, cleanup, err := newShell(t, []string{"sqly", "--csv", "--sql", "SELECT id FROM sample LIMIT 1", "--output", dir, filepath.Join("testdata", "sample.csv")})
@@ -2784,7 +2784,7 @@ func TestShellRun_OutputToDirectoryIsRejected(t *testing.T) {
 }
 
 func TestShellRun_OutputRejectedForNonRowsetDML(t *testing.T) {
-	// Regression for #364: --output for an UPDATE/DELETE without RETURNING must be
+	// Regression for: --output for an UPDATE/DELETE without RETURNING must be
 	// rejected, not silently ignored, and no output file is created.
 	work := t.TempDir()
 	src := filepath.Join(work, "u.csv")
@@ -2811,7 +2811,7 @@ func TestShellRun_OutputRejectedForNonRowsetDML(t *testing.T) {
 }
 
 func TestShellRun_OutputExportsReturningRows(t *testing.T) {
-	// Regression for #368: a DML statement with RETURNING must create the output
+	// Regression for: a DML statement with RETURNING must create the output
 	// file with the returned rows.
 	work := t.TempDir()
 	src := filepath.Join(work, "u.csv")
@@ -2838,7 +2838,7 @@ func TestShellRun_OutputExportsReturningRows(t *testing.T) {
 }
 
 func TestHelperCommandsRejectExtraArgs(t *testing.T) {
-	// Regression for #327: helper commands must reject unexpected extra
+	// Regression for: helper commands must reject unexpected extra
 	// arguments instead of silently ignoring them.
 	cases := []struct {
 		name string
@@ -2872,7 +2872,7 @@ func TestHelperCommandsRejectExtraArgs(t *testing.T) {
 }
 
 func TestShellRun_OutputRequiresSQL(t *testing.T) {
-	// Regression for #318/#319: --output is honored only with --sql, so it must
+	// Regression for/: --output is honored only with --sql, so it must
 	// be rejected (not silently ignored) on the batch and no-query paths.
 	t.Run("rejects --output with batch stdin and no --sql", func(t *testing.T) {
 		out := filepath.Join(t.TempDir(), "o.csv")
@@ -2919,9 +2919,9 @@ func TestShellRun_OutputRequiresSQL(t *testing.T) {
 }
 
 func TestCommandsRejectEmptyArgs(t *testing.T) {
-	// Regression for #323/#324/#325: empty quoted arguments must be rejected, not
+	// Regression for//: empty quoted arguments must be rejected, not
 	// reinterpreted as in-place save, a ".csv" file, or the current directory.
-	t.Run(".save empty is rejected and is not an in-place save (#323)", func(t *testing.T) {
+	t.Run(".save empty is rejected and is not an in-place save", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly"})
 		if err != nil {
 			t.Fatal(err)
@@ -2932,7 +2932,7 @@ func TestCommandsRejectEmptyArgs(t *testing.T) {
 		}
 	})
 
-	t.Run(".dump empty destination is rejected (#324)", func(t *testing.T) {
+	t.Run(".dump empty destination is rejected", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly"})
 		if err != nil {
 			t.Fatal(err)
@@ -2943,7 +2943,7 @@ func TestCommandsRejectEmptyArgs(t *testing.T) {
 		}
 	})
 
-	t.Run(".import empty path is rejected (#325)", func(t *testing.T) {
+	t.Run(".import empty path is rejected", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly"})
 		if err != nil {
 			t.Fatal(err)
@@ -2956,7 +2956,7 @@ func TestCommandsRejectEmptyArgs(t *testing.T) {
 }
 
 func TestShellValidateSheetFlag(t *testing.T) {
-	// Regression for #287: --sheet only affects Excel imports, so it must be
+	// Regression for: --sheet only affects Excel imports, so it must be
 	// rejected when no input can be an Excel file instead of being silently
 	// ignored.
 	t.Run("rejects --sheet when the only input is a non-Excel file", func(t *testing.T) {
@@ -3011,7 +3011,7 @@ func TestShellValidateSheetFlag(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects --sheet for a directory with no Excel files (#312)", func(t *testing.T) {
+	t.Run("rejects --sheet for a directory with no Excel files", func(t *testing.T) {
 		dir := t.TempDir()
 		if err := os.WriteFile(filepath.Join(dir, "u.csv"), []byte("a\n1\n"), 0o600); err != nil {
 			t.Fatal(err)
@@ -3039,7 +3039,7 @@ func TestShellValidateSheetFlag(t *testing.T) {
 }
 
 func TestShellRun_HistoryUnavailable(t *testing.T) {
-	// Regression for #262: non-interactive runs must succeed even when the
+	// Regression for: non-interactive runs must succeed even when the
 	// history DB cannot be created or written (e.g. read-only config dir).
 	readonlyErr := errors.New("attempt to write a readonly database")
 
@@ -3103,7 +3103,6 @@ func TestShell_shortCWD(t *testing.T) {
 
 // TestShellExec_SchemaQualifiedTempView covers the helper-command surface added
 // for v0.20.0 hardening: schema-qualified names, TEMP tables, and views.
-// Ref #445, #446, #447, #449, #450, #451, #464.
 func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 	newImportedShell := func(t *testing.T) (*Shell, func()) {
 		t.Helper()
@@ -3118,7 +3117,7 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 		return shell, cleanup
 	}
 
-	t.Run(".schema main.user accepts a schema-qualified name (#445)", func(t *testing.T) {
+	t.Run(".schema main.user accepts a schema-qualified name", func(t *testing.T) {
 		shell, cleanup := newImportedShell(t)
 		defer cleanup()
 		got, err := getExecStdOutput(t, shell.exec, ".schema main.user")
@@ -3130,7 +3129,7 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 		}
 	})
 
-	t.Run(".describe main.user accepts a schema-qualified name (#446)", func(t *testing.T) {
+	t.Run(".describe main.user accepts a schema-qualified name", func(t *testing.T) {
 		shell, cleanup := newImportedShell(t)
 		defer cleanup()
 		got, err := getExecStdOutput(t, shell.exec, ".describe main.user")
@@ -3142,7 +3141,7 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 		}
 	})
 
-	t.Run(".header main.user accepts a schema-qualified name (#447)", func(t *testing.T) {
+	t.Run(".header main.user accepts a schema-qualified name", func(t *testing.T) {
 		shell, cleanup := newImportedShell(t)
 		defer cleanup()
 		got, err := getExecStdOutput(t, shell.exec, ".header main.user")
@@ -3154,7 +3153,7 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 		}
 	})
 
-	t.Run(".tables lists session-created VIEW (#450)", func(t *testing.T) {
+	t.Run(".tables lists session-created VIEW", func(t *testing.T) {
 		shell, cleanup := newImportedShell(t)
 		defer cleanup()
 		if err := shell.exec(context.Background(), "CREATE VIEW v_user AS SELECT user_name FROM user"); err != nil {
@@ -3170,7 +3169,7 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 		}
 	})
 
-	t.Run(".tables lists session-created TEMP table (#449)", func(t *testing.T) {
+	t.Run(".tables lists session-created TEMP table", func(t *testing.T) {
 		shell, cleanup := newImportedShell(t)
 		defer cleanup()
 		if err := shell.exec(context.Background(), "CREATE TEMP TABLE temp_t (id INTEGER)"); err != nil {
@@ -3185,7 +3184,7 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 		}
 	})
 
-	t.Run(".schema on a VIEW prints CREATE VIEW, not a synthesized table (#451)", func(t *testing.T) {
+	t.Run(".schema on a VIEW prints CREATE VIEW, not a synthesized table", func(t *testing.T) {
 		shell, cleanup := newImportedShell(t)
 		defer cleanup()
 		if err := shell.exec(context.Background(), "CREATE VIEW v_user AS SELECT user_name FROM user"); err != nil {
@@ -3200,7 +3199,7 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 		}
 	})
 
-	t.Run(".schema on a constrained TEMP table preserves UNIQUE/CHECK (#464)", func(t *testing.T) {
+	t.Run(".schema on a constrained TEMP table preserves UNIQUE/CHECK", func(t *testing.T) {
 		shell, cleanup := newImportedShell(t)
 		defer cleanup()
 		const ddl = "CREATE TEMP TABLE temp_t (id INTEGER, name TEXT NOT NULL UNIQUE, qty INTEGER DEFAULT 7, CHECK (qty > 0))"
@@ -3216,4 +3215,285 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 			t.Fatalf(".schema on a TEMP table dropped constraints: %q", out)
 		}
 	})
+
+	t.Run(".schema prefers a TEMP table over a same-named main table", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), "CREATE TEMP TABLE user(id TEXT)"); err != nil {
+			t.Fatalf("create temp table error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".schema user")
+		if err != nil {
+			t.Fatalf(".schema user error: %v", err)
+		}
+		out := string(got)
+		// The temp table has only "id"; the imported main table has "first_name".
+		if !strings.Contains(out, "TEMP") || strings.Contains(out, "first_name") {
+			t.Fatalf(".schema did not prefer the temp table: %q", out)
+		}
+	})
+
+	t.Run(".schema prefers a TEMP view over a same-named main table", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), "CREATE TEMP VIEW user AS SELECT 1 AS id"); err != nil {
+			t.Fatalf("create temp view error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".schema user")
+		if err != nil {
+			t.Fatalf(".schema user error: %v", err)
+		}
+		if out := string(got); !strings.Contains(out, "TEMP VIEW") {
+			t.Fatalf(".schema did not return the temp view definition: %q", out)
+		}
+	})
+
+	t.Run(".tables keeps a main object and a same-named TEMP object", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), "CREATE TEMP TABLE user(id TEXT)"); err != nil {
+			t.Fatalf("create temp table error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".tables")
+		if err != nil {
+			t.Fatalf(".tables error: %v", err)
+		}
+		out := string(got)
+		if !strings.Contains(out, "temp.user") || strings.Count(out, "user") < 2 {
+			t.Fatalf(".tables collapsed the main and temp objects: %q", out)
+		}
+	})
+
+	t.Run(".schema targets a literal dotted table name", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), `CREATE TABLE "a.b"(id INTEGER)`); err != nil {
+			t.Fatalf("create table error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, `.schema "a.b"`)
+		if err != nil {
+			t.Fatalf(`.schema "a.b" error: %v`, err)
+		}
+		if !strings.Contains(string(got), "id") {
+			t.Fatalf(`.schema "a.b" missing the id column: %q`, got)
+		}
+	})
+
+	t.Run(".describe targets a literal dotted table name", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), `CREATE TABLE "a.b"(id INTEGER)`); err != nil {
+			t.Fatalf("create table error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, `.describe "a.b"`)
+		if err != nil {
+			t.Fatalf(`.describe "a.b" error: %v`, err)
+		}
+		if !strings.Contains(string(got), "id") {
+			t.Fatalf(`.describe "a.b" missing the id column: %q`, got)
+		}
+	})
+
+	t.Run(".header targets a literal dotted table name", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), `CREATE TABLE "a.b"(id INTEGER)`); err != nil {
+			t.Fatalf("create table error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, `.header "a.b"`)
+		if err != nil {
+			t.Fatalf(`.header "a.b" error: %v`, err)
+		}
+		if !strings.Contains(string(got), "id") {
+			t.Fatalf(`.header "a.b" missing the id header: %q`, got)
+		}
+	})
+
+	t.Run(".dump targets a literal dotted table name", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), `CREATE TABLE "a.b"(id INTEGER)`); err != nil {
+			t.Fatalf("create table error: %v", err)
+		}
+		dst := filepath.Join(t.TempDir(), "ab.csv")
+		backupErr := config.Stderr
+		config.Stderr = &bytes.Buffer{}
+		err := shell.exec(context.Background(), `.dump "a.b" `+dst)
+		config.Stderr = backupErr
+		if err != nil {
+			t.Fatalf(`.dump "a.b" error: %v`, err)
+		}
+		data, readErr := os.ReadFile(dst) //nolint:gosec // test path
+		if readErr != nil {
+			t.Fatalf("dump destination not written: %v", readErr)
+		}
+		if !strings.Contains(string(data), "id") {
+			t.Fatalf(`.dump "a.b" missing the id column: %q`, data)
+		}
+	})
+
+	t.Run(".tables prints paste-safe quoted identifiers", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), `CREATE TABLE "two words"(id INTEGER)`); err != nil {
+			t.Fatalf("create table error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".tables")
+		if err != nil {
+			t.Fatalf(".tables error: %v", err)
+		}
+		if !strings.Contains(string(got), `"two words"`) {
+			t.Fatalf(".tables did not quote the spaced identifier: %q", got)
+		}
+	})
+
+	t.Run(".header keeps the full spaced table name", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), `CREATE TABLE "two words"(id INTEGER)`); err != nil {
+			t.Fatalf("create table error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, `.header "two words"`)
+		if err != nil {
+			t.Fatalf(`.header "two words" error: %v`, err)
+		}
+		if !strings.Contains(string(got), "two words") {
+			t.Fatalf(".header truncated the spaced table name: %q", got)
+		}
+	})
+
+	t.Run(".schema temp.t keeps the TEMP keyword", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), "CREATE TEMP TABLE t(id INTEGER PRIMARY KEY)"); err != nil {
+			t.Fatalf("create temp table error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".schema temp.t")
+		if err != nil {
+			t.Fatalf(".schema temp.t error: %v", err)
+		}
+		if !strings.Contains(string(got), "TEMP") {
+			t.Fatalf(".schema temp.t dropped the TEMP keyword: %q", got)
+		}
+	})
+
+	t.Run(".schema temp.v keeps the TEMP keyword for a view", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), "CREATE TEMP VIEW v AS SELECT 1 AS id"); err != nil {
+			t.Fatalf("create temp view error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".schema temp.v")
+		if err != nil {
+			t.Fatalf(".schema temp.v error: %v", err)
+		}
+		if !strings.Contains(string(got), "TEMP VIEW") {
+			t.Fatalf(".schema temp.v dropped the TEMP keyword: %q", got)
+		}
+	})
+
+	t.Run(".tables respects .mode json", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), ".mode json"); err != nil {
+			t.Fatalf(".mode json error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".tables")
+		if err != nil {
+			t.Fatalf(".tables error: %v", err)
+		}
+		out := string(got)
+		if !strings.Contains(out, `"name"`) || !strings.Contains(out, "user") {
+			t.Fatalf(".tables ignored json mode: %q", out)
+		}
+	})
+
+	t.Run(".header respects .mode ndjson", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), ".mode ndjson"); err != nil {
+			t.Fatalf(".mode ndjson error: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".header user")
+		if err != nil {
+			t.Fatalf(".header user error: %v", err)
+		}
+		out := string(got)
+		if !strings.Contains(out, `"column"`) || !strings.Contains(out, "first_name") {
+			t.Fatalf(".header ignored ndjson mode: %q", out)
+		}
+	})
+}
+
+// TestRunDirectSQLRejectsMultipleStatements verifies that direct --sql refuses
+// multi-statement input instead of silently running every statement and keeping
+// only the last result.
+func TestRunDirectSQLRejectsMultipleStatements(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"two SELECTs keep only the last", "SELECT 1 AS x; SELECT 2 AS y"},
+		{"SELECT then UPDATE is multi-statement", "SELECT 1 AS x; UPDATE t SET x=1"},
+		{"trailing semicolon on two statements", "SELECT 1; SELECT 2;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shell, cleanup, err := newShell(t, []string{"sqly", "--sql", tc.query})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+			shell.isTTY = func() bool { return true }
+
+			runErr := shell.Run(context.Background())
+			if runErr == nil {
+				t.Fatal("expected a multi-statement rejection, got nil")
+			}
+			if !strings.Contains(runErr.Error(), "single SQL statement") {
+				t.Errorf("error = %q, want it to mention a single SQL statement", runErr)
+			}
+		})
+	}
+}
+
+// TestRunDirectSQLOutputRejectsMultipleStatementsBeforeWriting verifies that
+// --sql --output rejects multi-statement input before the destination file is
+// created, so a pipeline never sees a partial export.
+func TestRunDirectSQLOutputRejectsMultipleStatementsBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out.csv")
+
+	shell, cleanup, err := newShell(t, []string{"sqly", "--csv", "--sql", "SELECT 1 AS x; SELECT 2 AS y", "--output", out})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	shell.isTTY = func() bool { return true }
+
+	if runErr := shell.Run(context.Background()); runErr == nil {
+		t.Fatal("expected a multi-statement rejection, got nil")
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Errorf("output file %s was written despite the rejection", out)
+	}
+}
+
+// TestRunDirectSQLAllowsSingleStatementWithTrailingSemicolon guards against the
+// statement counter over-counting a single statement that ends in ";".
+func TestRunDirectSQLAllowsSingleStatementWithTrailingSemicolon(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly", "--sql", "SELECT 1 AS x;"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	shell.isTTY = func() bool { return true }
+
+	backup := config.Stdout
+	config.Stdout = &bytes.Buffer{}
+	defer func() { config.Stdout = backup }()
+
+	if runErr := shell.Run(context.Background()); runErr != nil {
+		t.Fatalf("single statement with trailing semicolon should run, got: %v", runErr)
+	}
 }

--- a/shell/tables.go
+++ b/shell/tables.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/nao1215/sqly/config"
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
+)
+
+// Column keys for the structured (.mode json/ndjson) .tables listing.
+const (
+	tablesColumnName   = "name"
+	tablesColumnSchema = "schema"
 )
 
 // tablesCommand print all tables name in DB.
@@ -19,15 +26,77 @@ func (c CommandList) tablesCommand(ctx context.Context, s *Shell, argv []string)
 	}
 	// List every queryable object (base tables, views, and TEMP tables/views),
 	// not only the file-imported base tables, so a session-created view or temp
-	// table is discoverable here the same way it is queryable. Ref #449, #450.
+	// table is discoverable here the same way it is queryable.
 	tables, err := s.usecases.metadata.SchemaObjects(ctx)
 	if err != nil {
 		return err
 	}
+
+	// In a structured mode emit one machine-readable {name, schema} object per
+	// table, so the schema disambiguates a main object from a same-named temp
+	// object and automation can consume the list.
+	if isStructuredMode(s.state.mode.PrintMode) {
+		records := make([]model.Record, 0, len(tables))
+		for _, t := range tables {
+			records = append(records, model.Record{t.Name(), schemaOf(t)})
+		}
+		out := model.NewTable("tables", model.Header{tablesColumnName, tablesColumnSchema}, records)
+		return out.Print(config.Stdout, s.state.mode.PrintMode)
+	}
+
 	if err := printTables(config.Stdout, tables); err != nil {
 		return fmt.Errorf("failed to print tables: %w", err)
 	}
 	return nil
+}
+
+// schemaOf returns the owning schema ("main" or "temp") that SchemaObjects encoded
+// as a table's single Header entry, or "main" when absent.
+func schemaOf(t *model.Table) string {
+	if h := t.Header(); len(h) > 0 && h[0] != "" {
+		return h[0]
+	}
+	return "main"
+}
+
+// tableDisplayName renders an object name for the ASCII .tables listing so it can
+// be pasted straight back into SQL or a helper command: identifiers that require
+// quoting are double-quoted, and a temp object is qualified with "temp." to keep
+// it distinct from a same-named main object.
+func tableDisplayName(t *model.Table) string {
+	name := quoteIdentifierIfNeeded(t.Name())
+	if schemaOf(t) == "temp" {
+		return "temp." + name
+	}
+	return name
+}
+
+// quoteIdentifierIfNeeded returns name unchanged when it is a safe bare SQL
+// identifier, and a double-quoted form (inner quotes doubled) otherwise, so the
+// result is always safe to paste back into SQL.
+func quoteIdentifierIfNeeded(name string) string {
+	if isBareIdentifier(name) && !model.IsReservedSQLiteKeyword(name) {
+		return name
+	}
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// isBareIdentifier reports whether s is a plain SQL identifier that needs no
+// quoting: it starts with a letter or underscore and contains only letters,
+// digits, and underscores.
+func isBareIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // printTables print table name
@@ -41,7 +110,7 @@ func printTables(out io.Writer, t []*model.Table) error {
 
 	tableData := [][]string{}
 	for _, v := range t {
-		tableData = append(tableData, []string{v.Name()})
+		tableData = append(tableData, []string{tableDisplayName(v)})
 	}
 
 	table := tablewriter.NewTable(out,

--- a/spec/batch_failfast_spec.sh
+++ b/spec/batch_failfast_spec.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Batch fail-fast semantics (#308, #320, #321, #322, #330, #331). The first
+# Batch fail-fast semantics. The first
 # failed statement stops the batch, so later statements and side-effecting
 # helper commands (.save, .dump) do not run, and an empty batch performs no
 # write-back.
 
-Describe 'sqly batch fail-fast (#308)'
+Describe 'sqly batch fail-fast'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {
@@ -30,7 +30,7 @@ Describe 'sqly batch fail-fast (#308)'
     The stderr should include 'no_such_table'
   End
 
-  It 'does not run .save --force after an earlier failure (#320)'
+  It 'does not run .save --force after an earlier failure'
     Data:expand
       #|UPDATE u SET first_name = 'BROKEN' WHERE identifier = 1;
       #|SELECT * FROM no_such_table;
@@ -43,7 +43,7 @@ Describe 'sqly batch fail-fast (#308)'
     The contents of file "$WORK/u.csv" should not include 'BROKEN'
   End
 
-  It 'does not run .dump after an earlier failure (#322)'
+  It 'does not run .dump after an earlier failure'
     Data:expand
       #|SELECT * FROM no_such_table;
       #|.dump u ${WORK}/out.csv
@@ -54,7 +54,7 @@ Describe 'sqly batch fail-fast (#308)'
     The path "$WORK/out.csv" should not be exist
   End
 
-  It 'does not write back for empty stdin with --save --force (#330)'
+  It 'does not write back for empty stdin with --save --force'
     When run sqly "$WORK/u.csv" --save --force
     The status should be success
     The stderr should not include 'Saved'

--- a/spec/batch_spec.sh
+++ b/spec/batch_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Non-TTY batch-mode end-to-end tests (#246). Piping into sqly (no terminal)
+# Non-TTY batch-mode end-to-end tests. Piping into sqly (no terminal)
 # runs commands from stdin; failures must surface a non-zero exit code.
 
 Describe 'sqly batch mode (piped stdin)'
@@ -58,7 +58,7 @@ Describe 'sqly batch mode (piped stdin)'
     The stderr should include 'no_such_table'
   End
 
-  Describe 'multiline statements (#263)'
+  Describe 'multiline statements'
     It 'runs a multiline SELECT terminated by a semicolon'
       Data
         #|SELECT user_name
@@ -95,7 +95,7 @@ Describe 'sqly batch mode (piped stdin)'
       The output should include 'booker12'
     End
 
-    It 'ignores a semicolon inside a leading line comment (#299)'
+    It 'ignores a semicolon inside a leading line comment'
       Data
         #|-- comment ;
         #|SELECT 'v' AS x;
@@ -105,7 +105,7 @@ Describe 'sqly batch mode (piped stdin)'
       The output should include 'v'
     End
 
-    It 'ignores a semicolon inside a block comment (#299)'
+    It 'ignores a semicolon inside a block comment'
       Data
         #|/* comment ; */
         #|SELECT 'v' AS x;
@@ -115,7 +115,7 @@ Describe 'sqly batch mode (piped stdin)'
       The output should include 'v'
     End
 
-    It 'ignores a semicolon inside a trailing line comment (#299)'
+    It 'ignores a semicolon inside a trailing line comment'
       Data
         #|SELECT 'first' AS x; -- trailing ; comment
         #|SELECT 'second' AS y;
@@ -126,7 +126,7 @@ Describe 'sqly batch mode (piped stdin)'
       The output should include 'second'
     End
 
-    It 'does not split on a semicolon inside a bracket-quoted identifier (#314)'
+    It 'does not split on a semicolon inside a bracket-quoted identifier'
       Data
         #|SELECT 'v' AS [a;b];
       End
@@ -136,7 +136,7 @@ Describe 'sqly batch mode (piped stdin)'
       The output should include 'v'
     End
 
-    It 'does not split on a semicolon inside a backtick-quoted identifier (#315)'
+    It 'does not split on a semicolon inside a backtick-quoted identifier'
       Data
         #|SELECT 'v' AS `a;b`;
       End

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -58,7 +58,7 @@ Describe 'sqly CLI surface'
     End
   End
 
-  Describe 'flags after input paths (#264)'
+  Describe 'flags after input paths'
     It 'applies --output placed after the file path instead of importing it'
       out_dir=$(mktemp -d)
       export out_dir

--- a/spec/collision_spec.sh
+++ b/spec/collision_spec.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Sanitized table-name collisions (#286). Two inputs that sanitize to the same
+# Sanitized table-name collisions. Two inputs that sanitize to the same
 # table name must fail instead of one silently overwriting the other.
 
-Describe 'sqly table-name collision (#286)'
+Describe 'sqly table-name collision'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {

--- a/spec/empty_args_spec.sh
+++ b/spec/empty_args_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Empty quoted command arguments (#323, #324, #325). An empty argument must be
+# Empty quoted command arguments. An empty argument must be
 # rejected, not reinterpreted as an in-place save, a ".csv" file, or the current
 # directory.
 
@@ -18,7 +18,7 @@ Describe 'sqly empty command arguments'
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
-  It 'rejects .save "" and leaves the source unchanged (#323)'
+  It 'rejects .save "" and leaves the source unchanged'
     Data
       #|UPDATE u SET first_name = 'EMPTY' WHERE identifier = 1;
       #|.save ""
@@ -30,7 +30,7 @@ Describe 'sqly empty command arguments'
     The contents of file "$WORK/u.csv" should not include 'EMPTY'
   End
 
-  It 'rejects .dump with an empty destination (#324)'
+  It 'rejects .dump with an empty destination'
     Data
       #|.dump user ""
     End
@@ -40,7 +40,7 @@ Describe 'sqly empty command arguments'
     The path .csv should not be exist
   End
 
-  It 'rejects .import with an empty path (#325)'
+  It 'rejects .import with an empty path'
     Data
       #|.import ""
       #|.tables

--- a/spec/excel_export_spec.sh
+++ b/spec/excel_export_spec.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Excel export end-to-end tests (#296). Exported .xlsx files must be ordinary
+# Excel export end-to-end tests. Exported .xlsx files must be ordinary
 # data files, not executables, matching other output formats.
 
-Describe 'sqly excel export (#296)'
+Describe 'sqly excel export'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {

--- a/spec/export_inference_spec.sh
+++ b/spec/export_inference_spec.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Export format and compression inference from --output and .dump paths (#260).
+# Export format and compression inference from --output and .dump paths.
 # Verifies the binary infers the format from the destination extension, applies
 # compression wrappers, round-trips compressed output, and reports conflicts.
 
-Describe 'sqly export format inference (#260)'
+Describe 'sqly export format inference'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   Describe '--output path inference'
@@ -43,7 +43,7 @@ Describe 'sqly export format inference (#260)'
     End
   End
 
-  Describe 'unknown extension honors the exact path (#292)'
+  Describe 'unknown extension honors the exact path'
     It 'writes the CSV fallback to the requested path without rewriting it'
       out_dir=$(mktemp -d)
       export out_dir
@@ -56,7 +56,7 @@ Describe 'sqly export format inference (#260)'
     End
   End
 
-  Describe 'directory destinations are rejected (#303)'
+  Describe 'directory destinations are rejected'
     It 'rejects --output to an existing directory'
       out_dir=$(mktemp -d)
       export out_dir

--- a/spec/extra_args_spec.sh
+++ b/spec/extra_args_spec.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Helper commands reject unexpected extra arguments (#327). Trailing arguments
+# Helper commands reject unexpected extra arguments. Trailing arguments
 # must cause a clear error, not be silently ignored.
 
-Describe 'sqly helper commands reject extra args (#327)'
+Describe 'sqly helper commands reject extra args'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   It 'rejects .schema with an extra argument'

--- a/spec/filesql_integration_spec.sh
+++ b/spec/filesql_integration_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# filesql integration end-to-end tests (#244). Locks that every supported file
+# filesql integration end-to-end tests. Locks that every supported file
 # format imports into the shared session and can be queried and inspected, and
 # that the ACH/Fedwire cleanup path stays deterministic across repeated imports.
 

--- a/spec/helpers_spec.sh
+++ b/spec/helpers_spec.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Shell helper-command end-to-end tests: in-process .ls/.clear/.cd (#236),
-# quoted .import arguments (#246), and the .mode listing (#237). Driven through
+# Shell helper-command end-to-end tests: in-process .ls/.clear/.cd,
+# quoted .import arguments, and the .mode listing. Driven through
 # piped stdin so the real binary is exercised.
 
 Describe 'sqly shell helper commands'

--- a/spec/history_tolerance_spec.sh
+++ b/spec/history_tolerance_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# History-storage tolerance end-to-end tests (#262). Non-interactive runs must
+# History-storage tolerance end-to-end tests. Non-interactive runs must
 # succeed even when the history database cannot be created or written. The
 # history DB path is pointed at a directory that does not exist, so creating it
 # fails the way a read-only or sandboxed config location would.
@@ -43,7 +43,7 @@ Describe 'sqly history tolerance'
   End
 End
 
-# Runtime history failures (#273): the DB is created successfully at startup but a
+# Runtime history failures: the DB is created successfully at startup but a
 # later write fails, simulating a history DB that becomes read-only mid-session.
 Describe 'sqly history tolerance after startup'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"

--- a/spec/import_failure_spec.sh
+++ b/spec/import_failure_spec.sh
@@ -1,28 +1,28 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Import-failure handling (#297, #300, #302, #306). When an explicitly requested
+# Import-failure handling. When an explicitly requested
 # input fails to import, non-interactive runs exit non-zero and keep import
 # diagnostics on stderr so stdout stays machine-readable.
 
 Describe 'sqly import failure handling'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
-  It 'fails query mode on a partial import and keeps stdout clean (#297, #306)'
+  It 'fails query mode on a partial import and keeps stdout clean'
     When run sqly --json --sql "SELECT user_name FROM user LIMIT 1" testdata/user.csv /no/such/file.csv
     The status should be failure
     The output should equal ''
     The stderr should include 'failed to import'
   End
 
-  It 'fails --inspect on a partial import (#300)'
+  It 'fails --inspect on a partial import'
     When run sqly --inspect testdata/user.csv /no/such/file.csv
     The status should be failure
     The output should equal ''
     The stderr should include 'failed to import'
   End
 
-  It 'fails batch .import on a partial import and stops later commands (#302)'
+  It 'fails batch .import on a partial import and stops later commands'
     Data
       #|.import testdata/user.csv /no/such/file.csv
       #|.tables
@@ -33,7 +33,7 @@ Describe 'sqly import failure handling'
     The stderr should include 'failed to import'
   End
 
-  It 'keeps stdout clean when a stdin dataset fails to import (#306)'
+  It 'keeps stdout clean when a stdin dataset fails to import'
     Data
       #|
     End

--- a/spec/inspect_conflicts_spec.sh
+++ b/spec/inspect_conflicts_spec.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# --inspect conflicting-flag validation (#288). --inspect is self-contained, so
+# --inspect conflicting-flag validation. --inspect is self-contained, so
 # combining it with action or side-effecting flags must fail instead of
 # silently discarding them.
 
-Describe 'sqly --inspect conflicts (#288)'
+Describe 'sqly --inspect conflicts'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {

--- a/spec/inspect_spec.sh
+++ b/spec/inspect_spec.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Non-interactive inspect workflow end-to-end tests (#259). Runs the binary with
+# Non-interactive inspect workflow end-to-end tests. Runs the binary with
 # --inspect and checks the machine-readable JSON report and stdout purity.
 
-Describe 'sqly --inspect (#259)'
+Describe 'sqly --inspect'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   It 'prints a JSON report for a single file'
@@ -34,7 +34,7 @@ Describe 'sqly --inspect (#259)'
     The line 1 should equal '{'
     The output should include '"name": "a"'
     The output should include '"name": "b"'
-    # Each table reports its real source file, not the directory path (#326).
+    # Each table reports its real source file, not the directory path.
     The output should include '/a.csv'
     The output should include '/b.csv'
     The stderr should include 'Successfully imported'

--- a/spec/json_null_spec.sh
+++ b/spec/json_null_spec.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# JSON/NDJSON NULL rendering (#328, #329). A SQL NULL must be emitted as JSON
+# JSON/NDJSON NULL rendering. A SQL NULL must be emitted as JSON
 # null, distinct from an empty string, in machine-readable output.
 
-Describe 'sqly JSON/NDJSON NULL handling (#328, #329)'
+Describe 'sqly JSON/NDJSON NULL handling'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   It 'emits NULL as JSON null in --json'

--- a/spec/mode_banner_spec.sh
+++ b/spec/mode_banner_spec.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# .mode change banner routing (#295). In batch mode the mode-change banner must
+# .mode change banner routing. In batch mode the mode-change banner must
 # not pollute stdout, so JSON and NDJSON output stay machine-readable. The
 # banner is a status message and goes to stderr instead.
 
-Describe 'sqly .mode banner routing (#295)'
+Describe 'sqly .mode banner routing'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   It 'keeps stdout pure JSON after .mode json'

--- a/spec/output_format_spec.sh
+++ b/spec/output_format_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Output-format end-to-end tests (#237 and existing formats). Runs the binary
+# Output-format end-to-end tests ( and existing formats). Runs the binary
 # with --json/--ndjson/--csv and checks the rendered query results.
 
 Describe 'sqly output formats'

--- a/spec/output_requires_sql_spec.sh
+++ b/spec/output_requires_sql_spec.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# --output requires --sql (#318, #319). --output is only honored by the --sql
+# --output requires --sql. --output is only honored by the --sql
 # path, so without --sql (no query or batch stdin) it must be rejected instead
 # of silently ignored.
 
-Describe 'sqly --output requires --sql (#318, #319)'
+Describe 'sqly --output requires --sql'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {
@@ -17,7 +17,7 @@ Describe 'sqly --output requires --sql (#318, #319)'
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
-  It 'rejects --output with no query (#318)'
+  It 'rejects --output with no query'
     Data
       #|
     End
@@ -27,7 +27,7 @@ Describe 'sqly --output requires --sql (#318, #319)'
     The path "$OUT_DIR/out.csv" should not be exist
   End
 
-  It 'rejects --output for batch SQL from stdin (#319)'
+  It 'rejects --output for batch SQL from stdin'
     Data
       #|SELECT user_name FROM user ORDER BY identifier LIMIT 1
     End

--- a/spec/output_status_spec.sh
+++ b/spec/output_status_spec.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# File-output status routing (#309). When data is written to a file via
+# File-output status routing. When data is written to a file via
 # --output, .dump, or .save, the success/status line is control-plane output
 # and must go to stderr so stdout stays empty for scripts.
 
-Describe 'sqly file-output status routing (#309)'
+Describe 'sqly file-output status routing'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {

--- a/spec/parquet_export_spec.sh
+++ b/spec/parquet_export_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Parquet export end-to-end tests (#241). Parquet is export-only, like Excel:
+# Parquet export end-to-end tests. Parquet is export-only, like Excel:
 # it is written by .dump and --output, re-imports cleanly, normalizes the file
 # extension, and reports a clear error for an empty result.
 

--- a/spec/path_validation_spec.sh
+++ b/spec/path_validation_spec.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Input path validation false positives (#316, #317). sqly runs locally with the
+# Input path validation false positives. sqly runs locally with the
 # user's own permissions, so legitimate readable paths must import regardless of
 # nesting depth or filenames that merely contain traversal-looking byte
 # sequences.
 
-Describe 'sqly input path validation (#316, #317)'
+Describe 'sqly input path validation'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {
@@ -18,7 +18,7 @@ Describe 'sqly input path validation (#316, #317)'
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
-  It 'imports a deeply nested path (#316)'
+  It 'imports a deeply nested path'
     deep="$WORK/a/b/c/d/e/f/g/h/i/j/k"
     mkdir -p "$deep"
     cp testdata/user.csv "$deep/user.csv"
@@ -27,7 +27,7 @@ Describe 'sqly input path validation (#316, #317)'
     The line 2 should equal '3'
   End
 
-  It 'imports a file whose name literally contains ..%2f (#317)'
+  It 'imports a file whose name literally contains ..%2f'
     cp testdata/user.csv "$WORK/..%2fuser.csv"
     When run sqly --inspect "$WORK/..%2fuser.csv"
     The status should be success

--- a/spec/save_spec.sh
+++ b/spec/save_spec.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Write-back end-to-end tests (#261). DML changes are persisted to files only
+# Write-back end-to-end tests. DML changes are persisted to files only
 # through the explicit --save / --save-dir flags and the .save command. --save
 # overwrites sources and requires --force; --save-dir never touches the source.
 
-Describe 'sqly write-back (#261)'
+Describe 'sqly write-back'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {

--- a/spec/schema_spec.sh
+++ b/spec/schema_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Schema inspection end-to-end tests (#238): .schema and .describe across CSV,
+# Schema inspection end-to-end tests: .schema and .describe across CSV,
 # JSON, Excel, and ACH-generated tables, plus JSON-mode structured output and
 # missing-table errors. Driven through piped stdin against the built binary.
 

--- a/spec/sheet_flag_spec.sh
+++ b/spec/sheet_flag_spec.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# --sheet validation end-to-end tests (#287). --sheet only affects Excel
+# --sheet validation end-to-end tests. --sheet only affects Excel
 # imports, so it must be rejected for non-Excel inputs instead of being
 # silently ignored.
 
-Describe 'sqly --sheet validation (#287)'
+Describe 'sqly --sheet validation'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   It 'rejects --sheet with a non-Excel file and --sql'
@@ -26,13 +26,13 @@ Describe 'sqly --sheet validation (#287)'
     The output should include 'name'
   End
 
-  It 'rejects an explicit empty --sheet (#313)'
+  It 'rejects an explicit empty --sheet'
     When run sqly --inspect --sheet "" testdata/user.csv
     The status should be failure
     The stderr should include 'sheet'
   End
 
-  It 'rejects --sheet for a directory with no Excel files (#312)'
+  It 'rejects --sheet for a directory with no Excel files'
     work=$(mktemp -d)
     cp testdata/user.csv "$work/u.csv"
     When run sqly --inspect --sheet anything "$work"

--- a/spec/sql_file_spec.sh
+++ b/spec/sql_file_spec.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# --sql-file end-to-end tests (#281). --sql-file loads SQL from a file for
+# --sql-file end-to-end tests. --sql-file loads SQL from a file for
 # non-interactive runs, which frees stdin to carry a piped --stdin dataset. The
 # file supports multiline statements and the same splitting rules as batch
 # stdin mode.
 
-Describe 'sqly --sql-file (#281)'
+Describe 'sqly --sql-file'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   setup() {

--- a/spec/stdin_dataset_spec.sh
+++ b/spec/stdin_dataset_spec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# stdin-as-dataset end-to-end tests (#258). With --stdin <format>, piped stdin
+# stdin-as-dataset end-to-end tests. With --stdin <format>, piped stdin
 # is imported as a dataset (default table "stdin") instead of being read as
 # SQL/helper commands, and it can be joined with file arguments. Without
 # --stdin, batch mode behavior is unchanged.
@@ -70,7 +70,7 @@ Describe 'sqly --stdin dataset'
   End
 
   Describe 'stdin dataset robustness'
-    It 'reports a stable stdin source in --inspect, not a temp path (#290)'
+    It 'reports a stable stdin source in --inspect, not a temp path'
       Data
         #|id,name
         #|1,alice
@@ -81,7 +81,7 @@ Describe 'sqly --stdin dataset'
       The output should not include 'sqly-stdin-'
     End
 
-    It 'rejects --save --force for a stdin-backed table (#291)'
+    It 'rejects --save --force for a stdin-backed table'
       Data
         #|id,name
         #|1,alice
@@ -89,12 +89,12 @@ Describe 'sqly --stdin dataset'
       When run sqly --stdin csv --sql "UPDATE stdin SET name = 'x'" --save --force
       The status should be failure
       # Write-back is validated before the query runs, so the run fails before any
-      # DML success count reaches stdout (#375).
+      # DML success count reaches stdout.
       The output should not include 'affected'
       The stderr should include 'stdin'
     End
 
-    It 'rejects a non-identifier --stdin-name so the name stays queryable (#289)'
+    It 'rejects a non-identifier --stdin-name so the name stays queryable'
       Data
         #|id,name
         #|1,alice
@@ -104,7 +104,7 @@ Describe 'sqly --stdin dataset'
       The stderr should include 'stdin-name'
     End
 
-    It 'rejects a path-like --stdin-name (#305)'
+    It 'rejects a path-like --stdin-name'
       Data
         #|a
         #|1

--- a/spec/v0_18_bugs_spec.sh
+++ b/spec/v0_18_bugs_spec.sh
@@ -2,32 +2,32 @@
 # shellcheck shell=sh
 #
 # Binary end-to-end tests for the bugs reported against the published v0.18.0
-# binary (#349-#378). These exercise the CLI the way a user does: flags, piped
+# binary. These exercise the CLI the way a user does: flags, piped
 # stdin, exit codes, and stdout/stderr separation.
 
 Describe 'sqly v0.18.0 binary bug fixes'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
   Describe 'explicit empty flag values are rejected'
-    It 'rejects an empty --output (#349)'
+    It 'rejects an empty --output'
       When run sqly --sql "SELECT 1 AS x" --output ""
       The status should be failure
       The stderr should include '--output'
     End
 
-    It 'rejects an empty --sql-file (#350)'
+    It 'rejects an empty --sql-file'
       When run sqly --sql-file ""
       The status should be failure
       The stderr should include '--sql-file'
     End
 
-    It 'rejects an empty --save-dir (#352)'
+    It 'rejects an empty --save-dir'
       When run sqly --sql "SELECT 1" --save-dir "" testdata/user.csv
       The status should be failure
       The stderr should include '--save-dir'
     End
 
-    It 'rejects an empty --stdin (#353)'
+    It 'rejects an empty --stdin'
       Data
         #|id,name
         #|1,a
@@ -39,13 +39,13 @@ Describe 'sqly v0.18.0 binary bug fixes'
   End
 
   Describe 'output mode and DML validation'
-    It 'rejects conflicting output mode flags (#365)'
+    It 'rejects conflicting output mode flags'
       When run sqly --csv --json --sql "SELECT 1 AS x"
       The status should be failure
       The stderr should include 'conflicting'
     End
 
-    It 'prints rows for a DML RETURNING statement (#363)'
+    It 'prints rows for a DML RETURNING statement'
       work=$(mktemp -d)
       cp testdata/user.csv "$work/u.csv"
       When run sqly --csv --sql "UPDATE u SET first_name='X' WHERE identifier=1 RETURNING identifier, first_name" "$work/u.csv"
@@ -55,7 +55,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'rejects --output for a non-rowset DML statement (#364)'
+    It 'rejects --output for a non-rowset DML statement'
       work=$(mktemp -d)
       cp testdata/user.csv "$work/u.csv"
       When run sqly --sql "UPDATE u SET first_name='X' WHERE identifier=1" --output "$work/out.csv" "$work/u.csv"
@@ -65,7 +65,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'exports RETURNING rows with --output (#368)'
+    It 'exports RETURNING rows with --output'
       work=$(mktemp -d)
       cp testdata/user.csv "$work/u.csv"
       When run sqly --csv --sql "UPDATE u SET first_name='X' WHERE identifier=1 RETURNING identifier" --output "$work/out.csv" "$work/u.csv"
@@ -77,7 +77,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
   End
 
   Describe 'sql-file and stdin routing'
-    It 'rejects a comment-only --sql-file (#351)'
+    It 'rejects a comment-only --sql-file'
       work=$(mktemp -d)
       printf -- '-- header only\n/* block */\n' > "$work/q.sql"
       When run sqly --sql-file "$work/q.sql"
@@ -86,7 +86,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'strips a UTF-8 BOM from a --sql-file script (#369)'
+    It 'strips a UTF-8 BOM from a --sql-file script'
       work=$(mktemp -d)
       printf '\357\273\277SELECT 2 AS y;\n' > "$work/q.sql"
       When run sqly --csv --sql-file "$work/q.sql" testdata/user.csv
@@ -95,7 +95,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'strips a UTF-8 BOM from batch stdin (#369)'
+    It 'strips a UTF-8 BOM from batch stdin'
       Data
         #|﻿SELECT 7 AS z;
       End
@@ -104,7 +104,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       The output should include '7'
     End
 
-    It 'rejects non-empty piped stdin with --sql-file (#373)'
+    It 'rejects non-empty piped stdin with --sql-file'
       work=$(mktemp -d)
       printf 'SELECT 1 AS x;\n' > "$work/q.sql"
       Data
@@ -116,7 +116,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'fails a --stdin dataset run with no query (#374)'
+    It 'fails a --stdin dataset run with no query'
       Data
         #|id,name
         #|1,a
@@ -128,7 +128,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
   End
 
   Describe 'directory imports'
-    It 'reports per-file provenance for a sanitized basename (#357)'
+    It 'reports per-file provenance for a sanitized basename'
       work=$(mktemp -d)
       printf 'id,name\n1,a\n' > "$work/2023-data.csv"
       When run sqly --inspect "$work"
@@ -138,7 +138,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'rejects duplicate basenames from different subdirectories (#359)'
+    It 'rejects duplicate basenames from different subdirectories'
       work=$(mktemp -d)
       mkdir -p "$work/a" "$work/b"
       printf 'id,name\n1,alpha\n' > "$work/a/user.csv"
@@ -149,7 +149,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'reports an overwrite when re-importing a directory (#361)'
+    It 'reports an overwrite when re-importing a directory'
       work=$(mktemp -d)
       cp testdata/user.csv "$work/user.csv"
       mkdir "$work/dir"
@@ -166,7 +166,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
   End
 
   Describe 'write-back safety'
-    It 'rejects --output that aliases an imported source (#371)'
+    It 'rejects --output that aliases an imported source'
       work=$(mktemp -d)
       cp testdata/user.csv "$work/user.csv"
       When run sqly --csv --sql "SELECT * FROM user WHERE identifier=1" --output "$work/user.csv" "$work/user.csv"
@@ -175,7 +175,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'rejects --save-dir that resolves to the source directory (#370)'
+    It 'rejects --save-dir that resolves to the source directory'
       work=$(mktemp -d)
       cp testdata/user.csv "$work/user.csv"
       When run sqly --sql "UPDATE user SET first_name='P' WHERE identifier=1" --save-dir "$work" "$work/user.csv"
@@ -184,7 +184,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'rejects a --save-dir destination that already exists (#372)'
+    It 'rejects a --save-dir destination that already exists'
       work=$(mktemp -d)
       mkdir -p "$work/src" "$work/out"
       cp testdata/user.csv "$work/src/user.csv"
@@ -195,7 +195,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'keeps stdout clean when write-back fails (#375)'
+    It 'keeps stdout clean when write-back fails'
       work=$(mktemp -d)
       cp testdata/user.csv "$work/user.csv"
       cp testdata/sample.xlsx "$work/sample.xlsx"
@@ -206,7 +206,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
       rm -rf "$work"
     End
 
-    It 'skips write-back for a read-only query under --save --force (#376)'
+    It 'skips write-back for a read-only query under --save --force'
       work=$(mktemp -d)
       cp testdata/user.csv "$work/user.csv"
       When run sqly --csv --sql "SELECT * FROM user WHERE identifier=1" --save --force "$work/user.csv"
@@ -218,7 +218,7 @@ Describe 'sqly v0.18.0 binary bug fixes'
   End
 
   Describe 'multi-workbook --sheet'
-    It 'skips workbooks lacking the requested sheet (#378)'
+    It 'skips workbooks lacking the requested sheet'
       When run sqly --inspect --sheet "A test" testdata/sheet_with_spaces.xlsx testdata/sample.xlsx testdata/sheet_with_accents.xlsx
       The status should be success
       The output should include 'sheet_with_spaces'

--- a/spec/v0_19_bugs_spec.sh
+++ b/spec/v0_19_bugs_spec.sh
@@ -1,124 +1,124 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# End-to-end regression tests for the v0.19.0 binary bugs (#380-#431). Each case
+# End-to-end regression tests for the v0.19.0 binary bugs. Each case
 # runs the built binary the way a user does and asserts the fixed behavior.
 
 Describe 'sqly v0.19.0 binary bug fixes'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
-  Describe 'machine-readable output stays valid (#380-#385, #426)'
-    It 'quotes a CSV value containing a comma (#380)'
+  Describe 'machine-readable output stays valid'
+    It 'quotes a CSV value containing a comma'
       When run sqly --csv --sql "SELECT 'a,b' AS c"
       The status should be success
       The line 2 should equal '"a,b"'
     End
 
-    It 'quotes a CSV value containing a double quote (#380)'
+    It 'quotes a CSV value containing a double quote'
       When run sqly --csv --sql "SELECT 'a' || char(34) || 'b' AS c"
       The status should be success
       The line 2 should equal '"a""b"'
     End
 
-    It 'rejects an LTSV value containing a tab (#382)'
+    It 'rejects an LTSV value containing a tab'
       When run sqly --ltsv --sql "SELECT 'a' || char(9) || 'b' AS c"
       The status should be failure
       The stderr should include 'LTSV'
     End
 
-    It 'rejects duplicate JSON keys (#384)'
+    It 'rejects duplicate JSON keys'
       When run sqly --json --sql "SELECT 1 AS x, 2 AS x"
       The status should be failure
       The stderr should include 'unique column names'
     End
 
-    It 'rejects duplicate NDJSON keys (#385)'
+    It 'rejects duplicate NDJSON keys'
       When run sqly --ndjson --sql "SELECT 1 AS x, 2 AS x"
       The status should be failure
       The stderr should include 'unique column names'
     End
 
-    It 'keeps a Markdown row on one line when a value has a newline (#426)'
+    It 'keeps a Markdown row on one line when a value has a newline'
       When run sqly --markdown --sql "SELECT 'a' || char(10) || 'b' AS x"
       The status should be success
       The output should include 'a<br>b'
     End
   End
 
-  Describe 'direct --sql accepts more SQLite statements (#386-#411, #430, #431)'
-    It 'accepts a leading block comment (#386)'
+  Describe 'direct --sql accepts more SQLite statements'
+    It 'accepts a leading block comment'
       When run sqly --csv --sql "/* note */ SELECT 1 AS x"
       The status should be success
       The line 2 should equal '1'
     End
 
-    It 'accepts PRAGMA (#406)'
+    It 'accepts PRAGMA'
       When run sqly --csv --sql "PRAGMA table_info(user)" testdata/user.csv
       The status should be success
       The output should include 'user_name'
     End
 
-    It 'accepts VALUES (#407)'
+    It 'accepts VALUES'
       When run sqly --csv --sql "VALUES (1), (2)"
       The status should be success
       The output should include '1'
     End
 
-    It 'accepts the TABLE shorthand (#408)'
+    It 'accepts the TABLE shorthand'
       When run sqly --csv --sql "TABLE user" testdata/user.csv
       The status should be success
       The output should include 'booker12'
     End
 
-    It 'accepts CREATE TABLE (#411)'
+    It 'accepts CREATE TABLE'
       When run sqly --sql "CREATE TABLE t(x)"
       The status should be success
-      # A DDL statement reports neutral success, not a misleading row count (#439).
+      # A DDL statement reports neutral success, not a misleading row count.
       The output should include 'statement executed successfully'
     End
 
-    It 'accepts ANALYZE (#431)'
+    It 'accepts ANALYZE'
       When run sqly --sql "ANALYZE" testdata/user.csv
       The status should be success
-      # ANALYZE changes no rows, so it reports neutral success (#439).
+      # ANALYZE changes no rows, so it reports neutral success.
       The output should include 'statement executed successfully'
     End
 
-    It 'runs WITH ... UPDATE without RETURNING as DML (#412)'
+    It 'runs WITH ... UPDATE without RETURNING as DML'
       When run sqly --sql "WITH s AS (SELECT 1 AS identifier) UPDATE user SET first_name='Z' WHERE identifier IN (SELECT identifier FROM s)" testdata/user.csv
       The status should be success
       The output should include 'affected is 1 row'
     End
   End
 
-  Describe 'dependent flags are validated (#391-#393)'
-    It 'rejects --stdin-name without --stdin (#391)'
+  Describe 'dependent flags are validated'
+    It 'rejects --stdin-name without --stdin'
       When run sqly --stdin-name weird --csv --sql "SELECT 1 AS x"
       The status should be failure
       The stderr should include 'stdin-name'
     End
 
-    It 'rejects --inspect-sample without --inspect (#392)'
+    It 'rejects --inspect-sample without --inspect'
       When run sqly --inspect-sample 0 --csv --sql "SELECT 1 AS x"
       The status should be failure
       The stderr should include 'inspect-sample'
     End
 
-    It 'rejects --force without --save (#393)'
+    It 'rejects --force without --save'
       When run sqly --force --sql "SELECT 1 AS x"
       The status should be failure
       The stderr should include 'force'
     End
 
-    It 'rejects --inspect combined with --csv (#390)'
+    It 'rejects --inspect combined with --csv'
       When run sqly --inspect --csv testdata/user.csv
       The status should be failure
       The stderr should include 'inspect'
     End
   End
 
-  Describe 'empty JSON inputs import as zero-row tables (#388, #389)'
-    It 'imports an empty JSON array (#388)'
+  Describe 'empty JSON inputs import as zero-row tables'
+    It 'imports an empty JSON array'
       empty_json="$(mktemp -d)/empty.json"
       printf '[]' > "$empty_json"
       When run sqly --csv --sql "SELECT COUNT(*) AS n FROM empty" "$empty_json"
@@ -126,7 +126,7 @@ Describe 'sqly v0.19.0 binary bug fixes'
       The line 2 should equal '0'
     End
 
-    It 'imports an empty JSONL file (#389)'
+    It 'imports an empty JSONL file'
       empty_jsonl="$(mktemp -d)/empty.jsonl"
       : > "$empty_jsonl"
       When run sqly --csv --sql "SELECT COUNT(*) AS n FROM empty" "$empty_jsonl"
@@ -135,15 +135,15 @@ Describe 'sqly v0.19.0 binary bug fixes'
     End
   End
 
-  Describe 'output destination safety (#419, #421)'
-    It 'rejects an --output path ending with a slash (#419)'
+  Describe 'output destination safety'
+    It 'rejects an --output path ending with a slash'
       out="$(mktemp -d)/outdir/"
       When run sqly --sql "SELECT 1 AS x" --output "$out" testdata/user.csv
       The status should be failure
       The stderr should include 'separator'
     End
 
-    It 'rejects an --output ACH destination (#421)'
+    It 'rejects an --output ACH destination'
       out="$(mktemp -d)/out.ach"
       When run sqly --sql "SELECT identifier FROM user LIMIT 1" --output "$out" testdata/user.csv
       The status should be failure
@@ -151,8 +151,8 @@ Describe 'sqly v0.19.0 binary bug fixes'
     End
   End
 
-  Describe 'batch helper commands run line-by-line (#397, #425)'
-    It 'parses a helper command after a terminated statement (#397)'
+  Describe 'batch helper commands run line-by-line'
+    It 'parses a helper command after a terminated statement'
       Data
         #|SELECT 1 AS x;
         #|.mode csv
@@ -164,7 +164,7 @@ Describe 'sqly v0.19.0 binary bug fixes'
       The stderr should not include 'arguments'
     End
 
-    It 'parses a helper command after a leading comment (#425)'
+    It 'parses a helper command after a leading comment'
       Data
         #|-- header
         #|.mode csv
@@ -177,13 +177,13 @@ Describe 'sqly v0.19.0 binary bug fixes'
     End
   End
 
-  Describe 'write-back semantics (#402, #404)'
+  Describe 'write-back semantics'
     setup_user() {
       WORK="$(mktemp -d)"
       cp "$PROJECT_ROOT/testdata/user.csv" "$WORK/user.csv"
     }
 
-    It 'does not write back for an EXPLAIN under --save-dir (#402)'
+    It 'does not write back for an EXPLAIN under --save-dir'
       setup_user
       out="$WORK/out"
       When run sqly --sql "EXPLAIN UPDATE user SET first_name='X' WHERE identifier=1" --save-dir "$out" "$WORK/user.csv"
@@ -192,7 +192,7 @@ Describe 'sqly v0.19.0 binary bug fixes'
       The path "$out/user.csv" should not be exist
     End
 
-    It 'does not write back for a zero-row DML under --save-dir (#404)'
+    It 'does not write back for a zero-row DML under --save-dir'
       setup_user
       out="$WORK/out"
       When run sqly --sql "UPDATE user SET first_name='X' WHERE identifier=999999" --save-dir "$out" "$WORK/user.csv"
@@ -201,7 +201,7 @@ Describe 'sqly v0.19.0 binary bug fixes'
       The path "$out/user.csv" should not be exist
     End
 
-    It 'keeps stdout clean when parquet write-back fails (#396)'
+    It 'keeps stdout clean when parquet write-back fails'
       WORK="$(mktemp -d)"
       cp "$PROJECT_ROOT/testdata/products.parquet" "$WORK/products.parquet"
       When run sqly --sql "DELETE FROM products" --save --force "$WORK/products.parquet"

--- a/spec/v0_20_bugs_spec.sh
+++ b/spec/v0_20_bugs_spec.sh
@@ -20,17 +20,16 @@ Describe 'sqly v0.20.0 binary regressions'
   AfterEach 'cleanup'
 
   # --save / --save-dir reject schema-only and maintenance statements up front
-  # instead of exiting 0 while leaving the source unchanged. Ref #433-#437,
-  # #469-#484.
+  # instead of exiting 0 while leaving the source unchanged.,
   Describe 'write-back rejects save-incompatible statements'
     Parameters
-      "ALTER TABLE user RENAME COLUMN first_name TO fname" # 433
-      "DROP TABLE user"                                    # 435
-      "CREATE VIEW v AS SELECT user_name FROM user"        # 469
-      "CREATE INDEX idx ON user(identifier)"               # 471
-      "CREATE TABLE backup (id INTEGER)"                   # 473
-      "REINDEX"                                            # 479
-      "ANALYZE"                                            # 481
+      "ALTER TABLE user RENAME COLUMN first_name TO fname"
+      "DROP TABLE user"
+      "CREATE VIEW v AS SELECT user_name FROM user"
+      "CREATE INDEX idx ON user(identifier)"
+      "CREATE TABLE backup (id INTEGER)"
+      "REINDEX"
+      "ANALYZE"
     End
 
     It "rejects: $1"
@@ -41,21 +40,21 @@ Describe 'sqly v0.20.0 binary regressions'
     End
   End
 
-  It 'rejects CREATE TABLE AS SELECT under --save-dir and writes nothing (#437)'
+  It 'rejects CREATE TABLE AS SELECT under --save-dir and writes nothing'
     When run sqly --sql "CREATE TABLE backup AS SELECT * FROM user" --save-dir "$WORK/out" "$WORK/user.csv"
     The status should be failure
     The stderr should be present
     The path "$WORK/out" should not be exist
   End
 
-  It 'preflight rejects a CTAS+DML script before it executes (#438)'
+  It 'preflight rejects a CTAS+DML script before it executes'
     printf 'CREATE TABLE backup AS SELECT * FROM user;\nUPDATE user SET first_name=%cZ%c WHERE identifier=1;\n' "'" "'" > "$WORK/s.sql"
     When run sqly --sql-file "$WORK/s.sql" --save-dir "$WORK/out" "$WORK/user.csv"
     The status should be failure
     The stderr should be present
   End
 
-  It 'allows a .import + UPDATE batch under --save-dir and writes the change (#456)'
+  It 'allows a .import + UPDATE batch under --save-dir and writes the change'
     printf '.import testdata/user.csv\nUPDATE user SET first_name=%cBatch%c WHERE identifier=1;\n' "'" "'" > "$WORK/imp.sql"
     When run sqly --sql-file "$WORK/imp.sql" --save-dir "$WORK/out"
     The status should be success
@@ -65,7 +64,7 @@ Describe 'sqly v0.20.0 binary regressions'
   End
 
   # DDL / PRAGMA / maintenance no longer print a misleading affected-row count.
-  Describe 'no-rowset statements report neutral success (#439)'
+  Describe 'no-rowset statements report neutral success'
     Parameters
       "CREATE VIEW v AS SELECT 1 AS x"
       "CREATE TABLE t (id INTEGER)"
@@ -80,42 +79,41 @@ Describe 'sqly v0.20.0 binary regressions'
     End
   End
 
-  # Setter and command PRAGMAs run on the exec path instead of failing. Ref #440,
-  # #485.
-  It 'runs a setter PRAGMA (#440)'
+  # Setter and command PRAGMAs run on the exec path instead of failing.,
+  It 'runs a setter PRAGMA'
     When run sqly --sql "PRAGMA user_version = 1" "$WORK/user.csv"
     The status should be success
     The output should include 'statement executed successfully'
   End
 
-  It 'runs a command PRAGMA that returns no rows (#485)'
+  It 'runs a command PRAGMA that returns no rows'
     When run sqly --sql "PRAGMA incremental_vacuum"
     The status should be success
     The output should include 'statement executed successfully'
   End
 
   # Transaction control, VACUUM, and ATTACH are rejected with a clear error.
-  It 'rejects BEGIN in a --sql-file script (#441)'
+  It 'rejects BEGIN in a --sql-file script'
     printf 'BEGIN IMMEDIATE;\nUPDATE user SET first_name=%cTX%c WHERE identifier=1;\nCOMMIT;\n' "'" "'" > "$WORK/tx.sql"
     When run sqly --sql-file "$WORK/tx.sql" "$WORK/user.csv"
     The status should be failure
     The stderr should include 'transaction'
   End
 
-  It 'rejects VACUUM (#457)'
+  It 'rejects VACUUM'
     When run sqly --sql "VACUUM"
     The status should be failure
     The stderr should include 'VACUUM'
   End
 
-  It 'rejects VACUUM INTO and writes no file (#458)'
+  It 'rejects VACUUM INTO and writes no file'
     When run sqly --sql "VACUUM INTO '$WORK/dump.db'"
     The status should be failure
     The stderr should include 'VACUUM'
     The path "$WORK/dump.db" should not be exist
   End
 
-  It 'rejects ATTACH DATABASE and persists no external file (#443)'
+  It 'rejects ATTACH DATABASE and persists no external file'
     printf "ATTACH DATABASE '%s/aux.db' AS aux;\nCREATE TABLE aux.t (id INTEGER);\n" "$WORK" > "$WORK/a.sql"
     When run sqly --sql-file "$WORK/a.sql"
     The status should be failure
@@ -123,8 +121,8 @@ Describe 'sqly v0.20.0 binary regressions'
     The path "$WORK/aux.db" should not be exist
   End
 
-  # A multiline CREATE TRIGGER is parsed as one statement. Ref #468.
-  It 'runs a multiline CREATE TRIGGER from a --sql-file (#468)'
+  # A multiline CREATE TRIGGER is parsed as one statement.
+  It 'runs a multiline CREATE TRIGGER from a --sql-file'
     printf 'CREATE TRIGGER trig_user AFTER UPDATE ON user BEGIN\n  UPDATE user SET last_name=%cTriggered%c WHERE identifier=2;\nEND;\n' "'" "'" > "$WORK/t.sql"
     When run sqly --sql-file "$WORK/t.sql" "$WORK/user.csv"
     The status should be success
@@ -132,7 +130,7 @@ Describe 'sqly v0.20.0 binary regressions'
   End
 
   # Helper command surface: schema-qualified names, views, and TEMP tables.
-  It 'accepts a schema-qualified .schema name (#445)'
+  It 'accepts a schema-qualified .schema name'
     Data
       #|.import testdata/user.csv
       #|.schema main.user
@@ -142,7 +140,7 @@ Describe 'sqly v0.20.0 binary regressions'
     The output should include 'user_name'
   End
 
-  It 'lists session-created views and temp tables in .tables (#449, #450)'
+  It 'lists session-created views and temp tables in .tables'
     Data
       #|CREATE TEMP TABLE temp_t (id INTEGER);
       #|CREATE VIEW v_user AS SELECT user_name FROM user;
@@ -154,7 +152,7 @@ Describe 'sqly v0.20.0 binary regressions'
     The output should include 'v_user'
   End
 
-  It 'prints CREATE VIEW for a view in .schema (#451)'
+  It 'prints CREATE VIEW for a view in .schema'
     Data
       #|CREATE VIEW v_user AS SELECT user_name FROM user;
       #|.schema v_user
@@ -164,8 +162,8 @@ Describe 'sqly v0.20.0 binary regressions'
     The output should include 'CREATE VIEW'
   End
 
-  # Empty compressed JSON/JSONL import as zero-row tables. Ref #452, #453.
-  It 'imports an empty compressed JSON array as a zero-row table (#452)'
+  # Empty compressed JSON/JSONL import as zero-row tables.
+  It 'imports an empty compressed JSON array as a zero-row table'
     printf '[]' > "$WORK/empty.json"
     gzip -c "$WORK/empty.json" > "$WORK/empty.json.gz"
     When run sqly --sql "SELECT COUNT(*) AS c FROM empty" "$WORK/empty.json.gz"
@@ -173,7 +171,7 @@ Describe 'sqly v0.20.0 binary regressions'
     The output should include '0'
   End
 
-  It 'imports an empty compressed JSONL file as a zero-row table (#453)'
+  It 'imports an empty compressed JSONL file as a zero-row table'
     : > "$WORK/empty.jsonl"
     gzip -c "$WORK/empty.jsonl" > "$WORK/empty.jsonl.gz"
     When run sqly --sql "SELECT COUNT(*) AS c FROM empty" "$WORK/empty.jsonl.gz"
@@ -181,8 +179,8 @@ Describe 'sqly v0.20.0 binary regressions'
     The output should include '0'
   End
 
-  # Standard Unix pseudo-files import end-to-end (staged as CSV). Ref #461, #462.
-  It 'imports /dev/stdin as CSV (#461)'
+  # Standard Unix pseudo-files import end-to-end (staged as CSV).
+  It 'imports /dev/stdin as CSV'
     Data
       #|name,score
       #|a,1
@@ -194,7 +192,7 @@ Describe 'sqly v0.20.0 binary regressions'
     The line 2 should equal '3'
   End
 
-  It 'imports /proc/self/fd/0 as CSV (#462)'
+  It 'imports /proc/self/fd/0 as CSV'
     if [ ! -e /proc/self/fd/0 ]; then
       Skip '/proc not available'
     fi
@@ -210,15 +208,15 @@ Describe 'sqly v0.20.0 binary regressions'
   End
 
   # ACH/Fedwire destinations hidden behind stacked compression suffixes are
-  # rejected. Ref #459, #460.
-  It 'rejects --output to a multi-compressed ACH destination (#459)'
+  # rejected.
+  It 'rejects --output to a multi-compressed ACH destination'
     When run sqly --sql "SELECT * FROM user LIMIT 1" --output "$WORK/out.ach.gz.zst" "$WORK/user.csv"
     The status should be failure
     The stderr should include 'ACH/Fedwire'
     The path "$WORK/out.ach.gz.zst" should not be exist
   End
 
-  It 'rejects .dump to a multi-compressed Fedwire destination (#460)'
+  It 'rejects .dump to a multi-compressed Fedwire destination'
     Data:expand
       #|.import testdata/user.csv
       #|.dump user ${WORK}/out.fed.gz.zst
@@ -229,21 +227,20 @@ Describe 'sqly v0.20.0 binary regressions'
     The path "$WORK/out.fed.gz.zst" should not be exist
   End
 
-  # LTSV output and import reject invalid or duplicate labels. Ref #465, #466,
-  # #467.
-  It 'rejects an invalid LTSV output label (#465)'
+  # LTSV output and import reject invalid or duplicate labels.,
+  It 'rejects an invalid LTSV output label'
     When run sqly --ltsv --sql 'SELECT 1 AS "foo:bar"' --output "$WORK/out.ltsv"
     The status should be failure
     The stderr should be present
   End
 
-  It 'rejects duplicate LTSV output labels (#466)'
+  It 'rejects duplicate LTSV output labels'
     When run sqly --ltsv --sql 'SELECT 1 AS x, 2 AS x' --output "$WORK/out.ltsv"
     The status should be failure
     The stderr should be present
   End
 
-  It 'rejects an LTSV import with duplicate labels (#467)'
+  It 'rejects an LTSV import with duplicate labels'
     printf 'x:1\tx:2\n' > "$WORK/dup.ltsv"
     When run sqly --sql 'SELECT * FROM dup' "$WORK/dup.ltsv"
     The status should be failure

--- a/spec/v0_21_bugs_spec.sh
+++ b/spec/v0_21_bugs_spec.sh
@@ -1,0 +1,289 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Binary-level regressions for the v0.21.0 hardening work. These run the built
+# sqly the way a user does (flags, batch stdin, --sql-file, exit codes, stdout vs
+# stderr, files on disk) so the fixes are pinned at the layer the bugs were
+# reported against.
+
+Describe 'sqly v0.21.0 binary regressions'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    WORK=$(mktemp -d)
+    export SQLY_HISTORY_DB_PATH="$WORK/history.db"
+    cp "$PROJECT_ROOT/testdata/user.csv" "$WORK/user.csv"
+  }
+  cleanup() {
+    rm -rf "$WORK"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # Helper-command name resolution: temp-before-main, TEMP keyword, dotted literal
+  # names, paste-safe quoting.
+  It 'prefers a TEMP table over a same-named main table in .schema'
+    Data
+      #|CREATE TEMP TABLE user(id TEXT);
+      #|.schema user
+    End
+    When run sqly "$WORK/user.csv"
+    The status should be success
+    The output should include 'TEMP'
+    The output should not include 'first_name'
+  End
+
+  It 'prefers a TEMP view over a same-named main table in .schema'
+    Data
+      #|CREATE TEMP VIEW user AS SELECT 1 AS id;
+      #|.schema user
+    End
+    When run sqly "$WORK/user.csv"
+    The status should be success
+    The output should include 'TEMP VIEW'
+  End
+
+  It 'keeps both a main and a same-named TEMP object in .tables'
+    Data
+      #|CREATE TEMP TABLE user(id TEXT);
+      #|.tables
+    End
+    When run sqly "$WORK/user.csv"
+    The status should be success
+    The output should include 'temp.user'
+  End
+
+  It 'targets a literal dotted table name in .schema'
+    Data
+      #|CREATE TABLE "a.b"(id INTEGER);
+      #|.schema "a.b"
+    End
+    When run sqly
+    The status should be success
+    The output should include 'id'
+  End
+
+  It 'targets a literal dotted table name in .describe'
+    Data
+      #|CREATE TABLE "a.b"(id INTEGER);
+      #|.describe "a.b"
+    End
+    When run sqly
+    The status should be success
+    The output should include 'id'
+  End
+
+  It 'targets a literal dotted table name in .header'
+    Data
+      #|CREATE TABLE "a.b"(id INTEGER);
+      #|.header "a.b"
+    End
+    When run sqly
+    The status should be success
+    The output should include 'id'
+  End
+
+  It 'targets a literal dotted table name in .dump'
+    Data:expand
+      #|CREATE TABLE "a.b"(id INTEGER);
+      #|.dump "a.b" $WORK/ab.csv
+    End
+    When run sqly
+    The status should be success
+    The output should include 'statement executed successfully'
+    The stderr should be present
+    The contents of file "$WORK/ab.csv" should include 'id'
+  End
+
+  It 'prints a paste-safe quoted identifier in .tables'
+    Data
+      #|CREATE TABLE "two words"(id INTEGER);
+      #|.tables
+    End
+    When run sqly
+    The status should be success
+    The output should include '"two words"'
+  End
+
+  It 'keeps the full spaced table name in .header'
+    Data
+      #|CREATE TABLE "two words"(id INTEGER);
+      #|.header "two words"
+    End
+    When run sqly
+    The status should be success
+    The output should include 'two words'
+  End
+
+  It 'keeps the TEMP keyword for a temp-qualified table in .schema'
+    Data
+      #|CREATE TEMP TABLE t(id INTEGER PRIMARY KEY);
+      #|.schema temp.t
+    End
+    When run sqly
+    The status should be success
+    The output should include 'TEMP'
+  End
+
+  It 'keeps the TEMP keyword for a temp-qualified view in .schema'
+    Data
+      #|CREATE TEMP VIEW v AS SELECT 1 AS id;
+      #|.schema temp.v
+    End
+    When run sqly
+    The status should be success
+    The output should include 'TEMP VIEW'
+  End
+
+  # Direct --sql runs exactly one statement; multi-statement input is rejected.
+  Describe 'direct --sql rejects multi-statement input'
+    Parameters
+      "SELECT 1 AS x; SELECT 2 AS y"
+      "SELECT 1 AS x; UPDATE user SET first_name='z'"
+    End
+
+    It "rejects: $1"
+      When run sqly --sql "$1" "$WORK/user.csv"
+      The status should be failure
+      The stderr should include 'single SQL statement'
+    End
+  End
+
+  It 'rejects multi-statement --sql --output before writing the file'
+    When run sqly --csv --sql "SELECT 1 AS x; SELECT 2 AS y" --output "$WORK/out.csv"
+    The status should be failure
+    The stderr should include 'single SQL statement'
+    The path "$WORK/out.csv" should not be exist
+  End
+
+  # --save / --save-dir reject side-effecting PRAGMA statements that cannot be
+  # written back.
+  Describe 'save mode rejects non-persistable PRAGMA statements'
+    Parameters
+      "PRAGMA user_version=1"
+      "PRAGMA incremental_vacuum"
+      "PRAGMA journal_mode=OFF"
+    End
+
+    It "rejects under --save --force: $1"
+      When run sqly --sql "$1" --save --force "$WORK/user.csv"
+      The status should be failure
+      The stderr should be present
+      The output should not include 'journal_mode'
+    End
+  End
+
+  It 'rejects a setter PRAGMA under --save-dir and writes nothing'
+    When run sqly --sql "PRAGMA user_version=1" --save-dir "$WORK/out" "$WORK/user.csv"
+    The status should be failure
+    The stderr should be present
+    The path "$WORK/out" should not be exist
+  End
+
+  It 'rejects a command PRAGMA under --save-dir and writes nothing'
+    When run sqly --sql "PRAGMA incremental_vacuum" --save-dir "$WORK/out" "$WORK/user.csv"
+    The status should be failure
+    The stderr should be present
+    The path "$WORK/out" should not be exist
+  End
+
+  # END (an alias for COMMIT) is rejected as unsupported transaction control on
+  # every execution path.
+  It 'rejects END in direct --sql'
+    When run sqly --sql "END"
+    The status should be failure
+    The stderr should include 'transaction'
+  End
+
+  It 'rejects END in batch stdin'
+    Data
+      #|END;
+    End
+    When run sqly
+    The status should be failure
+    The stderr should include 'transaction'
+  End
+
+  It 'rejects END in a --sql-file script'
+    printf 'END;\n' > "$WORK/end.sql"
+    When run sqly --sql-file "$WORK/end.sql"
+    The status should be failure
+    The stderr should include 'transaction'
+  End
+
+  # Nested compression suffixes are rejected instead of writing a mislabeled file.
+  Describe '--output rejects nested compression suffixes and writes nothing'
+    Parameters
+      "out.csv.gz.zst"
+      "out.parquet.gz.zst"
+      "out.xlsx.gz.zst"
+    End
+
+    It "rejects: $1"
+      When run sqly --sql "SELECT 1 AS x" --output "$WORK/$1"
+      The status should be failure
+      The stderr should be present
+      The path "$WORK/$1" should not be exist
+    End
+  End
+
+  It 'rejects a nested .dump destination and writes nothing'
+    Data:expand
+      #|.dump user $WORK/d.csv.gz.zst
+    End
+    When run sqly "$WORK/user.csv"
+    The status should be failure
+    The stderr should be present
+    The path "$WORK/d.csv.gz.zst" should not be exist
+  End
+
+  # .tables and .header honor structured output modes.
+  It 'emits structured .tables output under .mode json'
+    Data
+      #|.mode json
+      #|.tables
+    End
+    When run sqly "$WORK/user.csv"
+    The status should be success
+    The stderr should include 'Change output mode'
+    The output should include '"name"'
+    The output should include '"schema"'
+  End
+
+  It 'emits structured .header output under .mode ndjson'
+    Data
+      #|.mode ndjson
+      #|.header user
+    End
+    When run sqly "$WORK/user.csv"
+    The status should be success
+    The stderr should include 'Change output mode'
+    The output should include '"column"'
+    The output should include 'first_name'
+  End
+
+  # A read-only session writes back nothing, so .save does not rewrite sources or
+  # emit fresh exports.
+  It 'does not rewrite an unchanged source on .save --force'
+    printf 'user_name,identifier\nalice,1' > "$WORK/ro.csv"
+    Data
+      #|.save --force
+    End
+    When run sqly "$WORK/ro.csv"
+    The status should be success
+    The stderr should include 'nothing to save'
+  End
+
+  It 'writes no directory export for an unchanged session on .save DIR'
+    printf 'user_name,identifier\nalice,1' > "$WORK/ro2.csv"
+    Data:expand
+      #|SELECT 1;
+      #|.save $WORK/out
+    End
+    When run sqly "$WORK/ro2.csv"
+    The status should be success
+    The output should include '1'
+    The stderr should include 'nothing to save'
+    The path "$WORK/out" should not be exist
+  End
+End


### PR DESCRIPTION
This resolves the bugs reported against the published v0.21.0 binary under the roadmap in #148 and prepares the v0.22.0 release.

Helper commands: `.schema` now resolves an unqualified name against temp objects before main, preserves the TEMP keyword for temp-qualified objects, and `.schema`/`.describe`/`.header`/`.dump` target a SQL-created table whose quoted literal name contains a dot. `.tables` keeps a main object and a same-named temp object distinct, prints paste-safe quoted identifiers, and `.tables`/`.header` honor `.mode json`/`.mode ndjson`. `.header` keeps the full table name when it contains spaces.

Execution and output contracts: direct `--sql` rejects multi-statement input instead of silently keeping only the last result; `--save`/`--save-dir` reject non-persistable PRAGMA statements; `END`/`END TRANSACTION` is rejected as unsupported transaction control on every path; `--output` and `.dump` reject nested compression suffixes; and an interactive `.save` writes nothing after a read-only session.

Coverage: Go regression tests for each fix plus a shellspec binary suite (`spec/v0_21_bugs_spec.sh`) that exercises the built binary. `make test`, `make lint`, and `make test-e2e` are green.

This branch also removes issue-number references from the repository per a maintainer request, and refreshes the CHANGELOG and README to v0.22.0.

Refs #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured output for .tables and .header; clearer schema/temp reporting
  * Improved handling and quoting of schema-qualified and dotted identifiers

* **Bug Fixes**
  * Reject nested compression suffixes for exports
  * Tighter save/write-back safety to avoid accidental overwrites
  * Treat END as transaction-control (consistent rejection where unsupported)

* **Documentation**
  * Updated changelog and README version to v0.22.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->