### PR TITLE
fix: exit interactive shell cleanly on Ctrl-D instead of printing EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 * Content-Aware Import Cache Key: `--cache` now keys invalidation on each input file's path, size, and a SHA-256 content hash instead of path, size, and modification time. A source rewritten in place with different but same-length content and its original mtime restored is now detected and the cache rebuilt, so a warm run can no longer return stale rows for a modified file.
+* Clean Ctrl-D Exit: pressing Ctrl-D (EOF) in the interactive shell now exits cleanly like `.exit` instead of printing a raw `EOF` line. Both EOF spellings the prompt library reports (Ctrl-D on an empty line and a closed input stream) are treated as a normal termination.
 * Symlink-Resolved System-Path Guard: import path validation now rejects a symlink whose canonical target is a blocked system location (such as a link to `/etc/hosts`), not only a directly typed system path. It also normalizes the macOS `/private` prefix, while standard Unix pseudo-files (`/dev/stdin`, `/proc/self/fd/*`) keep importing.
 
 ## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0) (2026-06-06)

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -338,6 +338,13 @@ func (s *Shell) communicate(ctx context.Context) error {
 	for {
 		input, err := s.prompt(p)
 		if err != nil {
+			// Ctrl-D / EOF ends the session like ".exit": a normal exit, not a
+			// user-facing error. The prompt library reports this as io.EOF
+			// (Ctrl-D on an empty line) or prompt.ErrEOF (input stream closed);
+			// treat both as a clean termination so no raw "EOF" text leaks out.
+			if errors.Is(err, io.EOF) || errors.Is(err, prompt.ErrEOF) {
+				return nil
+			}
 			return err
 		}
 		if err = s.exec(ctx, input); err != nil {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1213,6 +1213,9 @@ type fakePromptSession struct {
 	runCalls        int
 	initialPrefix   string
 	capturedSuggest []prompt.Suggestion
+	// exhaustErr is returned once results are exhausted. It defaults to io.EOF,
+	// modeling Ctrl-D; set it to prompt.ErrEOF to model a closed input stream.
+	exhaustErr error
 }
 
 func (f *fakePromptSession) AddHistory(history string) {
@@ -1226,6 +1229,9 @@ func (f *fakePromptSession) Close() error {
 
 func (f *fakePromptSession) Run() (string, error) {
 	if f.runCalls >= len(f.results) {
+		if f.exhaustErr != nil {
+			return "", f.exhaustErr
+		}
 		return "", io.EOF
 	}
 
@@ -1349,6 +1355,62 @@ func TestShellCommunicate_ReusesPromptSessionForMultilineSQL(t *testing.T) {
 	}
 	if !strings.Contains(queryOutput.String(), "1") || !strings.Contains(queryOutput.String(), "2") {
 		t.Fatalf("multiline SQL output missing expected rows: %q", queryOutput.String())
+	}
+}
+
+// TestShellCommunicate_EOFExitsCleanly covers issue #594: Ctrl-D / EOF must end
+// the interactive shell cleanly, like ".exit", without returning an error or
+// leaking raw "EOF" text to the user. Both EOF spellings the prompt library can
+// report are exercised: io.EOF (Ctrl-D on an empty line) and prompt.ErrEOF (the
+// input stream was closed).
+func TestShellCommunicate_EOFExitsCleanly(t *testing.T) {
+	tests := []struct {
+		name string
+		eof  error
+	}{
+		{name: "Ctrl-D returns io.EOF", eof: io.EOF},
+		{name: "closed stream returns prompt.ErrEOF", eof: prompt.ErrEOF},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shell, cleanup, err := newShell(t, []string{"sqly"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+
+			fakePrompt := &fakePromptSession{exhaustErr: tt.eof}
+			shell.newPrompt = func(prefix string, _ func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+				fakePrompt.initialPrefix = prefix
+				return fakePrompt, nil
+			}
+
+			backupStdout := config.Stdout
+			backupStderr := config.Stderr
+			defer func() {
+				config.Stdout = backupStdout
+				config.Stderr = backupStderr
+			}()
+			var stdout, stderr bytes.Buffer
+			config.Stdout = &stdout
+			config.Stderr = &stderr
+
+			terminal := captureOSStdout(t, func() {
+				if err := shell.communicate(context.Background()); err != nil {
+					t.Fatalf("communicate returned %v on EOF, want a clean exit (nil)", err)
+				}
+			})
+
+			if strings.Contains(stderr.String(), "EOF") {
+				t.Errorf("stderr leaked EOF text: %q", stderr.String())
+			}
+			if strings.Contains(stdout.String(), "EOF") || strings.Contains(terminal, "EOF") {
+				t.Errorf("output leaked EOF text: stdout=%q terminal=%q", stdout.String(), terminal)
+			}
+			if fakePrompt.closeCalls != 1 {
+				t.Errorf("prompt close calls = %d, want 1 (session closed on EOF exit)", fakePrompt.closeCalls)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

In interactive mode, pressing Ctrl-D (EOF) exited the shell but also printed a visible `EOF` line, because the prompt library's EOF error was returned all the way up from `communicate` to `main`, which rendered it as a user-facing error. This made a normal shell exit look like an internal error leaking out. This fixes #594 so Ctrl-D terminates the session cleanly, the same as `.exit`.

## Changes

`communicate` now treats an EOF returned by the prompt session as a normal termination and returns `nil` instead of propagating the error. Both EOF spellings the `github.com/nao1215/prompt` library can report are handled: `io.EOF`, returned when the user presses Ctrl-D on an empty line, and `prompt.ErrEOF`, returned when the input stream is closed. Any other prompt error is still returned unchanged. Added a CHANGELOG entry under Unreleased.

## Tests

Added `TestShellCommunicate_EOFExitsCleanly`, a table-driven test that drives `communicate` with each EOF error and asserts the shell exits without an error, closes the prompt session, and leaks no `EOF` text to stdout, stderr, or the terminal. The shared `fakePromptSession` gained an optional `exhaustErr` field so a test can model either EOF spelling; it still defaults to `io.EOF`, so existing tests are unaffected. `make test` and `make lint` pass.

## Design Decisions

The EOF check lives in `communicate` rather than in `main` so the interactive loop owns the meaning of "the user ended the session", keeping the clean-exit decision next to the existing `.exit` (`ErrExitSqly`) handling. Ctrl-C (`prompt.ErrInterrupted`) is intentionally left out of scope: it is a separate signal not covered by this issue, and the library already prints its own `^C` marker before returning.

Closes #594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exiting the interactive shell with Ctrl-D now ends the session cleanly instead of showing a raw `EOF` message.
  * Both EOF-style exits are handled consistently, matching the normal `.exit` behavior.

* **Tests**
  * Added regression coverage to verify EOF exits return normally, produce no `EOF` output, and close the session once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->