### PR TITLE
feat: add opt-in typed JSON output contract (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0)
+
+### Features
+* Typed JSON Output Contract: `--json-typed` and `--ndjson-typed` (and the matching `.mode json-typed`/`.mode ndjson-typed`) opt query output into a typed contract that emits native JSON scalars instead of strings. A canonical JSON number becomes a number, `true`/`false` become booleans, and a SQL NULL becomes `null`; a large integer is preserved verbatim so it never regresses into scientific notation, while a value with a leading zero such as `007` stays a string. The default `--json`/`--ndjson` keep the legacy string contract for compatibility. `--inspect --json-typed` applies the same contract to the report's sample rows so the schema metadata and sample payloads agree.
+
 ## [v0.23.0](https://github.com/nao1215/sqly/compare/v0.22.0...v0.23.0) (2026-06-02)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Run `sqly` without `--sql` to open the shell. It behaves like `sqlite3` or `mysq
 
 ```shell
 $ sqly testdata/user.csv
-sqly v0.23.0
+sqly v0.24.0
 
 enter "SQL query" or "sqly command that begins with a dot".
 .help print usage, .exit exit sqly.
@@ -157,6 +157,16 @@ $ sqly --json --sql "SELECT user_name, identifier FROM user LIMIT 2" testdata/us
 $ sqly --ndjson --sql "SELECT user_name, identifier FROM user LIMIT 2" testdata/user.csv
 {"user_name":"booker12","identifier":"1"}
 {"user_name":"jenkins46","identifier":"2"}
+```
+
+For automation and ML workflows, `--json-typed` and `--ndjson-typed` emit native JSON scalars instead of strings: a value that is a canonical JSON number becomes a number, `true`/`false` become booleans, and a SQL NULL becomes `null`. A large integer is preserved exactly and never falls back to scientific notation; a value with a leading zero (such as `007`) stays a string. The default `--json`/`--ndjson` keep the string contract for compatibility. The same opt-in applies to the `--inspect` sample rows via `--inspect --json-typed`.
+
+```shell
+$ sqly --json-typed --sql "SELECT identifier, user_name FROM user LIMIT 2" testdata/user.csv
+[
+  {"identifier":1,"user_name":"booker12"},
+  {"identifier":2,"user_name":"jenkins46"}
+]
 ```
 
 Excel (`--excel`) and Parquet (`--parquet`) are export-only: they render as CSV on screen and write a real `.xlsx`/`.parquet` file through `--output` or `.dump`. Parquet needs at least one row to infer its schema.
