### PR TITLE
fix: invalidate import cache on content change via SHA-256 key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Content-Aware Import Cache Key: `--cache` now keys invalidation on each input file's path, size, and a SHA-256 content hash instead of path, size, and modification time. A source rewritten in place with different but same-length content and its original mtime restored is now detected and the cache rebuilt, so a warm run can no longer return stale rows for a modified file.
 * Symlink-Resolved System-Path Guard: import path validation now rejects a symlink whose canonical target is a blocked system location (such as a link to `/etc/hosts`), not only a directly typed system path. It also normalizes the macOS `/private` prefix, while standard Unix pseudo-files (`/dev/stdin`, `/proc/self/fd/*`) keep importing.
 
 ## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0) (2026-06-06)

--- a/README.md
+++ b/README.md
@@ -360,14 +360,14 @@ Saved ACH set payment to payment.ach
 
 ## Reuse imports: --cache
 
-For repeated queries against the same large inputs, `--cache PATH` snapshots the imported tables to a standalone SQLite file. A later run with unchanged inputs reloads from the snapshot instead of re-parsing the source files, which is much faster for big CSVs. The cache key is each input's path, size, and modification time, so it invalidates automatically when a source changes. `--cache-clear` forces a cold rebuild, and a cache that is unavailable or unwritable falls back to a normal import with a warning rather than failing the query.
+For repeated queries against the same large inputs, `--cache PATH` snapshots the imported tables to a standalone SQLite file. A later run with unchanged inputs reloads from the snapshot instead of re-parsing the source files, which is much faster for big CSVs. The cache key is each input's path, size, and a SHA-256 hash of its contents, so it invalidates automatically when a source changes. `--cache-clear` forces a cold rebuild, and a cache that is unavailable or unwritable falls back to a normal import with a warning rather than failing the query.
 
 ```shell
 $ sqly --cache ./sqly.cache --sql "SELECT COUNT(*) FROM big" big.csv   # cold: parses and snapshots
 $ sqly --cache ./sqly.cache --sql "SELECT COUNT(*) FROM big" big.csv   # warm: reloads the snapshot
 ```
 
-Caching is skipped for `--stdin` datasets and for ACH/Fedwire inputs. The cache key is path, size, and modification time, so an in-place edit that keeps the exact size and modification time would not be detected; use `--cache-clear` to force a rebuild when in doubt.
+Caching is skipped for `--stdin` datasets and for ACH/Fedwire inputs. Because the cache key includes a SHA-256 content hash, an in-place edit is detected even when the file's size and modification time are unchanged.
 
 ## Profile data quality: --profile
 

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -164,7 +164,7 @@ Tables created by SQL, tables imported from a directory, and Excel sources are r
 
 ### Reuse imports across runs: --cache
 
