### PR TITLE
chore: prepare v0.23.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v0.23.0](https://github.com/nao1215/sqly/compare/v0.22.0...v0.23.0) (2026-06-02)
 
 ### Bug Fixes
 * Literal Dotted Object Names With A Schema Prefix: `.schema`, `.describe`, `.header`, and `.dump` now reach a table or view whose quoted literal name begins with `main.` or `temp.` (for example `CREATE TABLE "main.x"` or `CREATE VIEW "temp.v"`). Because the shell strips the quotes the user typed, a name is read as a schema qualifier only when no object literally carries it. `.tables` prints such a name quoted so it pastes back into these commands.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Run `sqly` without `--sql` to open the shell. It behaves like `sqlite3` or `mysq
 
 ```shell
 $ sqly testdata/user.csv
-sqly v0.22.0
+sqly v0.23.0
 
 enter "SQL query" or "sqly command that begins with a dot".
 .help print usage, .exit exit sqly.
@@ -433,7 +433,7 @@ SELECT * FROM `customers100000` WHERE `Index` BETWEEN 1000 AND 2000 ORDER BY `In
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.22.0. Run `make bench` to reproduce on your machine.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.23.0. Run `make bench` to reproduce on your machine.
 
 ## Comparison with similar tools
 


### PR DESCRIPTION
## Summary

Release preparation for v0.23.0. This release resolves every bug reported against the published v0.22.0 binary (#521-#572), delivered across four focused PRs:

- #573: `.schema`/`.describe`/`.header`/`.dump` reach a table or view whose quoted literal name begins with `main.`/`temp.` (#521-#529, #553-#560).
- #574: `--output` and `.dump` reject stacked compression suffixes that use a long-form codec alias such as `.gzip` (#542-#549, #561-#568).
- #575: direct `--sql` drops a leading empty statement instead of discarding the statement that follows it (#550-#552, #569-#572).
- #576: write-back persists only imported tables whose content actually changed, so TEMP/scratch-only sessions and net-zero edits no longer rewrite or fail on a source (#530-#541).

## Changes in this PR

- Mark the CHANGELOG `Unreleased` section as `v0.23.0` with its compare link and date.
- Refresh the README `sqly v0.22.0` version strings to `sqly v0.23.0`.

No code changes; the fixes themselves already merged via the PRs above. After merge, tag `v0.23.0` to trigger the release workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CHANGELOG to document v0.23.0 release (June 2, 2026).
  * Updated README with new version references in interactive shell startup banner and benchmark information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->