@@ -433,7 +443,7 @@ SELECT * FROM `customers100000` WHERE `Index` BETWEEN 1000 AND 2000 ORDER BY `In
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.23.0. Run `make bench` to reproduce on your machine.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.24.0. Run `make bench` to reproduce on your machine.
 
 ## Comparison with similar tools
 

--- a/config/argument.go
+++ b/config/argument.go
@@ -31,6 +31,10 @@ type Output struct {
 	FilePath string
 	// Mode is enum to specify output method
 	Mode model.PrintMode
+	// JSONTyped opts JSON and NDJSON output into the typed contract (native
+	// numbers, booleans, and nulls instead of strings). It is set only by
+	// --json-typed/--ndjson-typed and is ignored unless Mode is JSON or NDJSON.
+	JSONTyped bool
 }
 
 // Arg is a structure for managing options and arguments
@@ -92,6 +96,10 @@ const (
 	outJSON     = "json"
 	outNDJSON   = "ndjson"
 	outParquet  = "parquet"
+	// Typed JSON variants: same JSON/NDJSON format, but native scalars instead of
+	// strings. They select the JSON/NDJSON mode and set Output.JSONTyped.
+	outJSONTyped   = "json-typed"
+	outNDJSONTyped = "ndjson-typed"
 )
 
 // outputFlag is a structure for managing output format options.
@@ -104,6 +112,9 @@ type outputFlag struct {
 	json     bool
 	ndjson   bool
 	parquet  bool
+
+	jsonTyped   bool
+	ndjsonTyped bool
 }
 
 // selectedNames returns the names of the output mode flags that are set. More
@@ -122,6 +133,8 @@ func (of outputFlag) selectedNames() []string {
 		{outJSON, of.json},
 		{outNDJSON, of.ndjson},
 		{outParquet, of.parquet},
+		{outJSONTyped, of.jsonTyped},
+		{outNDJSONTyped, of.ndjsonTyped},
 	}
 	var names []string
 	for _, f := range flags {
@@ -159,6 +172,8 @@ func NewArg(args []string) (*Arg, error) {
 	flag.BoolVarP(&oFlag.json, outJSON, "j", false, "change output format to json (default: table)")
 	flag.BoolVarP(&oFlag.ndjson, outNDJSON, "n", false, "change output format to ndjson (default: table)")
 	flag.BoolVarP(&oFlag.parquet, outParquet, "p", false, "export results as parquet (export-only; use with --output or .dump)")
+	flag.BoolVar(&oFlag.jsonTyped, outJSONTyped, false, "change output format to json with native scalars (numbers, booleans, nulls) instead of strings")
+	flag.BoolVar(&oFlag.ndjsonTyped, outNDJSONTyped, false, "change output format to ndjson with native scalars (numbers, booleans, nulls) instead of strings")
 	sheetName := flag.StringP("sheet", "S", "", "excel sheet name you want to import")
 	stdinFormat := flag.String("stdin", "", "treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)")
 	stdinName := flag.String("stdin-name", "stdin", "table name for the --stdin dataset")
@@ -317,6 +332,12 @@ func newOutput(filePath string, of outputFlag) *Output {
 		output.Mode = model.PrintModeJSON
 	case of.ndjson:
 		output.Mode = model.PrintModeNDJSON
+	case of.jsonTyped:
+		output.Mode = model.PrintModeJSON
+		output.JSONTyped = true
+	case of.ndjsonTyped:
+		output.Mode = model.PrintModeNDJSON
+		output.JSONTyped = true
 	case of.parquet:
 		output.Mode = model.PrintModeParquet
 	default:

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -117,6 +117,38 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("user set --json-typed option selects json mode with the typed contract", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--json-typed"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.Output.Mode != model.PrintModeJSON {
+			t.Errorf("mismatch got=%v, want=%v", arg.Output.Mode, model.PrintModeJSON)
+		}
+		if !arg.Output.JSONTyped {
+			t.Error("expected Output.JSONTyped to be true for --json-typed")
+		}
+	})
+
+	t.Run("user set --ndjson-typed option selects ndjson mode with the typed contract", func(t *testing.T) {
+		arg, err := NewArg([]string{"sqly", "--ndjson-typed"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if arg.Output.Mode != model.PrintModeNDJSON {
+			t.Errorf("mismatch got=%v, want=%v", arg.Output.Mode, model.PrintModeNDJSON)
+		}
+		if !arg.Output.JSONTyped {
+			t.Error("expected Output.JSONTyped to be true for --ndjson-typed")
+		}
+	})
+
+	t.Run("--json and --json-typed together are rejected as conflicting", func(t *testing.T) {
+		if _, err := NewArg([]string{"sqly", "--json", "--json-typed"}); err == nil {
+			t.Error("expected conflicting output mode flags error, got nil")
+		}
+	})
+
 	t.Run("user set --parquet option", func(t *testing.T) {
 		arg, err := NewArg([]string{"sqly", "--parquet"})
 		if err != nil {

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -26,6 +26,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -j, --json                 change output format to json (default: table)
   -n, --ndjson               change output format to ndjson (default: table)
   -p, --parquet              export results as parquet (export-only; use with --output or .dump)
+      --json-typed           change output format to json with native scalars (numbers, booleans, nulls) instead of strings
+      --ndjson-typed         change output format to ndjson with native scalars (numbers, booleans, nulls) instead of strings
   -S, --sheet string         excel sheet name you want to import
       --stdin string         treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
       --stdin-name string    table name for the --stdin dataset (default "stdin")

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -6,6 +6,8 @@ Flags may appear before or after the file and directory arguments; `sqly --csv d
 
 sqly allows you to change the display mode of SQL results with options. By default, the output is in table format. The output format can be changed to csv (`--csv`), tsv (`--tsv`), ltsv (`--ltsv`), markdown (`--markdown`), json (`--json`), or ndjson (`--ndjson`). Excel (`--excel`) and Parquet (`--parquet`) are export-only: they render as csv on screen and write a file only through `.dump` or `--output`. Since the output mode can be changed while the sqly shell is running, it is easy to execute `sqly sample.csv` and then change settings or execute SQL queries within the sqly shell.
 
+For automation-friendly output, `--json-typed` and `--ndjson-typed` (or `.mode json-typed` / `.mode ndjson-typed` in the shell) emit native JSON scalars instead of strings: a canonical JSON number becomes a number, `true`/`false` become booleans, and a SQL NULL becomes `null`. A large integer stays lossless and never regresses into scientific notation, while a value with a leading zero such as `007` remains a string. The default `--json`/`--ndjson` keep the legacy string contract. Pair `--inspect` with `--json-typed` to apply the same contract to the report's sample rows.
+
 
 ### sqly options
 
@@ -31,6 +33,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -j, --json            change output format to json (default: table)
   -n, --ndjson          change output format to ndjson (default: table)
   -p, --parquet         export results as parquet (export-only; use with --output or .dump)
+      --json-typed      change output format to json with native scalars (numbers, booleans, nulls) instead of strings
+      --ndjson-typed    change output format to ndjson with native scalars (numbers, booleans, nulls) instead of strings
   -S, --sheet string    excel sheet name you want to import
       --stdin string    treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
       --stdin-name string   table name for the --stdin dataset (default "stdin")

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -135,6 +135,13 @@ type Table struct {
 	// NULL is emitted as JSON null. nil means "no NULL information"; text formats
 	// ignore it and render every cell as a string.
 	nulls [][]bool
+	// jsonTyped opts JSON/NDJSON output into the typed contract: a cell that is a
+	// canonical JSON number is emitted as a native number, "true"/"false" as a
+	// native boolean, and everything else as a JSON string. It is false by
+	// default so the legacy string contract stays the default; only the explicit
+	// opt-in (--json-typed/--ndjson-typed or .mode json-typed/ndjson-typed) turns
+	// it on. Other output formats ignore it.
+	jsonTyped bool
 }
 
 // NewTable create new Table.