-For repeated queries against the same large inputs, `--cache PATH` snapshots the imported tables to a standalone SQLite file. A later run whose inputs are unchanged reloads from the snapshot instead of re-parsing the source files. The cache key is each input file's path, size, and modification time (directories are expanded recursively), so the cache invalidates automatically when a source changes. `--cache-clear` forces a cold rebuild, and a cache that is unavailable or unwritable falls back to a normal import with a warning instead of failing the query. Caching is skipped for `--stdin` datasets and for ACH/Fedwire inputs. Because the key is path, size, and modification time, an in-place edit that keeps the exact size and modification time would not be detected; use `--cache-clear` to force a rebuild when in doubt.
+For repeated queries against the same large inputs, `--cache PATH` snapshots the imported tables to a standalone SQLite file. A later run whose inputs are unchanged reloads from the snapshot instead of re-parsing the source files. The cache key is each input file's path, size, and a SHA-256 hash of its contents (directories are expanded recursively), so the cache invalidates automatically whenever a source changes, including an in-place edit that keeps the same size and modification time. `--cache-clear` forces a cold rebuild, and a cache that is unavailable or unwritable falls back to a normal import with a warning instead of failing the query. Caching is skipped for `--stdin` datasets and for ACH/Fedwire inputs.
 
 ```shell
 $ sqly --cache ./sqly.cache --sql "SELECT COUNT(*) FROM big" big.csv

--- a/shell/cache.go
+++ b/shell/cache.go
@@ -2,8 +2,11 @@ package shell
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,16 +16,20 @@ import (
 )
 
 // cacheManifestVersion is the manifest schema version. A mismatch invalidates the
-// cache so an older cache layout is rebuilt rather than misread.
-const cacheManifestVersion = 1
+// cache so an older cache layout is rebuilt rather than misread. Version 2 added a
+// content hash to the source signature (issue #592); a version 1 manifest is
+// treated as stale and rebuilt.
+const cacheManifestVersion = 2
 
 // cacheSource is the invalidation signature of one input file: its absolute path,
-// size, and modification time. A change in size or mtime invalidates the cache.
+// size, and a SHA-256 hash of its contents. The content hash detects edits that
+// leave the file size and modification time unchanged, which a size+mtime
+// signature would miss and so reuse stale cached data (issue #592).
 type cacheSource struct {
 	Path string `json:"path"`
 	Size int64  `json:"size"`
-	// ModTime is the source modification time in Unix nanoseconds.
-	ModTime int64 `json:"mod_time"`
+	// Hash is the hex-encoded SHA-256 digest of the file contents.
+	Hash string `json:"hash"`
 }
 
 // cacheManifest records what an import cache contains and the inputs it was built
@@ -216,7 +223,11 @@ func collectCacheSignatures(paths []string) ([]cacheSource, error) {
 		if err != nil {
 			return err
 		}
-		sigs = append(sigs, cacheSource{Path: abs, Size: info.Size(), ModTime: info.ModTime().UnixNano()})
+		hash, err := hashFile(abs)
+		if err != nil {
+			return err
+		}
+		sigs = append(sigs, cacheSource{Path: abs, Size: info.Size(), Hash: hash})
 		return nil
 	}
 	for _, p := range paths {
@@ -247,8 +258,24 @@ func collectCacheSignatures(paths []string) ([]cacheSource, error) {
 	return sigs, nil
 }
 
+// hashFile returns the hex-encoded SHA-256 digest of a file's contents. It
+// streams the file through the hash so memory use stays constant regardless of
+// file size.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // cache inputs are paths the user passed on the command line
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
 // cacheSignaturesMatch reports whether two signature sets are identical (same
-// files, sizes, and modification times). Either set is assumed sorted by path.
+// files, sizes, and content hashes). Either set is assumed sorted by path.
 func cacheSignaturesMatch(a, b []cacheSource) bool {
 	if len(a) != len(b) {
 		return false

--- a/shell/cache_test.go
+++ b/shell/cache_test.go
@@ -28,8 +28,40 @@ func TestCache_WarmHitReusesSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "data.csv")
 	cache := filepath.Join(dir, "snap.cache")
-	// Two rows with single-character values so the file can be edited later
-	// without changing its byte length (keeping the cache signature identical).
+	if err := os.WriteFile(src, []byte("id,v\n1,a\n2,b\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cold run populates the cache.
+	cold := runQuery(t, []string{"sqly", "--cache", cache, "--sql", "SELECT v FROM data WHERE id=1", src})
+	if !strings.Contains(cold, "a") {
+		t.Fatalf("cold run = %q, want value a", cold)
+	}
+	if _, err := os.Stat(cache); err != nil {
+		t.Fatalf("expected cache file at %s: %v", cache, err)
+	}
+
+	// A second run over the unchanged source must reuse the cache and emit the
+	// reuse banner on stderr.
+	warmErr := captureStderr(t, func() {
+		warm := runQuery(t, []string{"sqly", "--cache", cache, "--sql", "SELECT v FROM data WHERE id=1", src})
+		if !strings.Contains(warm, "a") {
+			t.Errorf("warm run = %q, want value a", warm)
+		}
+	})
+	if !strings.Contains(warmErr, "cache: reused") {
+		t.Errorf("warm run stderr = %q, want it to include 'cache: reused'", warmErr)
+	}
+}
+
+// TestCache_InvalidatesWhenContentChangesSameSizeAndMTime reproduces issue #592:
+// a source rewritten with different but same-length content and its original
+// mtime restored must invalidate the cache, not reuse stale data.
+func TestCache_InvalidatesWhenContentChangesSameSizeAndMTime(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "data.csv")
+	cache := filepath.Join(dir, "snap.cache")
+	// Single-character values so the edit keeps the file's byte length identical.
 	if err := os.WriteFile(src, []byte("id,v\n1,a\n2,b\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -44,13 +76,9 @@ func TestCache_WarmHitReusesSnapshot(t *testing.T) {
 	if !strings.Contains(cold, "a") {
 		t.Fatalf("cold run = %q, want value a", cold)
 	}
-	if _, err := os.Stat(cache); err != nil {
-		t.Fatalf("expected cache file at %s: %v", cache, err)
-	}
 
-	// Edit the source in place, keeping the same byte length, then restore the
-	// modification time so the cache signature still matches. A warm run must
-	// return the cached value 'a', proving it did not re-read the source.
+	// Rewrite with same length and restore the mtime: size and mtime are
+	// unchanged, so only a content hash can detect the edit.
 	if err := os.WriteFile(src, []byte("id,v\n1,Z\n2,b\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -58,9 +86,14 @@ func TestCache_WarmHitReusesSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	warm := runQuery(t, []string{"sqly", "--cache", cache, "--sql", "SELECT v FROM data WHERE id=1", src})
-	if !strings.Contains(warm, "a") || strings.Contains(warm, "Z") {
-		t.Errorf("warm run = %q, want cached value a (not the edited Z)", warm)
+	stderr := captureStderr(t, func() {
+		got := runQuery(t, []string{"sqly", "--cache", cache, "--sql", "SELECT v FROM data WHERE id=1", src})
+		if !strings.Contains(got, "Z") {
+			t.Errorf("after content change = %q, want the new value Z (cache must invalidate)", got)
+		}
+	})
+	if strings.Contains(stderr, "cache: reused") {
+		t.Errorf("stderr = %q, want no 'cache: reused' after a content change", stderr)
 	}
 }
 

--- a/spec/cache_spec.sh
+++ b/spec/cache_spec.sh
@@ -35,6 +35,17 @@ Describe 'sqly --cache import cache'
     The stderr should not include 'cache: reused'
   End
 
+  It 'invalidates the cache when content changes but size and mtime do not (issue #592)'
+    # Rewrite the source with different same-length content and restore the
+    # original mtime. A size+mtime signature would miss the edit and reuse stale
+    # data; a content hash must catch it.
+    When run sh -c "printf 'id,name\n1,Alice\n2,Bob\n' > '$WORKDIR/d.csv' && cp -p '$WORKDIR/d.csv' '$WORKDIR/ref.csv' && '$SQLY_BIN' --cache '$CACHE' --sql \"SELECT group_concat(name, ',') AS names FROM d\" '$WORKDIR/d.csv' >/dev/null && printf 'id,name\n1,Carol\n2,Eve\n' > '$WORKDIR/d.csv' && touch -r '$WORKDIR/ref.csv' '$WORKDIR/d.csv' && '$SQLY_BIN' --cache '$CACHE' --sql \"SELECT group_concat(name, ',') AS names FROM d\" '$WORKDIR/d.csv'"
+    The status should be success
+    The output should include 'Carol,Eve'
+    The output should not include 'Alice,Bob'
+    The stderr should not include 'cache: reused'
+  End
+
   It 'falls back to a cold import when the cache path is unwritable'
     # A non-empty directory at the cache path cannot be written as a SQLite file.
     When run sh -c "mkdir -p '$CACHE' && touch '$CACHE/keep' && '$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' '$WORKDIR/data.csv'"


### PR DESCRIPTION
## Summary

The opt-in import cache (`--cache`) keyed its invalidation signature only on each input file's absolute path, size, and modification time. When a source file was rewritten in place with different but same-length content and its original mtime was restored, the signature stayed identical, so a warm run reused the stale snapshot and returned outdated rows. This fixes that correctness bug reported in #592.

## Changes

The cache source signature now records a SHA-256 hash of the file contents instead of the modification time. The hash is computed by streaming the file through the digest so memory use stays constant regardless of file size. The manifest schema version is bumped from 1 to 2 so any cache written by an older binary is treated as stale and rebuilt rather than misread.

Updated the cache documentation in `README.md` and `doc/pages/markdown/how_to_use.md` to describe the content-hash key and removed the now-obsolete caveat that a same-size, same-mtime edit would go undetected. Added a `CHANGELOG.md` entry under Unreleased.

## Tests

Added a Go test `TestCache_InvalidatesWhenContentChangesSameSizeAndMTime` that reproduces the exact bug: a same-length in-place edit with the original mtime restored must rebuild the cache and return the new value without printing `cache: reused`. Reworked `TestCache_WarmHitReusesSnapshot` to assert genuine reuse on an unchanged source (it previously asserted the stale-reuse behavior the issue calls a bug). Added a shellspec case in `spec/cache_spec.sh` mirroring the issue reproduction. `make test` and `make lint` pass.

## Design Decisions

The modification time field was dropped from the signature rather than kept alongside the hash: a full content hash already detects every real change, so mtime added no correctness value and would only cause spurious rebuilds after a no-op `touch`. The hash is read on every warm check, which still skips the expensive parse/insert step that the cache exists to avoid.

Closes #592
