### PR TITLE
chore: prepare v0.24.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0)
+## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0) (2026-06-06)
 
 ### Features
 * Opt-In Import Cache: `--cache PATH` snapshots the imported tables to a standalone SQLite file so a repeated run against unchanged inputs reloads from it instead of re-parsing large source files. The cache key is each input file's path, size, and modification time (expanded recursively for directories), so it invalidates automatically when a source changes. `--cache-clear` forces a cold rebuild, and a cache that is unavailable or unwritable falls back cleanly to a cold import with a warning instead of failing the query. Caching is skipped for `--stdin` datasets and for ACH/Fedwire inputs (whose write-back needs the live import registry).


### PR DESCRIPTION
## Summary
Release PR for **v0.24.0**. Dates the CHANGELOG heading for release.

## What's in v0.24.0
Five roadmap features (issues from #148), each shipped via its own TDD + E2E PR:
- **Typed JSON output** (`--json-typed`/`--ndjson-typed`) — #282
- **Native ACH and Fedwire write-back** (`--save`/`--save-dir`/`.save`) — #242
- **CLI-first compare workflow** (`--compare`) — #276
- **CLI-first profile workflow** (`--profile`) — #275
- **Opt-in import cache** (`--cache`) — #284

Plus a comprehensive hardening pass over the new features and a fuzzing / property-based / metamorphic test sweep.

## Release/tagging note
v0.23.0 was prepared (#577) but never tagged. After this PR merges, both `v0.23.0` (at the #577 prep commit) and `v0.24.0` (at the release commit) will be tagged so the CHANGELOG compare links resolve and the abandoned v0.23.0 is published.

After merge, pushing the tags triggers GoReleaser (GitHub release + Homebrew tap).
