### PR TITLE
fix: reject stacked compression suffixes that use a long-form codec alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 * Literal Dotted Object Names With A Schema Prefix: `.schema`, `.describe`, `.header`, and `.dump` now reach a table or view whose quoted literal name begins with `main.` or `temp.` (for example `CREATE TABLE "main.x"` or `CREATE VIEW "temp.v"`). Because the shell strips the quotes the user typed, a name is read as a schema qualifier only when no object literally carries it. `.tables` prints such a name quoted so it pastes back into these commands.
+* Long-Form Compression Aliases In Stacked Suffixes: `--output` and `.dump` now reject a destination that stacks a long-form compression alias on another codec (for example `out.parquet.gzip.zst` or `out.tsv.gzip.zst`). Previously sqly applied only the outermost codec and wrote CSV bytes under a name that advertised a different format. `.gzip`, `.zstd`, and `.bzip2` are now recognized as compression suffixes when detecting stacked suffixes and when seeing through compression to an input-only `.ach`/`.fed` format.
 
 ### Documentation
 * Add README demos for cross-format JOIN (Parquet and CSV), --output format conversion (JSON, Parquet, Excel), and directory import across formats, recorded with VHS.

--- a/domain/model/export.go
+++ b/domain/model/export.go
@@ -315,23 +315,47 @@ func IsInputOnlyExtension(path string) bool {
 	}
 }
 