@@ -155,6 +162,16 @@ func NewTable(
 // rather than an empty string. Other output formats ignore it.
 func (t *Table) SetNulls(nulls [][]bool) {
 	t.nulls = nulls
+}
+
+// SetJSONTyped opts JSON and NDJSON output into the typed contract, where a cell
+// that is a canonical JSON number is emitted as a native number (large integers
+// verbatim, so no precision loss or scientific notation), "true"/"false" as a
+// native boolean, a SQL NULL as null, and every other value as a JSON string.
+// It has no effect on non-JSON output formats. The default (false) preserves the
+// legacy contract that emits every non-NULL value as a string.
+func (t *Table) SetJSONTyped(typed bool) {
+	t.jsonTyped = typed
 }
 
 // isNull reports whether the cell at (row, col) is a known SQL NULL.
@@ -515,7 +532,12 @@ func (t *Table) rowToJSONObject(row int, record Record) ([]byte, error) {
 		if i < len(record) {
 			val = record[i]
 		}
-		value, err := json.Marshal(val)
+		var value []byte
+		if t.jsonTyped {
+			value, err = jsonScalarToken(val)
+		} else {
+			value, err = json.Marshal(val)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode value for column %q: %w", h, err)
 		}
@@ -523,6 +545,83 @@ func (t *Table) rowToJSONObject(row int, record Record) ([]byte, error) {
 	}
 	b.WriteByte('}')
 	return b.Bytes(), nil
+}
+
+// JSON boolean literals recognized by the typed output contract.
+const (
+	jsonLiteralTrue  = "true"
+	jsonLiteralFalse = "false"
+)
+
+// jsonScalarToken returns the JSON token for a cell value in typed output mode.
+// A value that is a canonical JSON number is emitted verbatim, so a large integer
+// stays lossless and never regresses into scientific notation; the JSON literals
+// "true" and "false" become native booleans; everything else is emitted as a JSON
+// string. A SQL NULL is handled by the caller before this is reached.
+func jsonScalarToken(s string) ([]byte, error) {
+	if s == jsonLiteralTrue || s == jsonLiteralFalse {
+		return []byte(s), nil
+	}
+	if isCanonicalJSONNumber(s) {
+		return []byte(s), nil
+	}
+	return json.Marshal(s)
+}
+
+// isCanonicalJSONNumber reports whether s is a number in the exact JSON grammar
+// (RFC 8259): an optional leading minus, an integer part with no redundant
+// leading zero, an optional fraction, and an optional exponent. Emitting only
+// such strings verbatim as JSON numbers keeps the output valid while preserving
+// the original digits, so "007" stays a string and a 30-digit integer is not
+// rounded. Values like "+1", "1.", ".5", "1e", "NaN", or surrounding spaces are
+// rejected and fall back to a JSON string.
+func isCanonicalJSONNumber(s string) bool {
+	if s == "" {
+		return false
+	}
+	i, n := 0, len(s)
+	if s[i] == '-' {
+		i++
+		if i == n {
+			return false
+		}
+	}
+	// Integer part: a single "0", or a non-zero digit followed by more digits.
+	switch {
+	case s[i] == '0':
+		i++
+	case s[i] >= '1' && s[i] <= '9':
+		i++
+		for i < n && s[i] >= '0' && s[i] <= '9' {
+			i++
+		}
+	default:
+		return false
+	}
+	// Optional fraction.
+	if i < n && s[i] == '.' {
+		i++
+		if i >= n || s[i] < '0' || s[i] > '9' {
+			return false
+		}
+		for i < n && s[i] >= '0' && s[i] <= '9' {
+			i++
+		}
+	}
+	// Optional exponent.
+	if i < n && (s[i] == 'e' || s[i] == 'E') {
+		i++
+		if i < n && (s[i] == '+' || s[i] == '-') {
+			i++
+		}
+		if i >= n || s[i] < '0' || s[i] > '9' {
+			return false
+		}
+		for i < n && s[i] >= '0' && s[i] <= '9' {
+			i++
+		}
+	}
+	return i == n
 }
 
 // duplicateColumnName returns the first column name that appears more than once

--- a/domain/model/table_property_test.go
+++ b/domain/model/table_property_test.go
@@ -98,6 +98,102 @@ func TestTable_JSONRoundTripProperty(t *testing.T) {
 	}
 }
 
