### PR TITLE
test: add fuzzing, property-based, and metamorphic tests

### DIFF
--- a/infrastructure/sql_property_test.go
+++ b/infrastructure/sql_property_test.go
@@ -1,0 +1,93 @@
+package infrastructure
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// unquoteBacktick reverses Quote: it strips the outer backticks and halves each
+// doubled backtick. It is the inverse used to assert the round-trip property.
+func unquoteBacktick(q string) (string, bool) {
+	if len(q) < 2 || q[0] != '`' || q[len(q)-1] != '`' {
+		return "", false
+	}
+	return strings.ReplaceAll(q[1:len(q)-1], "``", "`"), true
+}
+
+// unquoteSingle reverses SingleQuote.
+func unquoteSingle(q string) (string, bool) {
+	if len(q) < 2 || q[0] != '\'' || q[len(q)-1] != '\'' {
+		return "", false
+	}
+	return strings.ReplaceAll(q[1:len(q)-1], "''", "'"), true
+}
+
+// FuzzQuoteRoundTrip asserts Quote always produces a well-formed backtick-quoted
+// identifier that reverses to the original input, for any string. This is the
+// metamorphic relation unquote(Quote(s)) == s, and it guards the identifier
+// quoting used throughout sqly against escaping regressions.
+func FuzzQuoteRoundTrip(f *testing.F) {
+	for _, s := range []string{"", "a", "a`b", "`", "``", "main.user", "a\nb", "日本語", "'", "\""} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		q := Quote(s)
+		if len(q) < 2 || q[0] != '`' || q[len(q)-1] != '`' {
+			t.Fatalf("Quote(%q) = %q is not backtick-delimited", s, q)
+		}
+		// Quote is rune-based, so it replaces invalid UTF-8 with U+FFFD (the same
+		// lossy behavior as encoding/json). The exact round-trip therefore only
+		// holds for valid UTF-8; for the rest, no-panic and well-formedness above
+		// is the guarantee.
+		if !utf8.ValidString(s) {
+			return
+		}
+		got, ok := unquoteBacktick(q)
+		if !ok || got != s {
+			t.Fatalf("round-trip failed: Quote(%q) = %q, unquote = %q (ok=%v)", s, q, got, ok)
+		}
+	})
+}
+
+// FuzzSingleQuoteRoundTrip asserts SingleQuote round-trips like Quote, for the
+// SQL string literals sqly builds for INSERT statements.
+func FuzzSingleQuoteRoundTrip(f *testing.F) {
+	for _, s := range []string{"", "a", "a'b", "'", "''", "a\nb", "日本語", "`", "\""} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		q := SingleQuote(s)
+		if len(q) < 2 || q[0] != '\'' || q[len(q)-1] != '\'' {
+			t.Fatalf("SingleQuote(%q) = %q is not single-quote-delimited", s, q)
+		}
+		if !utf8.ValidString(s) {
+			return // rune-based, lossy on invalid UTF-8 (see FuzzQuoteRoundTrip)
+		}
+		got, ok := unquoteSingle(q)
+		if !ok || got != s {
+			t.Fatalf("round-trip failed: SingleQuote(%q) = %q, unquote = %q (ok=%v)", s, q, got, ok)
+		}
+	})
+}
+
+// FuzzQuoteTableRef asserts QuoteTableRef never panics and always yields a
+// reference whose every component is backtick-quoted: a single quoted identifier,
+// or exactly two joined by an unquoted dot for a main./temp. schema prefix.
+func FuzzQuoteTableRef(f *testing.F) {
+	for _, s := range []string{"user", "main.user", "temp.t", "a.b", "main.", ".x", "MAIN.User", "a.b.c", ""} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		got := QuoteTableRef(s)
+		if len(got) < 2 || got[0] != '`' || got[len(got)-1] != '`' {
+			t.Fatalf("QuoteTableRef(%q) = %q is not backtick-delimited", s, got)
+		}
+		// It is either one quoted identifier or `schema`.`name`. In both cases the
+		// whole string reverses through the backtick rules when treated as one or
+		// two components; at minimum it must be non-empty and balanced.
+		if strings.Count(got, "`")%2 != 0 {
+			t.Fatalf("QuoteTableRef(%q) = %q has unbalanced backticks", s, got)
+		}
+	})
+}

