### PR TITLE
fix: reject symlink aliases that resolve to blocked system paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Bug Fixes
+* Symlink-Resolved System-Path Guard: import path validation now rejects a symlink whose canonical target is a blocked system location (such as a link to `/etc/hosts`), not only a directly typed system path. It also normalizes the macOS `/private` prefix, while standard Unix pseudo-files (`/dev/stdin`, `/proc/self/fd/*`) keep importing.
+
 ## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0) (2026-06-06)
 
 ### Features

--- a/shell/import.go
+++ b/shell/import.go
@@ -784,18 +784,49 @@ func validatePath(path string) (string, error) {
 		}
 	}
 
-	// Prevent access to system directories on Unix-like systems
+	// Prevent access to system directories on Unix-like systems. Validate both
+	// the raw absolute path and its symlink-resolved target, so a symlink to
+	// /etc/hosts is rejected like the direct path. EvalSymlinks only resolves
+	// existing paths, so its error is ignored for paths that do not exist yet.
 	absPath, err := filepath.Abs(cleanPath)
-	if err == nil && !isAllowedPseudoFile(absPath) { // Only check if we can resolve the absolute path
-		systemDirs := []string{"/etc", "/proc", "/sys", "/dev", "/boot"}
-		for _, sysDir := range systemDirs {
-			if absPath == sysDir || strings.HasPrefix(absPath, sysDir+"/") {
+	if err == nil {
+		if isBlockedSystemPath(absPath) {
+			return "", fmt.Errorf("access to system directory not allowed: %s", path)
+		}
+		// Skip symlink resolution for allowed pseudo-files: their fd aliases
+		// (e.g. /dev/stdin, /proc/self/fd/0) legitimately resolve to devices or
+		// pipes under /dev or /proc, which would otherwise look blocked.
+		if !isAllowedPseudoFile(absPath) {
+			if resolved, rerr := filepath.EvalSymlinks(absPath); rerr == nil && isBlockedSystemPath(resolved) {
 				return "", fmt.Errorf("access to system directory not allowed: %s", path)
 			}
 		}
 	}
 
 	return cleanPath, nil
+}
+
+// isBlockedSystemPath reports whether absPath (already absolute) targets a
+// protected OS directory such as /etc, /proc, or /dev. On macOS these live under
+// /private (/etc is a symlink to /private/etc), so a /private-prefixed resolved
+// target is normalized before comparison. Allowed Unix pseudo-files are not
+// treated as blocked.
+func isBlockedSystemPath(absPath string) bool {
+	if isAllowedPseudoFile(absPath) {
+		return false
+	}
+	candidates := []string{absPath}
+	if stripped, ok := strings.CutPrefix(absPath, "/private"); ok && strings.HasPrefix(stripped, "/") {
+		candidates = append(candidates, stripped)
+	}
+	for _, p := range candidates {
+		for _, sysDir := range []string{"/etc", "/proc", "/sys", "/dev", "/boot"} {
+			if p == sysDir || strings.HasPrefix(p, sysDir+"/") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // stagePseudoFileAsCSV stages an extensionless Unix pseudo-file (e.g. /dev/stdin,

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -997,6 +997,48 @@ func TestValidatePath_Import(t *testing.T) {
 	}
 }
 
+// TestValidatePath_Symlink verifies that the system-directory guard follows
+// symlinks: an alias to a blocked target must be rejected just like the direct
+// path, while an alias to an ordinary user file must still import. The guard
+// normalizes the macOS /private prefix, so this runs on Linux and macOS alike.
+func TestValidatePath_Symlink(t *testing.T) {
+	if runtime.GOOS == config.Windows {
+		t.Skip("Unix-only system directory check")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	t.Run("symlink alias to /etc/hosts is rejected like the direct path", func(t *testing.T) {
+		t.Parallel()
+		if _, err := os.Stat("/etc/hosts"); err != nil {
+			t.Skip("/etc/hosts is not present on this host")
+		}
+		link := filepath.Join(dir, "hosts_alias.csv")
+		if err := os.Symlink("/etc/hosts", link); err != nil {
+			t.Fatalf("os.Symlink: %v", err)
+		}
+		if _, err := validatePath(link); err == nil {
+			t.Errorf("validatePath(%q) = nil error, want rejection of a symlink to a blocked system path", link)
+		}
+	})
+
+	t.Run("symlink to an ordinary user file is accepted", func(t *testing.T) {
+		t.Parallel()
+		target := filepath.Join(dir, "real.csv")
+		if err := os.WriteFile(target, []byte("a,b\n1,2\n"), 0o600); err != nil {
+			t.Fatalf("os.WriteFile: %v", err)
+		}
+		link := filepath.Join(dir, "user_alias.csv")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatalf("os.Symlink: %v", err)
+		}
+		if _, err := validatePath(link); err != nil {
+			t.Errorf("validatePath(%q) = %v, want nil for a symlink to a user file", link, err)
+		}
+	})
+}
+
 func TestDiffTableNames(t *testing.T) {
 	t.Parallel()
 

--- a/spec/path_validation_spec.sh
+++ b/spec/path_validation_spec.sh
@@ -34,4 +34,23 @@ Describe 'sqly input path validation'
     The output should include 'user_name'
     The stderr should not include 'dangerous path pattern'
   End
+
+  # A symlink alias to a blocked system file must be rejected just like the
+  # direct path; otherwise the guard only checks the typed string, not the real
+  # target.
+  It 'rejects a symlink alias that resolves to a blocked system path'
+    Skip if 'no /etc/hosts on this host' test ! -e /etc/hosts
+    ln -sf /etc/hosts "$WORK/hosts_alias.csv"
+    When run sqly --inspect "$WORK/hosts_alias.csv"
+    The status should be failure
+    The stderr should include 'system directory not allowed'
+  End
+
+  It 'imports a symlink alias that resolves to an ordinary user file'
+    cp testdata/user.csv "$WORK/real.csv"
+    ln -sf "$WORK/real.csv" "$WORK/user_alias.csv"
+    When run sqly --inspect "$WORK/user_alias.csv"
+    The status should be success
+    The output should include 'user_name'
+  End
 End


### PR DESCRIPTION
This fixes a path-validation bypass: imports from blocked system paths were rejected by the typed string only, so a symlink alias to the same target (for example a link to /etc/hosts) was accepted.

validatePath now resolves symlinks with filepath.EvalSymlinks and checks the canonical target against the protected directories, in addition to the raw absolute path. The macOS /private prefix is normalized so the guard holds on both Linux and macOS. Standard Unix pseudo-files (/dev/stdin, /proc/self/fd/*) skip symlink resolution and keep importing, since their fd aliases resolve to devices or pipes.

Coverage: a Go test creates a symlink to /etc/hosts and asserts rejection (and that a symlink to a user file still imports), and a shellspec case exercises the same through the built binary.

Closes #593