### PR TITLE
fix: reach literal dotted object names with a main/temp prefix in helper commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+* Literal Dotted Object Names With A Schema Prefix: `.schema`, `.describe`, `.header`, and `.dump` now reach a table or view whose quoted literal name begins with `main.` or `temp.` (for example `CREATE TABLE "main.x"` or `CREATE VIEW "temp.v"`). Because the shell strips the quotes the user typed, a name is read as a schema qualifier only when no object literally carries it. `.tables` prints such a name quoted so it pastes back into these commands.
+
 ### Documentation
 * Add README demos for cross-format JOIN (Parquet and CSV), --output format conversion (JSON, Parquet, Excel), and directory import across formats, recorded with VHS.
 

--- a/infrastructure/memory/sqlite3.go
+++ b/infrastructure/memory/sqlite3.go
@@ -4,6 +4,7 @@ package memory
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -146,7 +147,11 @@ func (r *sqlite3Repository) Insert(ctx context.Context, t *model.Table) error {
 
 // List get records in the specified table
 func (r *sqlite3Repository) List(ctx context.Context, tableName string) (*model.Table, error) {
-	table, err := r.Query(ctx, "SELECT * FROM "+infra.QuoteTableRef(tableName))
+	ref, err := r.resolveTableRef(ctx, tableName)
+	if err != nil {
+		return nil, err
+	}
+	table, err := r.Query(ctx, "SELECT * FROM "+ref)
 	if err != nil {
 		return nil, err
 	}
@@ -157,11 +162,54 @@ func (r *sqlite3Repository) List(ctx context.Context, tableName string) (*model.
 // name rather than the name extractTableName parses from the query, which would
 // truncate a name containing spaces (e.g. "two words" -> "two").
 func (r *sqlite3Repository) Header(ctx context.Context, tableName string) (*model.Table, error) {
-	table, err := r.Query(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 1", infra.QuoteTableRef(tableName)))
+	ref, err := r.resolveTableRef(ctx, tableName)
+	if err != nil {
+		return nil, err
+	}
+	table, err := r.Query(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 1", ref))
 	if err != nil {
 		return nil, err
 	}
 	return model.NewTable(tableName, table.Header(), table.Records()), nil
+}
+
+// resolveTableRef returns the quoted SQL reference a helper command should query
+// for tableName, disambiguating a literal dotted name from a schema-qualified one.
+// It prefers the literal reading: when an object whose name is exactly tableName
+// exists, the name is quoted whole (so `.dump "main.x"` reaches a table created as
+// `CREATE TABLE "main.x"`); otherwise a "main."/"temp."-prefixed name keeps its
+// schema-qualified quoting (so `.dump main.user` resolves the imported user table).
+func (r *sqlite3Repository) resolveTableRef(ctx context.Context, tableName string) (string, error) {
+	exists, err := r.objectExists(ctx, tableName)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return infra.Quote(tableName), nil
+	}
+	return infra.QuoteTableRef(tableName), nil
+}
+
+// objectExists reports whether a table or view whose name is exactly name exists
+// in either the temp or main schema.
+func (r *sqlite3Repository) objectExists(ctx context.Context, name string) (bool, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const query = "SELECT 1 FROM sqlite_temp_master WHERE name = ? AND type IN ('table', 'view') " +
+		"UNION ALL SELECT 1 FROM sqlite_master WHERE name = ? AND type IN ('table', 'view') LIMIT 1"
+	var dummy int
+	err = tx.QueryRowContext(ctx, query, name, name).Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
 }
 
 // Query execute "SELECT" or "EXPLAIN" query

--- a/shell/describe.go
+++ b/shell/describe.go
@@ -37,8 +37,9 @@ func (c CommandList) describeCommand(ctx context.Context, s *Shell, argv []strin
 // empty record set means the table does not exist (PRAGMA returns no rows).
 func (s *Shell) tableColumns(ctx context.Context, tableName string) (*model.Table, error) {
 	// A schema-qualified name (main.user, temp.t) is inspected against that schema
-	// via "PRAGMA schema.table_info(table)", matching the SQL surface.
-	schema, object := splitTableQualifier(tableName)
+	// via "PRAGMA schema.table_info(table)", matching the SQL surface. A literal
+	// dotted name (a table created as "main.x") is resolved whole instead.
+	schema, object := s.resolveObjectName(ctx, tableName)
 	pragma := "PRAGMA "
 	if schema != "" {
 		pragma += s.usecases.importer.QuoteIdentifier(schema) + "."

--- a/shell/schema.go
+++ b/shell/schema.go
@@ -53,7 +53,7 @@ func isStructuredMode(m model.PrintMode) bool {
 // temp.t) is resolved against that schema. Returns an error when the object does
 // not exist.
 func (s *Shell) tableCreateStatement(ctx context.Context, tableName string) (string, error) {
-	schema, object := splitTableQualifier(tableName)
+	schema, object := s.resolveObjectName(ctx, tableName)
 	stored, isTemp, err := s.storedCreateSQL(ctx, schema, object)
 	if err != nil {
 		return "", err
@@ -152,6 +152,35 @@ func splitTableQualifier(name string) (schema, object string) {
 		return name[:i], name[i+1:]
 	}
 	return "", name
+}
+
+// resolveObjectName disambiguates a user-supplied helper-command argument between
+// a literal dotted identifier and a schema-qualified reference. The shell tokenizer
+// strips the quotes the user typed, so "main.x" and main.x arrive identically and
+// the name alone cannot say which was meant. It prefers the literal reading: when
+// an object whose name is exactly tableName exists in the temp or main schema, the
+// name is returned whole (empty schema), so `.schema "main.x"` reaches a table
+// created as `CREATE TABLE "main.x"`. Otherwise a "main."/"temp."-prefixed name is
+// split, so `.schema main.user` still resolves the imported user table.
+func (s *Shell) resolveObjectName(ctx context.Context, tableName string) (schema, object string) {
+	if s.objectExists(ctx, tableName) {
+		return "", tableName
+	}
+	return splitTableQualifier(tableName)
+}
+
+// objectExists reports whether a table or view named exactly name exists in either
+// the temp or main schema. A failed lookup reports false so resolution falls back
+// to the syntactic schema-qualifier split.
+func (s *Shell) objectExists(ctx context.Context, name string) bool {
+	literal := "'" + strings.ReplaceAll(name, "'", "''") + "'"
+	res, err := s.usecases.query.Query(ctx,
+		"SELECT 1 FROM sqlite_temp_master WHERE name = "+literal+" AND type IN ('table', 'view') "+
+			"UNION ALL SELECT 1 FROM sqlite_master WHERE name = "+literal+" AND type IN ('table', 'view')")
+	if err != nil {
+		return false
+	}
+	return len(res.Records()) > 0
 }
 
 // isSchemaName reports whether prefix is a SQLite schema name a sqly session can

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -3425,6 +3425,135 @@ func TestShellExec_SchemaQualifiedTempView(t *testing.T) {
 	})
 }
 
+// TestShellExec_LiteralDottedObjectNames verifies that the helper commands reach a
+// table or view whose quoted literal name happens to begin with a "main."/"temp."
+// prefix (e.g. `CREATE TABLE "main.x"`). The prefix is a real schema qualifier only
+// when no object literally carries that name, so the literal object must win.
+func TestShellExec_LiteralDottedObjectNames(t *testing.T) {
+	newImportedShell := func(t *testing.T) (*Shell, func()) {
+		t.Helper()
+		shell, cleanup, err := newShell(t, []string{"sqly"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := shell.commands.importCommand(context.Background(), shell, []string{filepath.Join("testdata", "user.csv")}); err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+		return shell, cleanup
+	}
+
+	// Each case creates one literal-named object and then inspects it. The literal
+	// name carries a column unique to the object so a wrong resolution (an empty or
+	// imported result) is detectable.
+	cases := []struct {
+		name   string
+		create string
+		object string // literal name as it reaches argv after quote stripping
+	}{
+		{"literal table main.x", `CREATE TABLE "main.x"(litcol INTEGER)`, "main.x"},
+		{"literal table temp.x", `CREATE TABLE "temp.x"(litcol INTEGER)`, "temp.x"},
+		{"literal view main.v", `CREATE VIEW "main.v" AS SELECT 1 AS litcol`, "main.v"},
+		{"literal view temp.v", `CREATE VIEW "temp.v" AS SELECT 1 AS litcol`, "temp.v"},
+	}
+
+	for _, tc := range cases {
+		t.Run(".schema reaches "+tc.name, func(t *testing.T) {
+			shell, cleanup := newImportedShell(t)
+			defer cleanup()
+			if err := shell.exec(context.Background(), tc.create); err != nil {
+				t.Fatalf("create error: %v", err)
+			}
+			got, err := getExecStdOutput(t, shell.exec, `.schema "`+tc.object+`"`)
+			if err != nil {
+				t.Fatalf(".schema %q error: %v", tc.object, err)
+			}
+			if !strings.Contains(string(got), "litcol") {
+				t.Fatalf(".schema %q missing the literal object definition: %q", tc.object, got)
+			}
+		})
+
+		t.Run(".describe reaches "+tc.name, func(t *testing.T) {
+			shell, cleanup := newImportedShell(t)
+			defer cleanup()
+			if err := shell.exec(context.Background(), tc.create); err != nil {
+				t.Fatalf("create error: %v", err)
+			}
+			got, err := getExecStdOutput(t, shell.exec, `.describe "`+tc.object+`"`)
+			if err != nil {
+				t.Fatalf(".describe %q error: %v", tc.object, err)
+			}
+			if !strings.Contains(string(got), "litcol") {
+				t.Fatalf(".describe %q missing the literal column: %q", tc.object, got)
+			}
+		})
+
+		t.Run(".header reaches "+tc.name, func(t *testing.T) {
+			shell, cleanup := newImportedShell(t)
+			defer cleanup()
+			if err := shell.exec(context.Background(), tc.create); err != nil {
+				t.Fatalf("create error: %v", err)
+			}
+			got, err := getExecStdOutput(t, shell.exec, `.header "`+tc.object+`"`)
+			if err != nil {
+				t.Fatalf(".header %q error: %v", tc.object, err)
+			}
+			if !strings.Contains(string(got), "litcol") {
+				t.Fatalf(".header %q missing the literal column: %q", tc.object, got)
+			}
+		})
+
+		t.Run(".dump reaches "+tc.name, func(t *testing.T) {
+			shell, cleanup := newImportedShell(t)
+			defer cleanup()
+			if err := shell.exec(context.Background(), tc.create); err != nil {
+				t.Fatalf("create error: %v", err)
+			}
+			dest := filepath.Join(t.TempDir(), "out.csv")
+			if err := shell.exec(context.Background(), `.dump "`+tc.object+`" `+dest); err != nil {
+				t.Fatalf(".dump %q error: %v", tc.object, err)
+			}
+			data, err := os.ReadFile(dest) //nolint:gosec // test path
+			if err != nil {
+				t.Fatalf("reading dump output: %v", err)
+			}
+			if !strings.Contains(string(data), "litcol") {
+				t.Fatalf(".dump %q wrote the wrong table: %q", tc.object, data)
+			}
+		})
+	}
+
+	// A literal "main.user" and the schema-qualified main.user can coexist: the
+	// literal object must win, while a name with no literal match still resolves the
+	// imported table. This guards the disambiguation rule against both readings.
+	t.Run("literal name wins over a same-named schema qualifier", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		if err := shell.exec(context.Background(), `CREATE TABLE "main.user"(litcol INTEGER)`); err != nil {
+			t.Fatalf("create error: %v", err)
+		}
+		gotLiteral, err := getExecStdOutput(t, shell.exec, `.describe "main.user"`)
+		if err != nil {
+			t.Fatalf(".describe literal error: %v", err)
+		}
+		if !strings.Contains(string(gotLiteral), "litcol") {
+			t.Fatalf(".describe did not prefer the literal table: %q", gotLiteral)
+		}
+	})
+
+	t.Run("schema qualifier still resolves when no literal object exists", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+		got, err := getExecStdOutput(t, shell.exec, ".describe main.user")
+		if err != nil {
+			t.Fatalf(".describe main.user error: %v", err)
+		}
+		if !strings.Contains(string(got), "first_name") {
+			t.Fatalf(".describe main.user lost the imported table: %q", got)
+		}
+	})
+}
+
 // TestRunDirectSQLRejectsMultipleStatements verifies that direct --sql refuses
 // multi-statement input instead of silently running every statement and keeping
 // only the last result.

--- a/spec/v0_22_bugs_spec.sh
+++ b/spec/v0_22_bugs_spec.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Binary-level regressions for the v0.22.0 hardening work. These run the built
+# sqly the way a user does (batch stdin, --sql, --output, files on disk, exit
+# codes) so the fixes are pinned at the layer the bugs were reported against.
+
+Describe 'sqly v0.22.0 binary regressions'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    WORK=$(mktemp -d)
+    export SQLY_HISTORY_DB_PATH="$WORK/history.db"
+  }
+  cleanup() {
+    rm -rf "$WORK"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # Literal dotted object names whose prefix is "main"/"temp". The quoted name is a
+  # single identifier, so the literal object must win over the schema qualifier.
+  It 'inspects a literal "main.x" table with .schema'
+    Data
+      #|CREATE TABLE "main.x"(litcol INTEGER);
+      #|.schema "main.x"
+    End
+    When run sqly
+    The status should be success
+    The output should include 'litcol'
+  End
+
+  It 'inspects a literal "temp.x" table with .describe'
+    Data
+      #|CREATE TABLE "temp.x"(litcol INTEGER);
+      #|.describe "temp.x"
+    End
+    When run sqly
+    The status should be success
+    The output should include 'litcol'
+  End
+
+  It 'inspects a literal "main.v" view with .header'
+    Data
+      #|CREATE VIEW "main.v" AS SELECT 1 AS litcol;
+      #|.header "main.v"
+    End
+    When run sqly
+    The status should be success
+    The output should include 'litcol'
+  End
+
+  It 'exports a literal "temp.v" view with .dump'
+    Data:expand
+      #|CREATE VIEW "temp.v" AS SELECT 1 AS litcol;
+      #|.dump "temp.v" $WORK/tv.csv
+    End
+    When run sqly
+    The status should be success
+    The output should include 'statement executed successfully'
+    The stderr should be present
+    The contents of file "$WORK/tv.csv" should include 'litcol'
+  End
+
+  It 'prints a paste-safe literal "main.x" name in .tables'
+    Data
+      #|CREATE TABLE "main.x"(litcol INTEGER);
+      #|.tables
+    End
+    When run sqly
+    The status should be success
+    The output should include '"main.x"'
+  End
+End


### PR DESCRIPTION
## Summary

`.schema`, `.describe`, `.header`, and `.dump` could not reach a table or view whose quoted literal name begins with a `main.` or `temp.` prefix, such as one created with `CREATE TABLE "main.x"` or `CREATE VIEW "temp.v"`. The commands failed with `no such table: main.x`.

The shell tokenizer strips the quotes the user types, so `.schema "main.x"` and `.schema main.x` arrive identically as the string `main.x`. The commands always read that as a schema qualifier (schema `main`, object `x`), which does not exist.

## Fix

Resolve the argument against the live catalog before splitting on the dot. When an object named exactly the argument exists in the temp or main schema, the name is a single literal identifier and is used whole. Otherwise a `main.`/`temp.`-prefixed name keeps its schema-qualifier split, so `.schema main.user` still resolves the imported `user` table. A literal object wins over a same-named schema qualifier, matching the quoted name `.tables` already prints.

## Tests

Go: `TestShellExec_LiteralDottedObjectNames` exercises `.schema`/`.describe`/`.header`/`.dump` against literal `main.x`, `temp.x`, `main.v`, and `temp.v` objects (tables and views), plus the literal-wins-over-qualifier and qualifier-still-resolves cases. Verified the suite fails on `main` before the fix.

shellspec: `spec/v0_22_bugs_spec.sh` runs the built binary for the same literal names and asserts `.tables` prints the literal name quoted so it pastes back into the other commands.

Closes #521
Closes #522
Closes #523
Closes #524
Closes #525
Closes #526
Closes #527
Closes #528
Closes #529
Closes #553
Closes #554
Closes #555
Closes #556
Closes #557
Closes #558
Closes #559
Closes #560


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed helper commands (`.schema`, `.describe`, `.header`, `.dump`) to correctly resolve quoted object names starting with `main.` or `temp.` as literal identifiers rather than schema-qualified references, improving handling of quoted names like `"main.x"` and `"temp.v"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->