--- a/shell/batch_fuzz_test.go
+++ b/shell/batch_fuzz_test.go
@@ -1,0 +1,68 @@
+package shell
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+// FuzzSplitSQLStatements asserts the batch statement splitter never panics and
+// never loses the open-quote/comment state in a way that drops the remainder: the
+// concatenation of the returned statements and the remainder must contain every
+// non-separator rune of the input (the splitter only removes top-level ";" and
+// leading comments). It exercises untrusted multi-statement SQL with quotes,
+// comments, and triggers.
+func FuzzSplitSQLStatements(f *testing.F) {
+	seeds := []string{
+		"SELECT 1;",
+		"SELECT 1; SELECT 2",
+		"SELECT ';' AS x;",
+		"-- c\nSELECT 1;",
+		"/* a; b */ SELECT 1;",
+		"CREATE TRIGGER t BEGIN SELECT 1; END;",
+		"SELECT `a;b`;",
+		"SELECT [a;b];",
+		"",
+		";",
+		";;;",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		stmts, remainder := splitSQLStatements(s)
+		// The splitter works on runes and only removes top-level ";" and leading
+		// comments, so the retained content can only shrink. Compare in runes, since
+		// []rune normalizes invalid UTF-8 to U+FFFD (which changes the byte length).
+		inputRunes := utf8.RuneCountInString(s)
+		total := utf8.RuneCountInString(remainder)
+		for _, st := range stmts {
+			total += utf8.RuneCountInString(st)
+		}
+		if total > inputRunes {
+			t.Fatalf("split of %q produced more runes than the input (%d > %d): stmts=%v remainder=%q",
+				s, total, inputRunes, stmts, remainder)
+		}
+	})
+}
+
+// FuzzSplitArgs asserts the shell argument splitter never panics for any input
+// (including unbalanced quotes, control characters, and invalid UTF-8). It either
+// returns fields or a clean parse error; it must never crash the shell parser.
+func FuzzSplitArgs(f *testing.F) {
+	for _, s := range []string{"a b c", `"a b" c`, `a "b\"c"`, "  ", "", `'single'`, "tab\tsep", `" "`, `""`, `"unterminated`} {
+		f.Add(s)
+	}
+	f.Fuzz(func(_ *testing.T, s string) {
+		// A parse error (e.g. an unbalanced quote) is a valid outcome; the only
+		// guarantee under fuzzing is that the parser does not panic. Touch the
+		// returned fields so the call is not optimized away.
+		args, err := splitArgs(s)
+		if err == nil {
+			total := 0
+			for _, a := range args {
+				total += len(a)
+			}
+			_ = total
+		}
+	})
+}