-// hasNestedCompressionSuffix reports whether path ends in two or more stacked
-// compression suffixes (e.g. "out.csv.gz.zst" or "fake.parquet.gz.zst").
-func hasNestedCompressionSuffix(path string) bool {
-	if _, ok := CompressionFromExtension(filepath.Ext(path)); !ok {
-		return false
+// compressionSuffixAliases maps a long-form compression extension to its canonical
+// short form. sqly writes only the short forms, and filesql reads only those, so an
+// alias is never a writable codec. It is recognized only when detecting
+// stacked suffixes or seeing through compression to the underlying format, so a
+// destination like "out.parquet.gzip.zst" cannot smuggle a masked format past
+// validation by spelling one codec out in full.
+var compressionSuffixAliases = map[string]string{
+	".gzip":  ExtGzip,
+	".zstd":  ExtZstd,
+	".bzip2": ExtBzip2,
+}
+
+// isCompressionSuffix reports whether ext is a compression suffix sqly recognizes
+// for detection, including the long-form aliases (".gzip", ".zstd", ".bzip2"). It
+// is broader than CompressionFromExtension, which admits only writable codecs.
+func isCompressionSuffix(ext string) bool {
+	if _, ok := CompressionFromExtension(ext); ok {
+		return true
 	}
-	inner := strings.TrimSuffix(path, filepath.Ext(path))
-	_, ok := CompressionFromExtension(filepath.Ext(inner))
+	_, ok := compressionSuffixAliases[strings.ToLower(ext)]
 	return ok
 }
 
+// hasNestedCompressionSuffix reports whether path ends in two or more stacked
+// compression suffixes (e.g. "out.csv.gz.zst" or "fake.parquet.gzip.zst"). A
+// long-form alias such as ".gzip" counts, so spelling a codec out in full cannot
+// slip a stacked destination past validation.
+func hasNestedCompressionSuffix(path string) bool {
+	if !isCompressionSuffix(filepath.Ext(path)) {
+		return false
+	}
+	inner := strings.TrimSuffix(path, filepath.Ext(path))
+	return isCompressionSuffix(filepath.Ext(inner))
+}
+
 // stripCompressionSuffixes removes every trailing compression extension from a
-// path (e.g. "out.ach.gz.zst" -> "out.ach"), so a check on the remaining base
-// extension is not fooled by stacked codecs.
+// path (e.g. "out.ach.gzip.zst" -> "out.ach"), so a check on the remaining base
+// extension is not fooled by stacked codecs or a long-form alias.
 func stripCompressionSuffixes(path string) string {
 	for {
-		if _, ok := CompressionFromExtension(filepath.Ext(path)); !ok {
+		if !isCompressionSuffix(filepath.Ext(path)) {
 			return path
 		}
 		path = strings.TrimSuffix(path, filepath.Ext(path))

--- a/domain/model/export_test.go
+++ b/domain/model/export_test.go
@@ -267,6 +267,46 @@ func TestResolveOutputTarget(t *testing.T) {
 			path:    "fake.xlsx.gz.zst",
 			wantErr: ErrNestedCompression,
 		},
+		{
+			name:    "long-form gzip alias before zstd is a stacked suffix",
+			path:    "fake.parquet.gzip.zst",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "long-form gzip alias before zstd on json is a stacked suffix",
+			path:    "fake.json.gzip.zst",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "long-form gzip alias before zstd on ndjson is a stacked suffix",
+			path:    "fake.ndjson.gzip.zst",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "long-form gzip alias before zstd on markdown is a stacked suffix",
+			path:    "fake.md.gzip.zst",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "long-form gzip alias before zstd on tsv is a stacked suffix",
+			path:    "fake.tsv.gzip.zst",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "long-form gzip alias before zstd on xlsx is a stacked suffix",
+			path:    "fake.xlsx.gzip.zst",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "long-form zstd alias stacked on gz is rejected",
+			path:    "fake.csv.zstd.gz",
+			wantErr: ErrNestedCompression,
+		},
+		{
+			name:    "long-form bzip2 alias stacked on zst is rejected",
+			path:    "fake.csv.bzip2.zst",
+			wantErr: ErrNestedCompression,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -398,6 +438,11 @@ func TestIsInputOnlyExtension(t *testing.T) {
 		{"out.ach.gz.zst", true},
 		{"out.fed.gz.zst", true},
 		{"out.ach.gz.gz.gz", true},
+		// A long-form alias such as .gzip must be seen through too, so an ACH or
+		// Fedwire destination cannot hide behind it.
+		{"out.ach.gzip.zst", true},
+		{"out.fed.gzip.zst", true},
+		{"out.ach.bzip2", true},
 		{"out.csv", false},
 		{"out.csv.gz", false},
 		{"out.csv.gz.zst", false},

--- a/spec/v0_22_bugs_spec.sh
+++ b/spec/v0_22_bugs_spec.sh
@@ -71,4 +71,37 @@ Describe 'sqly v0.22.0 binary regressions'
     The status should be success
     The output should include '"main.x"'
   End
+
+  # Nested compression suffixes, including a long-form alias such as .gzip, must be
+  # rejected before --output or .dump writes bytes under a name that lies about them.
+  It 'rejects a --output destination that stacks .gzip and .zst on a format suffix'
+    When run sqly --sql 'SELECT 1 AS x' --output "$WORK/fake.parquet.gzip.zst"
+    The status should be failure
+    The stderr should be present
+    The path "$WORK/fake.parquet.gzip.zst" should not be exist
+  End
+
+  It 'rejects a --output .json.gzip.zst destination'
+    When run sqly --sql 'SELECT 1 AS x' --output "$WORK/fake.json.gzip.zst"
+    The status should be failure
+    The stderr should be present
+    The path "$WORK/fake.json.gzip.zst" should not be exist
+  End
+
+  It 'rejects a --output .ach.gzip.zst destination as input-only'
+    When run sqly --sql 'SELECT 1 AS x' --output "$WORK/fake.ach.gzip.zst"
+    The status should be failure
+    The stderr should be present
+    The path "$WORK/fake.ach.gzip.zst" should not be exist
+  End
+
+  It 'rejects a .dump destination that stacks .gzip and .zst'
+    Data:expand
+      #|.dump user $WORK/fake.parquet.gzip.zst
+    End
+    When run sqly "$PROJECT_ROOT/testdata/user.csv"
+    The status should be failure
+    The stderr should be present
+    The path "$WORK/fake.parquet.gzip.zst" should not be exist
+  End
 End


### PR DESCRIPTION
## Summary

`--output` and `.dump` accepted destinations like `out.parquet.gzip.zst`, `out.json.gzip.zst`, `out.xlsx.gzip.zst`, and `out.ach.gzip.zst`. sqly applied only the outermost `.zst` codec and wrote CSV bytes, so decompressing the file yielded plain CSV under a name that advertised Parquet, JSON, Excel, or an input-only ACH/Fedwire format.

The root cause: the stacked-suffix detector and the input-only check only recognized the canonical short compression extensions (`.gz`, `.zst`, ...). A destination that spelled a codec out in full (`.gzip`) put an unrecognized token between the format suffix and the outer codec, so neither check fired.

## Fix

Recognize the long-form aliases `.gzip`, `.zstd`, and `.bzip2` as compression suffixes for detection only. `hasNestedCompressionSuffix` and `stripCompressionSuffixes` now see through them, so a stacked destination is rejected as nested compression and an `.ach`/`.fed` destination hidden behind an alias is rejected as input-only. The aliases are deliberately not writable codecs: sqly writes and filesql reads only the short forms, so treating an alias as writable would create files sqly cannot read back.

## Tests

Go: `TestResolveOutputTarget` and `TestIsInputOnlyExtension` gain cases for `.gzip`, `.zstd`, and `.bzip2` stacked on a second codec across CSV/TSV/JSON/NDJSON/Markdown/Parquet/Excel/ACH/Fedwire. Verified they fail on `main` before the fix.

shellspec: `spec/v0_22_bugs_spec.sh` runs the built binary and asserts `--output` and `.dump` exit non-zero and write no file for `.parquet.gzip.zst`, `.json.gzip.zst`, and `.ach.gzip.zst` destinations.

Closes #542
Closes #543
Closes #544
Closes #545
Closes #546
Closes #547
Closes #548
Closes #549
Closes #561
Closes #562
Closes #563
Closes #564
Closes #565
Closes #566
Closes #567
Closes #568


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `--output` and `.dump` now properly reject destinations with stacked long-form compression aliases (e.g., `.parquet.gzip.zst`).
  * Long-form compression suffixes (`.gzip`, `.zstd`, `.bzip2`) are now recognized as compression formats when validating output destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->