+// FuzzJSONScalarToken asserts the typed-mode scalar tokenizer never emits a
+// byte sequence that is not valid JSON, for any input string. A value that is
+// not a canonical number or boolean must come back as a JSON string equal to the
+// input, and a canonical number/bool must decode back to the same text.
+func FuzzJSONScalarToken(f *testing.F) {
+	for _, s := range []string{"", "0", "-1.5", "1e10", "007", "true", "false", "hello", "\"q\"", "\n\t", "日本語", "1.2.3", "+1"} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		tok, err := jsonScalarToken(s)
+		if err != nil {
+			t.Fatalf("jsonScalarToken(%q) returned error: %v", s, err)
+		}
+		// Invariant 1: the token is always valid JSON, for any input.
+		if !json.Valid(tok) {
+			t.Fatalf("jsonScalarToken(%q) produced invalid JSON: %q", s, tok)
+		}
+		// Invariant 2: the token matches the exact typed contract. Canonical
+		// numbers and the JSON booleans are emitted verbatim (lossless); every
+		// other value falls back to json.Marshal, identical to the legacy string
+		// contract (which is lossy for invalid UTF-8 the same way encoding/json is).
+		var want []byte
+		switch {
+		case s == "true" || s == "false":
+			want = []byte(s)
+		case isCanonicalJSONNumber(s):
+			want = []byte(s)
+		default:
+			want, err = json.Marshal(s)
+			if err != nil {
+				t.Fatalf("json.Marshal(%q) returned error: %v", s, err)
+			}
+		}
+		if !bytes.Equal(tok, want) {
+			t.Fatalf("jsonScalarToken(%q) = %q, want %q", s, tok, want)
+		}
+	})
+}
+
+// TestTable_TypedJSONRoundTripProperty asserts the typed JSON contract never
+// corrupts data: for any table, typed output is valid JSON, and every cell
+// decodes back to its original string. A canonical number decodes to a
+// json.Number whose text equals the original (lossless, no scientific notation),
+// "true"/"false" decode to the matching boolean, and any other value stays a
+// string. This is the metamorphic relation render(typed) -> parse -> stringify
+// == identity.
+func TestTable_TypedJSONRoundTripProperty(t *testing.T) {
+	stringify := func(v any) (string, bool) {
+		switch x := v.(type) {
+		case json.Number:
+			return x.String(), true
+		case bool:
+			if x {
+				return "true", true
+			}
+			return "false", true
+		case string:
+			return x, true
+		default:
+			return "", false
+		}
+	}
+	property := func(g genTable) bool {
+		g.table.SetJSONTyped(true)
+		var buf bytes.Buffer
+		if err := g.table.Print(&buf, PrintModeJSON); err != nil {
+			return false
+		}
+		dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+		dec.UseNumber()
+		var got []map[string]any
+		if err := dec.Decode(&got); err != nil {
+			return false
+		}
+		want := rowMaps(g.table)
+		if len(want) != len(got) {
+			return false
+		}
+		for i, row := range got {
+			if len(row) != len(want[i]) {
+				return false
+			}
+			for k, v := range row {
+				s, ok := stringify(v)
+				if !ok || s != want[i][k] {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	if err := quick.Check(property, quickConfig()); err != nil {
+		t.Error(err)
+	}
+}
+
 // TestTable_NDJSONRoundTripProperty asserts every NDJSON line decodes back to
 // the corresponding record, and the line count matches the record count.
 func TestTable_NDJSONRoundTripProperty(t *testing.T) {

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -484,6 +484,101 @@ func TestTablePrintJSON_NullDistinctFromEmpty(t *testing.T) {
 	})
 }
 
+func TestTablePrintJSON_TypedScalars(t *testing.T) {
+	t.Parallel()
+
+	// In typed mode a cell that is a canonical JSON number is emitted as a native
+	// number (large integers verbatim, so no precision loss or scientific
+	// notation), "true"/"false" become native booleans, a SQL NULL becomes null,
+	// and everything else stays a JSON string.
+	header := Header{"i", "f", "b", "n", "empty", "big", "lead", "text"}
+	rec := Record{"42", "-1.5", "true", "", "", "123456789012345678901234567890", "007", "hello"}
+	tbl := NewTable("t", header, []Record{rec})
+	// Column 3 (n) is a SQL NULL; column 4 (empty) is a real empty string.
+	tbl.SetNulls([][]bool{{false, false, false, true, false, false, false, false}})
+	tbl.SetJSONTyped(true)
+
+	t.Run("typed json emits native scalars and keeps non-numbers as strings", func(t *testing.T) {
+		t.Parallel()
+		out := &bytes.Buffer{}
+		if err := tbl.Print(out, PrintModeJSON); err != nil {
+			t.Fatal(err)
+		}
+		want := "[\n  {\"i\":42,\"f\":-1.5,\"b\":true,\"n\":null,\"empty\":\"\",\"big\":123456789012345678901234567890,\"lead\":\"007\",\"text\":\"hello\"}\n]\n"
+		if diff := cmp.Diff(out.String(), want); diff != "" {
+			t.Errorf("value is mismatch (-got +want):\n%s", diff)
+		}
+	})
+
+	t.Run("typed ndjson emits native scalars", func(t *testing.T) {
+		t.Parallel()
+		out := &bytes.Buffer{}
+		if err := tbl.Print(out, PrintModeNDJSON); err != nil {
+			t.Fatal(err)
+		}
+		want := "{\"i\":42,\"f\":-1.5,\"b\":true,\"n\":null,\"empty\":\"\",\"big\":123456789012345678901234567890,\"lead\":\"007\",\"text\":\"hello\"}\n"
+		if diff := cmp.Diff(out.String(), want); diff != "" {
+			t.Errorf("value is mismatch (-got +want):\n%s", diff)
+		}
+	})
+
+	t.Run("default mode keeps the legacy string contract", func(t *testing.T) {
+		t.Parallel()
+		plain := NewTable("t", header, []Record{rec})
+		plain.SetNulls([][]bool{{false, false, false, true, false, false, false, false}})
+		out := &bytes.Buffer{}
+		if err := plain.Print(out, PrintModeJSON); err != nil {
+			t.Fatal(err)
+		}
+		want := "[\n  {\"i\":\"42\",\"f\":\"-1.5\",\"b\":\"true\",\"n\":null,\"empty\":\"\",\"big\":\"123456789012345678901234567890\",\"lead\":\"007\",\"text\":\"hello\"}\n]\n"
+		if diff := cmp.Diff(out.String(), want); diff != "" {
+			t.Errorf("value is mismatch (-got +want):\n%s", diff)
+		}
+	})
+}
+
+func TestIsCanonicalJSONNumber(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"0", true},
+		{"-0", true},
+		{"42", true},
+		{"-42", true},
+		{"3.14", true},
+		{"-3.14", true},
+		{"1e10", true},
+		{"1E10", true},
+		{"1.5e-3", true},
+		{"-2.0E+8", true},
+		{"123456789012345678901234567890", true},
+		{"", false},
+		{"007", false},
+		{"+1", false},
+		{"1.", false},
+		{".5", false},
+		{"1e", false},
+		{"1.2.3", false},
+		{"0x10", false},
+		{" 1", false},
+		{"1 ", false},
+		{"NaN", false},
+		{"Infinity", false},
+		{"-", false},
+		{"abc", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			if got := isCanonicalJSONNumber(tt.in); got != tt.want {
+				t.Errorf("isCanonicalJSONNumber(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTableEqual(t *testing.T) {
 	t.Parallel()
 

--- a/shell/dump.go
+++ b/shell/dump.go
@@ -55,6 +55,9 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 	if err != nil {
 		return err
 	}
+	// Carry the typed JSON contract into a JSON/NDJSON dump when the session is in
+	// a typed mode; ignored for every other export format.
+	table.SetJSONTyped(s.state.mode.jsonTyped)
 
 	// The current .mode sets the format unless it is table; otherwise the format
 	// (and any compression) is inferred from the destination path.

--- a/shell/inspect.go
+++ b/shell/inspect.go
@@ -58,11 +58,25 @@ func (s *Shell) validateInspectFlags() error {
 	// An output mode flag (--csv, --tsv, --ltsv, --json, --ndjson, --markdown,
 	// --excel, --parquet) selects a result format, but --inspect always emits its
 	// own JSON report. Reject the conflicting flag instead of silently discarding
-	// it, matching the other --inspect conflict checks.
+	// it, matching the other --inspect conflict checks. The one exception is
+	// --json-typed, the opt-in that makes the report's sample rows use the typed
+	// contract; it is allowed precisely because it shapes the inspect output.
+	case s.inspectTypedSample():
+		return nil
 	case s.argument.Output != nil && s.argument.Output.Mode != model.PrintModeTable:
 		return fmt.Errorf("--inspect cannot be combined with an output mode flag (--%s)", s.argument.Output.Mode.String())
 	}
 	return nil
+}
+
+// inspectTypedSample reports whether --inspect should render its sample rows with
+// the typed JSON contract. It is the --json-typed opt-in: JSON mode plus the
+// typed flag. Plain --json and the NDJSON modes do not apply, since the report is
+// always a single JSON document.
+func (s *Shell) inspectTypedSample() bool {
+	return s.argument.Output != nil &&
+		s.argument.Output.JSONTyped &&
+		s.argument.Output.Mode == model.PrintModeJSON
 }
 
 // runInspect prints a machine-readable JSON report of the imported tables:
@@ -194,6 +208,10 @@ func (s *Shell) inspectSample(ctx context.Context, name string, limit int) (json
 	if err != nil {
 		return nil, fmt.Errorf("failed to sample rows of %s: %w", name, err)
 	}
+
+	// In the --json-typed opt-in, the sample rows use the typed contract so the
+	// schema metadata and the sample payloads agree on numeric/boolean/null types.
+	table.SetJSONTyped(s.inspectTypedSample())
 
 	var buf bytes.Buffer
 	if err := table.Print(&buf, model.PrintModeJSON); err != nil {

--- a/shell/inspect_test.go
+++ b/shell/inspect_test.go
@@ -117,6 +117,70 @@ func TestInspect_SingleFile(t *testing.T) {
 	}
 }
 
+func TestInspect_TypedJSONSampleRows(t *testing.T) {
+	// --inspect --json-typed renders the report's sample rows with the typed
+	// contract: a numeric column decodes to a native number, not a string.
+	dir := t.TempDir()
+	csv := writeCSV(t, dir, "people.csv", "name,age\nAlice,30\nBob,25\n")
+
+	shell, cleanup, err := newShell(t, []string{"sqly", "--inspect", "--json-typed", csv})
+	if err != nil {
+		t.Fatalf("newShell: %v", err)
+	}
+	defer cleanup()
+
+	out := captureStdout(t, func() {
+		if err := shell.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+
+	// Decode sample rows as any so the value types are observable.
+	var report struct {
+		Tables []struct {
+			SampleRows []map[string]any `json:"sample_rows"`
+		} `json:"tables"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("inspect output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(report.Tables) != 1 || len(report.Tables[0].SampleRows) == 0 {
+		t.Fatalf("expected sample rows, got %s", out)
+	}
+	row := report.Tables[0].SampleRows[0]
+	if _, ok := row["age"].(float64); !ok {
+		t.Errorf("expected numeric age in typed sample, got %#v (%s)", row["age"], out)
+	}
+	if name, ok := row["name"].(string); !ok || name == "" {
+		t.Errorf("expected string name in typed sample, got %#v", row["name"])
+	}
+}
+
+func TestInspect_RejectsPlainJSONButAllowsTyped(t *testing.T) {
+	dir := t.TempDir()
+	csv := writeCSV(t, dir, "people.csv", "name,age\nAlice,30\n")
+
+	// Plain --json adds nothing to --inspect (already JSON) and is rejected.
+	shellPlain, cleanupPlain, err := newShell(t, []string{"sqly", "--inspect", "--json", csv})
+	if err != nil {
+		t.Fatalf("newShell: %v", err)
+	}
+	defer cleanupPlain()
+	if err := shellPlain.Run(context.Background()); err == nil {
+		t.Error("expected --inspect --json to be rejected, got nil")
+	}
+
+	// --json-typed is the meaningful opt-in and must be accepted.
+	shellTyped, cleanupTyped, err := newShell(t, []string{"sqly", "--inspect", "--json-typed", csv})
+	if err != nil {
+		t.Fatalf("newShell: %v", err)
+	}
+	defer cleanupTyped()
+	if err := shellTyped.Run(context.Background()); err != nil {
+		t.Errorf("expected --inspect --json-typed to be accepted, got %v", err)
+	}
+}
+
 func TestInspect_SampleRowsAreLimited(t *testing.T) {
 	dir := t.TempDir()
 	// 10 rows; the sample must be capped below the row count.

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -656,6 +656,8 @@ func (s *Shell) getRegularCompletions(ctx context.Context, input string) []Sugge
 		{Text: "ltsv", Description: "sqly command argument: ltsv output format"},
 		{Text: "json", Description: "sqly command argument: json output format"},
 		{Text: "ndjson", Description: "sqly command argument: ndjson output format"},
+		{Text: "json-typed", Description: "sqly command argument: json output with native scalars"},
+		{Text: "ndjson-typed", Description: "sqly command argument: ndjson output with native scalars"},
 		{Text: "excel", Description: "sqly command argument: excel output format"},
 		{Text: "parquet", Description: "sqly command argument: parquet export format"},
 	}
@@ -787,6 +789,11 @@ func (s *Shell) execSQL(ctx context.Context, req string) error {
 		fmt.Fprint(config.Stdout, msg)
 		return nil
 	}
+
+	// Opt JSON/NDJSON output into the typed contract when the session selected a
+	// typed mode (--json-typed/--ndjson-typed or .mode json-typed/ndjson-typed).
+	// The flag is ignored by every non-JSON format.
+	table.SetJSONTyped(s.state.mode.jsonTyped)
 
 	// use --sql option and user want to output table data to file.
 	if s.argument.NeedsOutputToFile() {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2183,6 +2183,61 @@ func TestShellExec_NDJSONModeSwitch(t *testing.T) {
 	}
 }
 
+func TestShellRun_TypedJSONOutputFromCLI(t *testing.T) {
+	// --json-typed renders numeric, boolean, and null values as native JSON
+	// scalars while keeping non-numeric strings as strings, and a large integer
+	// stays lossless (no scientific notation).
+	shell, cleanup, err := newShell(t, []string{
+		"sqly", "--json-typed",
+		"--sql", "SELECT 42 AS i, -1.5 AS f, 'hello' AS s, NULL AS n, '007' AS lead, 9223372036854775807 AS big",
+		filepath.Join("testdata", "actor.csv"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	got := getStdoutForRunFunc(t, shell.Run)
+	want := "[\n  {\"i\":42,\"f\":-1.5,\"s\":\"hello\",\"n\":null,\"lead\":\"007\",\"big\":9223372036854775807}\n]\n"
+	if string(got) != want {
+		t.Fatalf("typed json output mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestShellExec_TypedJSONModeSwitch(t *testing.T) {
+	// .mode json-typed switches interactive query output into the typed contract.
+	shell, cleanup, err := newShell(t, []string{"sqly", filepath.Join("testdata", "actor.csv")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if err := shell.commands.importCommand(context.Background(), shell, []string{filepath.Join("testdata", "actor.csv")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getExecStdOutput(t, shell.exec, ".mode json-typed"); err != nil {
+		t.Fatalf(".mode json-typed failed: %v", err)
+	}
+
+	out, err := getExecStdOutput(t, shell.exec, "SELECT 7 AS n, 'x' AS s")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(out, &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1: %s", len(rows), out)
+	}
+	if n, ok := rows[0]["n"].(float64); !ok || n != 7 {
+		t.Fatalf("expected numeric n=7, got %#v", rows[0]["n"])
+	}
+	if s, ok := rows[0]["s"].(string); !ok || s != "x" {
+		t.Fatalf("expected string s=x, got %#v", rows[0]["s"])
+	}
+}
+
 func TestShellExec_SchemaAndDescribe(t *testing.T) {
 	// Regression for: schema inspection commands over an imported CSV.
 	newImportedShell := func(t *testing.T) (*Shell, func()) {

--- a/shell/state.go
+++ b/shell/state.go
@@ -24,7 +24,7 @@ func newState(arg *config.Arg) (*state, error) {
 	}
 	return &state{
 		cwd:  dir,
-		mode: newMode(config.Stdout, arg.Output.Mode),
+		mode: newMode(config.Stdout, arg.Output.Mode, arg.Output.JSONTyped),
 	}, nil
 }
 
@@ -43,18 +43,46 @@ func (s *state) shortCWD() string {
 	return strings.Replace(s.cwd, home, "~", 1)
 }
 
+// Typed JSON output mode names accepted by .mode and shown in the prompt. They
+// mirror the --json-typed/--ndjson-typed CLI flags.
+const (
+	outputModeJSONTyped   = "json-typed"
+	outputModeNDJSONTyped = "ndjson-typed"
+)
+
 // mode is output mode.
 type mode struct {
 	w io.Writer
 	model.PrintMode
+	// jsonTyped, when true and PrintMode is JSON or NDJSON, opts query JSON/NDJSON
+	// output into the typed contract (native numbers, booleans, and nulls). It is
+	// ignored for every other PrintMode.
+	jsonTyped bool
 }
 
 // newMode returns mode.
-func newMode(w io.Writer, m model.PrintMode) *mode {
+func newMode(w io.Writer, m model.PrintMode, jsonTyped bool) *mode {
 	return &mode{
 		w:         w,
 		PrintMode: m,
+		jsonTyped: jsonTyped,
 	}
+}
+
+// displayName returns the user-facing name of the current mode, distinguishing
+// the typed JSON variants ("json-typed"/"ndjson-typed") from the default
+// string-valued JSON modes. It backs the prompt label and the .mode banner so a
+// typed session is visible to the user.
+func (m *mode) displayName() string {
+	if m.jsonTyped {
+		switch m.PrintMode {
+		case model.PrintModeJSON:
+			return outputModeJSONTyped
+		case model.PrintModeNDJSON:
+			return outputModeNDJSONTyped
+		}
+	}
+	return m.String()
 }
 
 // changeOutputModeIfNeeded change output mode.
@@ -65,42 +93,50 @@ func newMode(w io.Writer, m model.PrintMode) *mode {
 // stdout, so a banner there would corrupt it; keeping the status message on
 // stderr preserves stdout purity for every mode.
 func (m *mode) changeOutputModeIfNeeded(modeName string) error {
-	if modeName == m.String() {
+	if modeName == m.displayName() {
 		return fmt.Errorf("already %s mode", modeName)
 	}
 
+	// Resolve the requested name to a target PrintMode and typed flag before
+	// mutating anything, so an invalid name leaves the current mode untouched. The
+	// banner suffix flags the dump-only formats whose on-screen output is CSV.
+	var (
+		target model.PrintMode
+		typed  bool
+		suffix string
+	)
 	switch modeName {
 	case model.PrintModeTable.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeTable.String())
-		m.PrintMode = model.PrintModeTable
+		target = model.PrintModeTable
 	case model.PrintModeMarkdownTable.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s table\n", m.String(), model.PrintModeMarkdownTable.String())
-		m.PrintMode = model.PrintModeMarkdownTable
+		target = model.PrintModeMarkdownTable
+		suffix = " table"
 	case model.PrintModeCSV.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeCSV.String())
-		m.PrintMode = model.PrintModeCSV
+		target = model.PrintModeCSV
 	case model.PrintModeTSV.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeTSV.String())
-		m.PrintMode = model.PrintModeTSV
+		target = model.PrintModeTSV
 	case model.PrintModeLTSV.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeLTSV.String())
-		m.PrintMode = model.PrintModeLTSV
+		target = model.PrintModeLTSV
 	case model.PrintModeJSON.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeJSON.String())
-		m.PrintMode = model.PrintModeJSON
+		target = model.PrintModeJSON
 	case model.PrintModeNDJSON.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s\n", m.String(), model.PrintModeNDJSON.String())
-		m.PrintMode = model.PrintModeNDJSON
+		target = model.PrintModeNDJSON
+	case outputModeJSONTyped:
+		target, typed = model.PrintModeJSON, true
+	case outputModeNDJSONTyped:
+		target, typed = model.PrintModeNDJSON, true
 	case model.PrintModeExcel.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
-			m.String(), model.PrintModeExcel.String())
-		m.PrintMode = model.PrintModeExcel
+		target = model.PrintModeExcel
+		suffix = " (active only when executing .dump, otherwise same as csv mode)"
 	case model.PrintModeParquet.String():
-		fmt.Fprintf(config.Stderr, "Change output mode from %s to %s (active only when executing .dump, otherwise same as csv mode)\n",
-			m.String(), model.PrintModeParquet.String())
-		m.PrintMode = model.PrintModeParquet
+		target = model.PrintModeParquet
+		suffix = " (active only when executing .dump, otherwise same as csv mode)"
 	default:
 		return fmt.Errorf("invalid output mode: %s", modeName)
 	}
+
+	fmt.Fprintf(config.Stderr, "Change output mode from %s to %s%s\n", m.displayName(), modeName, suffix)
+	m.PrintMode = target
+	m.jsonTyped = typed
 	return nil
 }

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -26,6 +26,8 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -j, --json                 change output format to json (default: table)
   -n, --ndjson               change output format to ndjson (default: table)
   -p, --parquet              export results as parquet (export-only; use with --output or .dump)
+      --json-typed           change output format to json with native scalars (numbers, booleans, nulls) instead of strings
+      --ndjson-typed         change output format to ndjson with native scalars (numbers, booleans, nulls) instead of strings
   -S, --sheet string         excel sheet name you want to import
       --stdin string         treat stdin as an input dataset of this format (csv|tsv|ltsv|json|jsonl)
       --stdin-name string    table name for the --stdin dataset (default "stdin")

--- a/spec/typed_json_spec.sh
+++ b/spec/typed_json_spec.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Typed JSON output contract (issue #282). --json-typed/--ndjson-typed emit
+# native JSON scalars (numbers, booleans, nulls) instead of strings, while the
+# default --json/--ndjson keep the legacy string contract. A large integer from
+# an imported column stays lossless and never regresses into scientific notation.
+
+Describe 'sqly typed JSON output (--json-typed / --ndjson-typed)'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'emits native numbers, booleans, and null with --json-typed'
+    When run sqly --json-typed --sql "SELECT 42 AS i, -1.5 AS f, NULL AS n, 'x' AS s"
+    The status should be success
+    The output should include '"i":42'
+    The output should include '"f":-1.5'
+    The output should include '"n":null'
+    The output should include '"s":"x"'
+  End
+
+  It 'keeps the legacy string contract with plain --json'
+    When run sqly --json --sql "SELECT 42 AS i"
+    The status should be success
+    The output should include '"i":"42"'
+  End
+
+  It 'emits native scalars per line with --ndjson-typed'
+    When run sqly --ndjson-typed --sql "SELECT 7 AS n, 't' AS s"
+    The status should be success
+    The output should include '"n":7'
+    The output should include '"s":"t"'
+  End
+
+  It 'keeps a large integer column lossless (no scientific notation)'
+    When run sqly --json-typed --sql "SELECT amount FROM typed_bigint WHERE id = 1" testdata/typed_bigint.csv
+    The status should be success
+    The output should include '"amount":9007199254740993'
+    The output should not include 'e+'
+  End
+
+  It 'leaves a leading-zero value as a string'
+    When run sqly --json-typed --sql "SELECT '007' AS code"
+    The status should be success
+    The output should include '"code":"007"'
+  End
+
+  It 'uses the typed contract for --inspect sample rows'
+    When run sqly --inspect --json-typed testdata/typed_bigint.csv
+    The status should be success
+    The output should include '"amount": 9007199254740993'
+  End
+
+  It 'rejects plain --json combined with --inspect'
+    When run sqly --inspect --json testdata/typed_bigint.csv
+    The status should be failure
+    The stderr should include 'inspect'
+  End
+End

--- a/testdata/typed_bigint.csv
+++ b/testdata/typed_bigint.csv
@@ -1,0 +1,3 @@
+id,amount,flag
+1,9007199254740993,true
+2,42,false


### PR DESCRIPTION
## Summary
Implements roadmap issue #282: an opt-in typed JSON contract for automation-friendly output.

`--json-typed` and `--ndjson-typed` (and the matching `.mode json-typed` / `.mode ndjson-typed`) opt query output into a typed contract that emits native JSON scalars instead of strings:
- a canonical JSON number becomes a number,
- `true`/`false` become booleans,
- a SQL NULL becomes `null`,
- a large integer is preserved verbatim, so it never regresses into scientific notation,
- a value with a leading zero such as `007` stays a string.

The default `--json`/`--ndjson` keep the legacy string contract for compatibility. `--inspect --json-typed` applies the same contract to the report's sample rows so the schema metadata and sample payloads agree.

## Design
Typed-ness is a render property on `model.Table` (`SetJSONTyped`) carried alongside the print mode through `config.Output.JSONTyped` and shell state, rather than new `PrintMode`/`ExportFormat` enum values. This keeps the export-format resolution and `ResolveOutputTarget` conflict checks untouched while still flowing typed output to stdout, `--output` files, `.dump`, and `--inspect`.

## Tests (TDD)
- Model unit tests for typed scalars and `isCanonicalJSONNumber` boundaries (`007`, `+1`, `1.`, `NaN`, large integers, ...).
- Property-based round-trip test: typed output is valid JSON and every cell round-trips to its original string (metamorphic render→parse→stringify == identity).
- Fuzz target `FuzzJSONScalarToken`: the tokenizer never emits invalid JSON for any input.
- Config flag parsing + conflict detection (`--json --json-typed` rejected).
- Shell CLI and `.mode` switch tests; inspect typed-sample test and plain-`--json` rejection.
- shellspec E2E (`spec/typed_json_spec.sh`) exercising the built binary, including large-integer losslessness from an imported column.

Done criteria from the issue (integers, floats, booleans, nulls, empty strings, large integers across JSON and NDJSON; typed `--inspect`; legacy default retained) are all covered.

Closes #282


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v0.24.0 Release Notes

* **New Features**
  * Added `--json-typed` and `--ndjson-typed` output modes that emit native JSON scalars (numbers, booleans, null) instead of strings.
  * Large integers preserved exactly without scientific notation.
  * Leading-zero values retained as strings.
  * `--inspect --json-typed` applies typed contract to sample rows.

* **Documentation**
  * Updated help text and guides for new typed JSON output options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->