--- a/shell/feature_property_test.go
+++ b/shell/feature_property_test.go
@@ -1,0 +1,199 @@
+package shell
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+	"testing/quick"
+
+	"github.com/nao1215/sqly/domain/model"
+)
+
+// randCell returns a small random string covering digits, letters, the empty
+// string, and a few JSON/Unicode-significant runes, to vary keyed-row values.
+func randCell(r *rand.Rand) string {
+	alphabet := []rune("abc012 ,\"'\n日本é")
+	n := r.Intn(6)
+	out := make([]rune, 0, n)
+	for range n {
+		out = append(out, alphabet[r.Intn(len(alphabet))])
+	}
+	return string(out)
+}
+
+func featureQuickConfig() *quick.Config {
+	return &quick.Config{
+		MaxCount: 300,
+		Rand:     rand.New(rand.NewSource(7)), //nolint:gosec // deterministic test seed
+	}
+}
+
+// genColumns builds a schema with unique column names (real table columns are
+// always unique) and random types, so the schema-diff properties exercise
+// realistic inputs rather than degenerate duplicate-name cases.
+func genColumns(r *rand.Rand) []inspectColumn {
+	types := []string{"INTEGER", "TEXT", "REAL", "BLOB", "NUMERIC", ""}
+	n := r.Intn(6)
+	cols := make([]inspectColumn, 0, n)
+	for i := range n {
+		cols = append(cols, inspectColumn{
+			Name: fmt.Sprintf("c%d", i),
+			Type: types[r.Intn(len(types))],
+		})
+	}
+	return cols
+}
+
+// TestCompareSchemas_ReflexiveProperty asserts that comparing any schema with
+// itself reports no differences. This metamorphic relation (compare(x,x) is
+// empty) guards the schema diff against spurious change reports.
+func TestCompareSchemas_ReflexiveProperty(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(17)) //nolint:gosec // deterministic test seed
+	for range 300 {
+		cols := genColumns(r)
+		got := compareSchemas(cols, cols)
+		if !got.Equal || len(got.LeftOnlyColumns) != 0 ||
+			len(got.RightOnlyColumns) != 0 || len(got.TypeChanges) != 0 {
+			t.Fatalf("compare(x,x) reported a difference for %+v: %+v", cols, got)
+		}
+	}
+}
+
+// TestCompareSchemas_SwapProperty asserts that swapping the two sides swaps the
+// left-only and right-only column sets and preserves the equality verdict.
+func TestCompareSchemas_SwapProperty(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(19)) //nolint:gosec // deterministic test seed
+	for range 300 {
+		a := genColumns(r)
+		b := genColumns(r)
+		ab := compareSchemas(a, b)
+		ba := compareSchemas(b, a)
+		if ab.Equal != ba.Equal {
+			t.Fatalf("equality verdict not symmetric for %+v vs %+v", a, b)
+		}
+		if !equalStringSet(ab.LeftOnlyColumns, ba.RightOnlyColumns) ||
+			!equalStringSet(ab.RightOnlyColumns, ba.LeftOnlyColumns) {
+			t.Fatalf("left/right-only sets not swapped: %+v vs %+v", ab, ba)
+		}
+	}
+}
+
+// genKeyedTable builds a table with a unique integer "id" key column and one
+// random "v" value column, suitable for keyed-row comparison properties.
+func genKeyedTable(r *rand.Rand) *model.Table {
+	n := r.Intn(6)
+	records := make([]model.Record, 0, n)
+	for i := range n {
+		records = append(records, model.Record{strconv.Itoa(i), randCell(r)})
+	}
+	return model.NewTable("t", model.Header{"id", "v"}, records)
+}
+
+// TestCompareKeyedRows_IdentityProperty asserts that comparing a keyed table with
+// itself yields no added, removed, or modified rows.
+func TestCompareKeyedRows_IdentityProperty(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(11)) //nolint:gosec // deterministic test seed
+	for range 300 {
+		tbl := genKeyedTable(r)
+		rows, err := compareKeyedRows("t", "t", tbl, tbl, "id")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(rows.Added) != 0 || len(rows.Removed) != 0 || len(rows.Modified) != 0 {
+			t.Fatalf("compare(x,x) reported diffs: %+v", rows)
+		}
+	}
+}
+
+// TestCompareKeyedRows_SwapProperty asserts that swapping the two tables swaps
+// added and removed keys and preserves the modified key set.
+func TestCompareKeyedRows_SwapProperty(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(13)) //nolint:gosec // deterministic test seed
+	keysOf := func(rows []compareRow, key string) []string {
+		out := make([]string, 0, len(rows))
+		for _, row := range rows {
+			if v := row[key]; v != nil {
+				out = append(out, *v)
+			}
+		}
+		sort.Strings(out)
+		return out
+	}
+	modKeys := func(rows []compareModifiedRow) []string {
+		out := make([]string, 0, len(rows))
+		for _, m := range rows {
+			out = append(out, m.Key)
+		}
+		sort.Strings(out)
+		return out
+	}
+	for range 300 {
+		left := genKeyedTable(r)
+		right := genKeyedTable(r)
+		lr, err := compareKeyedRows("l", "r", left, right, "id")
+		if err != nil {
+			t.Fatal(err)
+		}
+		rl, err := compareKeyedRows("r", "l", right, left, "id")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(keysOf(lr.Added, "id"), keysOf(rl.Removed, "id")) {
+			t.Fatalf("added(l,r) != removed(r,l): %v vs %v", keysOf(lr.Added, "id"), keysOf(rl.Removed, "id"))
+		}
+		if !reflect.DeepEqual(keysOf(lr.Removed, "id"), keysOf(rl.Added, "id")) {
+			t.Fatalf("removed(l,r) != added(r,l)")
+		}
+		if !reflect.DeepEqual(modKeys(lr.Modified), modKeys(rl.Modified)) {
+			t.Fatalf("modified keys differ under swap: %v vs %v", modKeys(lr.Modified), modKeys(rl.Modified))
+		}
+	}
+}
+
+// TestProfileColumnStats_PartitionProperty asserts the column counts partition
+// the values exactly: every value is counted as null, blank, or non-empty, and
+// the numeric and distinct counts never exceed the non-empty count.
+func TestProfileColumnStats_PartitionProperty(t *testing.T) {
+	t.Parallel()
+	property := func(values []string, nulls []bool) bool {
+		pc := profileColumnStats("c", "TEXT", values, nulls)
+		var nullN, blankN, nonEmpty int64
+		for i, v := range values {
+			switch {
+			case i < len(nulls) && nulls[i]:
+				nullN++
+			case v == "":
+				blankN++
+			default:
+				nonEmpty++
+			}
+		}
+		if pc.NullCount != nullN || pc.BlankCount != blankN {
+			return false
+		}
+		if pc.NumericCount > nonEmpty || pc.DistinctCount > nonEmpty {
+			return false
+		}
+		return pc.NullCount+pc.BlankCount+nonEmpty == int64(len(values))
+	}
+	if err := quick.Check(property, featureQuickConfig()); err != nil {
+		t.Error(err)
+	}
+}
+
+// equalStringSet reports whether two string slices contain the same elements,
+// ignoring order and duplicates.
+func equalStringSet(a, b []string) bool {
+	as := append([]string(nil), a...)
+	bs := append([]string(nil), b...)
+	sort.Strings(as)
+	sort.Strings(bs)
+	return reflect.DeepEqual(as, bs)
+}


