### PR TITLE
chore: improve OSS standards, release integrity, and pin Actions to SHAs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/nao1215/sqly/security/policy
+    about: Report a vulnerability privately. Please do not open a public issue.
+  - name: Question or help
+    url: https://github.com/nao1215/sqly/blob/main/.github/SUPPORT.md
+    about: How to get help and where to ask before opening an issue.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,20 @@
+---
+name: Question
+about: Ask how to use sqly or about its behavior
+title: ""
+labels: question
+assignees: ''
+
+---
+
+<!-- Please read the README and search existing issues before asking. -->
+
+## Question
+What do you want to do, and what is unclear?
+
+## What you tried
+The commands you ran (and the input file format, if relevant) and what happened.
+
+## Environment
+- sqly version (`sqly --version`):
+- OS and architecture (e.g. linux/amd64):

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,17 @@
+# Support
+
+Thanks for using sqly. Here is how to get help.
+
+## Before you ask
+- Read the [README](../README.md) and the documentation at [https://nao1215.github.io/sqly/](https://nao1215.github.io/sqly/).
+- Search the [existing issues](https://github.com/nao1215/sqly/issues); your question may already be answered.
+
+## Where to ask
+- Usage question: open a [Question issue](https://github.com/nao1215/sqly/issues/new?template=question.md).
+- Bug: open a [Bug report](https://github.com/nao1215/sqly/issues/new?template=bug_report.md).
+- Feature idea: open a [Feature request](https://github.com/nao1215/sqly/issues/new?template=feature-request.md).
+
+When reporting a problem, include your `sqly --version`, OS and architecture, the input file format, the command you ran, and what happened.
+
+## Security
+Do not report security issues in public issues. Follow the [Security Policy](../SECURITY.md).

--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version-file: "go.mod"
 

--- a/.github/workflows/check_generate_file.yml
+++ b/.github/workflows/check_generate_file.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,9 +19,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1"
           check-latest: true
@@ -29,4 +29,4 @@ jobs:
       - name: Run tests with coverage report output
         run: go test -cover -coverpkg=./... -coverprofile=coverage.out ./...
 
-      - uses: k1LoW/octocov-action@v1
+      - uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "go.mod"
 

--- a/.github/workflows/git-leaks.yml
+++ b/.github/workflows/git-leaks.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v3
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -10,8 +10,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
       - run: pip install mkdocs-material

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,14 @@ on:
     tags:
       - "v*"
 
+# id-token: keyless cosign signing + provenance via GitHub OIDC.
+# attestations: publish build provenance for the release artifacts.
+# contents: create the GitHub Release and upload assets.
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
 jobs:
   release:
     name: Release
@@ -12,18 +20,33 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "go.mod"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+      - name: Install Syft (SBOM generator)
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.deb
+            dist/*.rpm
+            dist/*.apk
+            dist/checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "go.mod"
+          # Disable the shared module/build cache in this privileged, OIDC-enabled
+          # release job to avoid cache-poisoning from lower-privilege workflows.
+          cache: false
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
       - name: Install Syft (SBOM generator)
@@ -35,7 +38,8 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
-          version: latest
+          # Pin the GoReleaser CLI to a fixed version so the release is reproducible.
+          version: "v2.16.0"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,3 +54,5 @@ jobs:
             dist/*.rpm
             dist/*.apk
             dist/checksums.txt
+            dist/*.sbom.json
+            dist/checksums.txt.sigstore.json

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: reviewdog/action-golangci-lint@4c4340f3ef9498ffe9a0dd3e589bc00e12e2d77c # v2.9.0
         with:
           golangci_lint_flags: "--timeout 10m"
           reporter: github-pr-review
@@ -24,11 +24,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: misspell
-        uses: reviewdog/action-misspell@v1
+        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
         with:
           reporter: github-pr-review
           level: warning
@@ -39,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: reviewdog/action-actionlint@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           reporter: github-pr-review
           level: warning

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -26,9 +26,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ matrix.go }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: sqly
 env:
   - GO111MODULE=on
@@ -20,19 +21,71 @@ builds:
       - arm64
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
+# Curated release notes: a short human summary first, then changes grouped by
+# user-facing category instead of a raw commit dump.
+release:
+  header: |
+    ## sqly {{ .Tag }}
+
+    Easily execute SQL against CSV/TSV/LTSV/JSON and Microsoft Excel™ with a shell.
+
+    Install or upgrade, then see the grouped highlights below. Every artifact is
+    signed and ships with an SBOM and build provenance — see
+    [Verifying release integrity](https://github.com/nao1215/sqly#verifying-release-integrity).
+  footer: |
+    **Full changelog**: https://github.com/nao1215/sqly/compare/{{ .PreviousTag }}...{{ .Tag }}
 changelog:
   sort: asc
+  use: github
+  groups:
+    - title: "Breaking changes"
+      regexp: '^.*?[a-zA-Z]+(\(.+\))??!:.+$'
+      order: 0
+    - title: "Features"
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 1
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 2
+    - title: "Performance"
+      regexp: '^.*?perf(\(.+\))??!?:.+$'
+      order: 3
+    - title: "Documentation"
+      regexp: '^.*?docs(\(.+\))??!?:.+$'
+      order: 4
+    - title: "Others"
+      order: 999
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
+      - "^tests?(\\(.+\\))?!?:"
+      - "^chore(\\(.+\\))?!?:"
+      - "^style(\\(.+\\))?!?:"
+      - "^ci(\\(.+\\))?!?:"
+      - "Merge pull request"
+      - "Merge branch"
+# Software Bill of Materials for every release archive.
+sboms:
+  - artifacts: archive
+# Keyless artifact signing with cosign. Signing the checksums file transitively
+# covers every published artifact.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
 nfpms:
   - maintainer: Naohiro CHIKAMATSU <n.chika156@gmail.com>
     description: sqly - easily execute SQL against CSV/TSV/LTSV/JSON and Microsoft Excel™ with shell.
@@ -44,7 +97,7 @@ nfpms:
       - apk
 brews:
   - name: sqly
-    description: sqly - eaisly execute SQL against CSV/TSV/LTSV/JSON and Microsoft Excel™ with shell.
+    description: sqly - easily execute SQL against CSV/TSV/LTSV/JSON and Microsoft Excel™ with shell.
     license: MIT
     repository:
       owner: nao1215

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,6 +74,8 @@ changelog:
 # Software Bill of Materials for every release archive.
 sboms:
   - artifacts: archive
+    documents:
+      - "${artifact}.sbom.json"
 # Keyless artifact signing with cosign. Signing the checksums file transitively
 # covers every published artifact.
 signs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,79 @@
-## Contributing as a Developer
+## Contributing to sqly
+Thank you for building sqly with us.
+Every report, patch, test, and review helps people query CSV/TSV/LTSV/JSON and
+Excel files with SQL more easily. Let's keep sqly fast, safe, and reliable
+together.
 
-- When creating a bug report: Please follow the template and provide detailed information.
-- When fixing a feature: Create a Pull Request (PR) with accompanying test code.
-- When adding a feature: First, propose the feature in an Issue.
+## Contributing as a Developer
+### 1. Start with clear communication
+- Bug report: Use the issue template and include reproducible steps, the input
+  file format, expected behavior, and actual behavior.
+- New feature: Open an issue first so we can agree on direction before
+  implementation.
+- Bug fix or improvement: Open a PR with a clear problem statement and solution
+  summary.
+
+### 2. Keep the quality bar high
+- Add or update unit tests when you add features or fix bugs.
+- Avoid regressions on supported OSes (Linux, macOS, Windows).
+- Keep CLI and shell behavior and error messages clear and consistent.
+- sqly follows Clean Architecture; respect the layer boundaries enforced by
+  go-arch-lint (`.go-arch-lint.yml`).
+
+### 3. Run checks before opening a PR
+```shell
+make test
+make lint
+make build
+```
+
+`make test` runs the unit tests with coverage. `make lint` runs golangci-lint
+and go-arch-lint. Aim for 80% or higher coverage with unit tests.
+
+### 4. Run the end-to-end tests (recommended for CLI/shell changes)
+sqly has a [ShellSpec](https://github.com/shellspec/shellspec) suite that
+exercises the real `sqly` binary. It runs in CI
+(`.github/workflows/e2e_test.yml`).
+
+```shell
+# Install ShellSpec once (see https://github.com/shellspec/shellspec#installation)
+curl -fsSL https://git.io/shellspec | sh -s 0.28.1 --yes
+
+# Build the binary and run the suite
+make test-e2e
+```
+
+### 5. Regenerate code when you touch DI or templates
+sqly uses Google Wire for dependency injection. After changing `di/wire.go` or
+anything covered by `go:generate`, regenerate and verify:
+
+```shell
+make generate
+```
+
+### 6. Install developer tools
+```shell
+make tools
+```
+
+## Documentation
+`README.md` (English) is the source of truth for user-facing documentation. When
+you add or change a feature, also update the GitHub Pages docs under
+`doc/pages/markdown/`. Avoid bold and emoji in documentation. Localized READMEs
+have been removed; please do not add new ones.
+
+## Releasing
+Maintainers cut releases by pushing a `v*` tag. The process is documented in
+[doc/RELEASE.md](./doc/RELEASE.md).
+
+## Need help?
+See [SUPPORT.md](./.github/SUPPORT.md) for where to ask questions and report
+problems.
 
 ## Contributing Outside of Coding
-The following actions help boost my motivation:
+You can still make a huge impact even if you are not writing code:
 
-- Giving a GitHub Star
-- Promoting the application
-- Becoming a GitHub Sponsor
+- Give sqly a GitHub Star
+- Share sqly with your team and community
+- Open issues with clear reproduction steps
+- Sponsor the project

--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ brew install nao1215/tap/sqly
 
 Runs on Windows, macOS, and Linux. Requires Go 1.25 or later when building from source.
 
+## Verifying release integrity
+Every release ships supply-chain metadata so you can verify what you download:
+
+- Signed checksums: `checksums.txt` is signed with [cosign](https://github.com/sigstore/cosign) (keyless), producing `checksums.txt.sigstore.json`.
+- SBOM: an SPDX Software Bill of Materials is attached to each release archive.
+- Build provenance: SLSA build provenance is attested via GitHub OIDC.
+
+Verify the signed checksums (then check your archive against `checksums.txt`):
+
+```shell
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/nao1215/sqly/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Verify the build provenance of a downloaded artifact with the GitHub CLI:
+
+```shell
+gh attestation verify sqly_<version>_<os>_<arch>.tar.gz --repo nao1215/sqly
+```
+
 ## Run SQL: --sql
 
 Pass file or directory paths as arguments; sqly imports each one and names the table after the file (so `user.csv` becomes table `user`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,33 @@
-# Security Policy
+# Security policy
 
-## Reporting a Vulnerability
+## Supported versions
+Only the latest release of sqly gets fixes, including security fixes. If you hit
+an issue on an older version, please reproduce it on the latest release first.
 
-If you discover any security-related issues or vulnerabilities, please contact us at [n.chika156@gmail.com](mailto:n.chika156@gmail.com). We appreciate your responsible disclosure and will work with you to address the issue promptly.
+## Reporting a vulnerability
+Report security issues privately, not through public issues or pull requests.
 
-## Supported Versions
+- Email: [n.chika156@gmail.com](mailto:n.chika156@gmail.com)
+- Or use the "Report a vulnerability" button on the repository's Security tab.
 
-We recommend using the latest release for the most up-to-date and secure experience. Security updates are provided for the latest stable version.
+sqly imports untrusted files (CSV/TSV/LTSV/JSON/Parquet/Excel, including
+compressed variants) into an in-memory SQLite database and runs SQL against
+them, so reports about file parsing, path handling, resource exhaustion, or the
+import/save flow are especially useful. Please include enough detail to
+reproduce:
 
-## Security Policy
+- sqly version (`sqly --version`)
+- OS and architecture
+- The input file format and the command you ran
+- A minimal reproduction, if you have one
 
-- Security issues are treated with the highest priority.
-- We follow responsible disclosure practices.
-- Fixes for security vulnerabilities will be provided in a timely manner.
+## What to expect
+sqly is maintained by one developer in spare time, so there is no guaranteed
+response time. I will acknowledge the report, confirm the issue, and fix it in a
+new release. You will be credited in the release notes unless you prefer to stay
+anonymous.
 
-## Acknowledgments
-
-We would like to thank the security researchers and contributors who responsibly report security issues and work with us to make our project more secure.
-
-Thank you for your help in making our project safe and secure for everyone.
+## Verifying releases
+Release artifacts are signed with cosign and ship with an SBOM and build
+provenance. See [Verifying release integrity](./README.md#verifying-release-integrity)
+for how to check what you download.

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -1,0 +1,54 @@
+# Release process
+
+This describes how a sqly release is cut. It is for maintainers.
+
+## Overview
+Releases are driven by Git tags. Pushing a tag that matches `v*` triggers the
+[release workflow](../.github/workflows/release.yml), which runs
+[GoReleaser](https://goreleaser.com/) using [.goreleaser.yml](../.goreleaser.yml).
+There is no manual upload step.
+
+## Versioning
+- sqly follows [Semantic Versioning](https://semver.org/): `vMAJOR.MINOR.PATCH`.
+- Release notes are generated from commit messages, so use
+  [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`,
+  `perf:`, `docs:`, and `!` for breaking changes). `chore:`, `ci:`, `style:`,
+  and `test:` commits are excluded from the notes.
+
+## Before tagging
+- Make sure `main` is green (build, unit tests, e2e, lint, gitleaks).
+- Locally you can dry-run the build with `goreleaser release --snapshot --clean`.
+
+## Cut a release
+```shell
+git switch main
+git pull --ff-only
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+The release workflow then:
+- builds binaries for linux, macOS, and Windows (amd64 and arm64);
+- publishes archives, `deb`/`rpm`/`apk` packages, and `checksums.txt`;
+- signs the checksums with cosign (keyless) and attaches an SBOM;
+- attests build provenance via GitHub OIDC;
+- updates the Homebrew tap (`nao1215/homebrew-tap`).
+
+## Required secrets
+- `GITHUB_TOKEN`: provided automatically; used to create the GitHub Release.
+- `TAP_GITHUB_TOKEN`: a token with write access to `nao1215/homebrew-tap`,
+  used to push the updated formula.
+
+## After releasing
+- Check the [Releases page](https://github.com/nao1215/sqly/releases) for the
+  generated notes and artifacts.
+- Verify a downloaded artifact as described in
+  [Verifying release integrity](../README.md#verifying-release-integrity).
+- Confirm `brew upgrade sqly` picks up the new version.
+
+## If a release fails
+- Re-run the failed job from the Actions tab once the cause is fixed.
+- If the tag itself is wrong, delete it locally and remotely, then tag again:
+  ```shell
+  git tag -d vX.Y.Z
+  git push origin :refs/tags/vX.Y.Z
+  ```

--- a/doc/pages/markdown/installation.md
+++ b/doc/pages/markdown/installation.md
@@ -33,3 +33,28 @@ The following binaries are distributed on the release page.
 - Linux (linux_arm64.rpm)
 - Windows (windows_amd64.zip)
 - Windows (windows_arm64.zip)
+
+### Verifying release integrity
+
+Every release ships supply-chain metadata so you can verify what you download:
+
+- Signed checksums: `checksums.txt` is signed with [cosign](https://github.com/sigstore/cosign) (keyless), producing `checksums.txt.sigstore.json`.
+- SBOM: an SPDX Software Bill of Materials is attached to each release archive.
+- Build provenance: SLSA build provenance is attested via GitHub OIDC.
+
+Verify the signed checksums (then check your archive against `checksums.txt`):
+
+```shell
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/nao1215/sqly/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Verify the build provenance of a downloaded artifact with the GitHub CLI:
+
+```shell
+gh attestation verify sqly_<version>_<os>_<arch>.tar.gz --repo nao1215/sqly
+```


### PR DESCRIPTION
## Summary
Bring sqly in line with the [gup](https://github.com/nao1215/gup) project's CI/release hardening pass (mirrors gup#383). Three areas: OSS Community Standards, release integrity, and supply-chain hardening of GitHub Actions.

### OSS Community Standards
- Add `.github/ISSUE_TEMPLATE/config.yml` — security + support contact links, blank issues disabled.
- Add a Question issue template (`.github/ISSUE_TEMPLATE/question.md`).
- Add `.github/SUPPORT.md` describing where to ask for help before opening an issue.
- Expand `CONTRIBUTING.md` with concrete build / test / e2e (ShellSpec) / generate / release guidance, sqly-specific.
- Rework `SECURITY.md` — private vulnerability reporting, sqly-specific scope (untrusted file import), what to expect, and a release-verification pointer.
- Add `doc/RELEASE.md` documenting the tag-driven release process for maintainers.

### Release integrity (matching gup's "Verifying release integrity")
- `.goreleaser.yml`: pin to schema `version: 2`, sign `checksums.txt` with cosign (keyless), attach an SPDX SBOM, curate grouped release notes (header links to the verify section + footer changelog), and modernize deprecated keys (`version_template`, `formats`).
- `release.yml`: add `id-token` / `attestations` permissions, install cosign and Syft, and attest SLSA build provenance via GitHub OIDC.
- Document the verification steps (cosign verify-blob + `gh attestation verify`) in `README.md` and the Pages installation doc.

### Supply-chain hardening
- Pin every GitHub Action across all workflows to a full commit SHA, with the version kept in a trailing comment, so a retagged or compromised action cannot silently change what runs.

## Verification
- `go build ./...` passes.
- `goreleaser check` — config is valid (only the pre-existing `brews` deprecation warning remains, kept to match gup).
- `goreleaser release --snapshot --clean --skip=publish,sign,sbom` builds all archives/packages successfully.
- All workflow YAML and `.goreleaser.yml` parse cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added supply-chain “Verifying release integrity” details and copy-pastable commands to check signed checksums, SBOMs, and build provenance.
* **Documentation**
  * Expanded README and installation docs with release verification steps.
  * Rewrote contribution, security, and release guides; added a dedicated questions issue template and support guide.
* **Security**
  * Strengthened release signing and published provenance/attestations.
  * Improved workflow hardening by pinning third-party CI actions to specific commit versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->