### PR TITLE
docs: credit issue reporters as contributors and fix Marukome0743 avatar

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -41,10 +41,46 @@
     {
       "login": "Marukome0743",
       "name": "まるこめ",
-      "avatar_url": "https://avatars.githubusercontent.com/u/113521295?v=4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/146040408?v=4",
       "profile": "https://github.com/Marukome0743",
       "contributions": [
         "code"
+      ]
+    },
+    {
+      "login": "jedvardsson",
+      "name": "Jon Edvardsson",
+      "avatar_url": "https://avatars.githubusercontent.com/u/672606?v=4",
+      "profile": "https://github.com/jedvardsson",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "jgstew",
+      "name": "JGStew",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2439367?v=4",
+      "profile": "https://github.com/jgstew",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "ricardoseriani",
+      "name": "Ricardo Seriani",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3369718?v=4",
+      "profile": "https://github.com/ricardoseriani",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "SnowleopardXI",
+      "name": "Ephraim Steve Micaiah",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69493681?v=4",
+      "profile": "https://github.com/SnowleopardXI",
+      "contributions": [
+        "bug"
       ]
     }
   ],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
   
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/sqly/coverage.svg)
@@ -583,7 +583,13 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://debimate.jp/"><img src="https://avatars.githubusercontent.com/u/22737008?v=4?s=75" width="75px;" alt="CHIKAMATSU Naohiro"/><br /><sub><b>CHIKAMATSU Naohiro</b></sub></a><br /><a href="https://github.com/nao1215/sqly/commits?author=nao1215" title="Code">💻</a> <a href="https://github.com/nao1215/sqly/commits?author=nao1215" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Wozzardman"><img src="https://avatars.githubusercontent.com/u/128730409?v=4?s=75" width="75px;" alt="Wozzardman"/><br /><sub><b>Wozzardman</b></sub></a><br /><a href="https://github.com/nao1215/sqly/commits?author=Wozzardman" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/edsilegxrepo"><img src="https://avatars.githubusercontent.com/u/153197739?v=4?s=75" width="75px;" alt="edsilegxrepo"/><br /><sub><b>edsilegxrepo</b></sub></a><br /><a href="https://github.com/nao1215/sqly/commits?author=edsilegxrepo" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Marukome0743"><img src="https://avatars.githubusercontent.com/u/113521295?v=4?s=75" width="75px;" alt="まるこめ"/><br /><sub><b>まるこめ</b></sub></a><br /><a href="https://github.com/nao1215/sqly/commits?author=Marukome0743" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Marukome0743"><img src="https://avatars.githubusercontent.com/u/146040408?v=4?s=75" width="75px;" alt="まるこめ"/><br /><sub><b>まるこめ</b></sub></a><br /><a href="https://github.com/nao1215/sqly/commits?author=Marukome0743" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/jedvardsson"><img src="https://avatars.githubusercontent.com/u/672606?v=4?s=75" width="75px;" alt="Jon Edvardsson"/><br /><sub><b>Jon Edvardsson</b></sub></a><br /><a href="https://github.com/nao1215/sqly/issues?q=author%3Ajedvardsson" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/jgstew"><img src="https://avatars.githubusercontent.com/u/2439367?v=4?s=75" width="75px;" alt="JGStew"/><br /><sub><b>JGStew</b></sub></a><br /><a href="https://github.com/nao1215/sqly/issues?q=author%3Ajgstew" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ricardoseriani"><img src="https://avatars.githubusercontent.com/u/3369718?v=4?s=75" width="75px;" alt="Ricardo Seriani"/><br /><sub><b>Ricardo Seriani</b></sub></a><br /><a href="https://github.com/nao1215/sqly/issues?q=author%3Aricardoseriani" title="Bug reports">🐛</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/SnowleopardXI"><img src="https://avatars.githubusercontent.com/u/69493681?v=4?s=75" width="75px;" alt="Ephraim Steve Micaiah"/><br /><sub><b>Ephraim Steve Micaiah</b></sub></a><br /><a href="https://github.com/nao1215/sqly/issues?q=author%3ASnowleopardXI" title="Bug reports">🐛</a></td>
     </tr>
   </tbody>
   <tfoot>


### PR DESCRIPTION
## Summary

Following the gup convention of crediting everyone who reported a bug or requested a feature, this credits the external issue reporters as contributors and fixes a broken avatar for an existing contributor. The contributor list, badge, and table are regenerated with the all-contributors CLI from `.all-contributorsrc`.

## Changes

Added the four external issue reporters as bug-report (🐛) contributors: jedvardsson (#42, #43), jgstew (#171), ricardoseriani (#181), and SnowleopardXI (#151, #155, #218). A sweep of every issue and pull request found no other missing contributors: all non-bot PR authors (Wozzardman, edsilegxrepo, Marukome0743) were already credited as code contributors, and Dependabot is excluded as a bot.

Fixed the Marukome0743 entry, whose avatar pointed at GitHub user id 113521295. That id now belongs to a different account (mhmtgngr), so the rendered avatar showed the wrong or a missing image. Marukome0743's current id is 146040408, which the entry now uses.

The all-contributors badge count went from 4 to 8, and the README contributors table was regenerated to match.

## Design Decisions

Issue #171 ("GitHub repo description still mentions JSON") was classified as a bug report rather than documentation, since the reporter flagged an inaccuracy rather than contributing docs. Contribution-type detection followed gup's scheme (code, doc, bug, ideas); every external sqly issue so far has been a bug report, so all four reporters are credited with 🐛.