### PR DESCRIPTION
## Summary
Introduces fuzzing, property-based, and metamorphic testing across the new v0.24.0 features and the core parsers/transformers, as requested for the v0.24.0 hardening.

## Fuzzing (no-panic + invariants)
- `infrastructure`: `FuzzQuoteRoundTrip`, `FuzzSingleQuoteRoundTrip` (unquote∘quote == identity for valid UTF-8; always well-formed/balanced for any input, including invalid UTF-8), `FuzzQuoteTableRef`.
- `shell`: `FuzzSplitSQLStatements` (the splitter's rune content never grows), `FuzzSplitArgs` (the arg parser never crashes on unbalanced quotes, control chars, or invalid UTF-8).

## Property-based / metamorphic
- `compareSchemas`: reflexive (`compare(x,x)` is empty) and swap-symmetric (left-only ↔ right-only).
- `compareKeyedRows`: identity (`compare(x,x)` has no diff) and swap (added ↔ removed, modified preserved).
- `profileColumnStats`: partition invariant (null + blank + non-empty == len; numeric and distinct counts bounded by non-empty).

These complement the per-feature property/fuzz tests already added with each feature (typed-JSON round-trip + `FuzzJSONScalarToken`, sanitize/parse properties, ACH/Fedwire round-trips). Fuzz seed corpora run under normal `go test`, so they execute in CI; each target was also run under `-fuzz` locally with no crashes.

Notable finding (documented, not a regression): `Quote`/`SingleQuote` are rune-based and therefore lossy on invalid-UTF-8 identifiers (the same behavior as `encoding/json`); the round-trip assertions are scoped to valid UTF-8 accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced fuzz testing coverage for SQL parsing, quoting, and argument splitting operations
  * Added property-based tests for schema comparison, row comparison, and column statistics analysis
  * Improved test robustness to catch edge cases and prevent regressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->