### PR TITLE
fix(shell): reflect typed JSON modes in prompt and .mode output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Typed JSON Mode Shell UX: switching to `.mode json-typed`/`.mode ndjson-typed` now shows the typed mode name in the prompt label and the `.mode` current-mode banner instead of the plain `json`/`ndjson`, and `.mode` lists both typed variants.
 * Content-Aware Import Cache Key: `--cache` now keys invalidation on each input file's path, size, and a SHA-256 content hash instead of path, size, and modification time. A source rewritten in place with different but same-length content and its original mtime restored is now detected and the cache rebuilt, so a warm run can no longer return stale rows for a modified file.
 * Clean Ctrl-D Exit: pressing Ctrl-D (EOF) in the interactive shell now exits cleanly like `.exit` instead of printing a raw `EOF` line. Both EOF spellings the prompt library reports (Ctrl-D on an empty line and a closed input stream) are treated as a normal termination.
 * Symlink-Resolved System-Path Guard: import path validation now rejects a symlink whose canonical target is a blocked system location (such as a link to `/etc/hosts`), not only a directly typed system path. It also normalizes the macOS `/private` prefix, while standard Unix pseudo-files (`/dev/stdin`, `/proc/self/fd/*`) keep importing.

--- a/doc/pages/markdown/sqly_helper_command.md
+++ b/doc/pages/markdown/sqly_helper_command.md
@@ -121,6 +121,8 @@ sqly:~/github/github.com/nao1215/sqly(table)$ .mode
   ltsv
   json
   ndjson
+  json-typed ※ json output with native numbers, booleans, and nulls
+  ndjson-typed ※ ndjson output with native numbers, booleans, and nulls
   excel ※ active only when executing .dump, otherwise same as csv mode
   parquet ※ active only when executing .dump, otherwise same as csv mode
 ```

--- a/shell/compare.go
+++ b/shell/compare.go
@@ -26,9 +26,9 @@ func outputModeFlagName(o *config.Output) string {
 	if o.JSONTyped {
 		switch o.Mode {
 		case model.PrintModeJSON:
-			return "json-typed"
+			return outputModeJSONTyped
 		case model.PrintModeNDJSON:
-			return "ndjson-typed"
+			return outputModeNDJSONTyped
 		}
 	}
 	return o.Mode.String()

--- a/shell/mode.go
+++ b/shell/mode.go
@@ -11,7 +11,7 @@ import (
 func (c CommandList) modeCommand(_ context.Context, s *Shell, argv []string) error {
 	if len(argv) == 0 {
 		fmt.Fprintln(config.Stdout, "[Usage]")
-		fmt.Fprintf(config.Stdout, "  .mode OUTPUT_MODE   ※ current mode=%s\n", s.state.mode.String())
+		fmt.Fprintf(config.Stdout, "  .mode OUTPUT_MODE   ※ current mode=%s\n", s.state.mode.displayName())
 		fmt.Fprintln(config.Stdout, "[Output mode list]")
 		fmt.Fprintln(config.Stdout, "  table")
 		fmt.Fprintln(config.Stdout, "  markdown")
@@ -20,6 +20,8 @@ func (c CommandList) modeCommand(_ context.Context, s *Shell, argv []string) err
 		fmt.Fprintln(config.Stdout, "  ltsv")
 		fmt.Fprintln(config.Stdout, "  json")
 		fmt.Fprintln(config.Stdout, "  ndjson")
+		fmt.Fprintln(config.Stdout, "  json-typed ※ json output with native numbers, booleans, and nulls")
+		fmt.Fprintln(config.Stdout, "  ndjson-typed ※ ndjson output with native numbers, booleans, and nulls")
 		fmt.Fprintln(config.Stdout, "  excel ※ active only when executing .dump, otherwise same as csv mode")
 		fmt.Fprintln(config.Stdout, "  parquet ※ active only when executing .dump, otherwise same as csv mode")
 		return nil

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -538,7 +538,7 @@ func (s *Shell) prompt(p promptSession) (string, error) {
 }
 
 func (s *Shell) promptPrefix() string {
-	return fmt.Sprintf("sqly:%s(%s)$ ", s.state.shortCWD(), s.state.mode.String())
+	return fmt.Sprintf("sqly:%s(%s)$ ", s.state.shortCWD(), s.state.mode.displayName())
 }
 
 // Suggest is a local struct to maintain compatibility with old code structure
@@ -685,8 +685,8 @@ func (s *Shell) getRegularCompletions(ctx context.Context, input string) []Sugge
 		{Text: "ltsv", Description: "sqly command argument: ltsv output format"},
 		{Text: "json", Description: "sqly command argument: json output format"},
 		{Text: "ndjson", Description: "sqly command argument: ndjson output format"},
-		{Text: "json-typed", Description: "sqly command argument: json output with native scalars"},
-		{Text: "ndjson-typed", Description: "sqly command argument: ndjson output with native scalars"},
+		{Text: outputModeJSONTyped, Description: "sqly command argument: json output with native scalars"},
+		{Text: outputModeNDJSONTyped, Description: "sqly command argument: ndjson output with native scalars"},
 		{Text: "excel", Description: "sqly command argument: excel output format"},
 		{Text: "parquet", Description: "sqly command argument: parquet export format"},
 	}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2300,6 +2300,67 @@ func TestShellExec_TypedJSONModeSwitch(t *testing.T) {
 	}
 }
 
+func TestShell_promptPrefixReflectsTypedJSONMode(t *testing.T) {
+	// The prompt label must distinguish the typed JSON variants from the plain
+	// json/ndjson modes so a typed session is visible at the prompt.
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{name: "json-typed mode shows (json-typed) in prompt", mode: "json-typed", want: "(json-typed)"},
+		{name: "ndjson-typed mode shows (ndjson-typed) in prompt", mode: "ndjson-typed", want: "(ndjson-typed)"},
+		{name: "plain json mode still shows (json) in prompt", mode: "json", want: "(json)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shell, cleanup, err := newShell(t, []string{"sqly"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+
+			if err := shell.state.mode.changeOutputModeIfNeeded(tt.mode); err != nil {
+				t.Fatalf("changeOutputModeIfNeeded(%q): %v", tt.mode, err)
+			}
+			if prefix := shell.promptPrefix(); !strings.Contains(prefix, tt.want) {
+				t.Errorf("promptPrefix() = %q, want it to contain %q", prefix, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandList_modeCommand_listsTypedJSONVariants(t *testing.T) {
+	// `.mode` with no argument prints the current mode and the selectable mode
+	// list. Both must surface the typed JSON variants so the user can discover and
+	// confirm them.
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if err := shell.state.mode.changeOutputModeIfNeeded("json-typed"); err != nil {
+		t.Fatalf("changeOutputModeIfNeeded: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := shell.commands.modeCommand(context.Background(), shell, nil); err != nil {
+			t.Fatalf("modeCommand: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "current mode=json-typed") {
+		t.Errorf("`.mode` banner = %q, want it to contain %q", out, "current mode=json-typed")
+	}
+	if !strings.Contains(out, "json-typed") {
+		t.Errorf("`.mode` list = %q, want it to list json-typed", out)
+	}
+	if !strings.Contains(out, "ndjson-typed") {
+		t.Errorf("`.mode` list = %q, want it to list ndjson-typed", out)
+	}
+}
+
 func TestShellExec_SchemaAndDescribe(t *testing.T) {
 	// Regression for: schema inspection commands over an imported CSV.
 	newImportedShell := func(t *testing.T) (*Shell, func()) {

--- a/shell/testdata/golden/mode_without_arg.golden
+++ b/shell/testdata/golden/mode_without_arg.golden
@@ -8,5 +8,7 @@
   ltsv
   json
   ndjson
+  json-typed ※ json output with native numbers, booleans, and nulls
+  ndjson-typed ※ ndjson output with native numbers, booleans, and nulls
   excel ※ active only when executing .dump, otherwise same as csv mode
   parquet ※ active only when executing .dump, otherwise same as csv mode

--- a/spec/mode_banner_spec.sh
+++ b/spec/mode_banner_spec.sh
@@ -31,4 +31,16 @@ Describe 'sqly .mode banner routing'
     The output should not include 'Change output mode'
     The stderr should include 'Change output mode from table to ndjson'
   End
+
+  It 'reports the typed mode by name and emits typed output after .mode json-typed'
+    Data
+      #|.mode json-typed
+      #|SELECT 7 AS n, 'x' AS s
+    End
+    When run sqly testdata/user.csv
+    The status should be success
+    The stderr should include 'Change output mode from table to json-typed'
+    The output should include '"n":7'
+    The output should include '"s":"x"'
+  End
 End

--- a/spec/mode_banner_spec.sh
+++ b/spec/mode_banner_spec.sh
@@ -39,6 +39,7 @@ Describe 'sqly .mode banner routing'
     End
     When run sqly testdata/user.csv
     The status should be success
+    The output should not include 'Change output mode'
     The stderr should include 'Change output mode from table to json-typed'
     The output should include '"n":7'
     The output should include '"s":"x"'


### PR DESCRIPTION
## Summary

The typed JSON shell modes were only partially wired into the interactive UX: switching to `.mode json-typed`/`.mode ndjson-typed` changed the output contract but the prompt label, the `.mode` current-mode banner, and the `.mode` mode list still showed the plain `json`/`ndjson`. This left the session state misleading even though typed output was active. This PR makes the typed variants visible consistently across the prompt, the banner, and the mode list.

## Changes

- shell/shell.go: build the prompt prefix from `mode.displayName()` instead of `mode.String()` so a typed session shows `(json-typed)`/`(ndjson-typed)`.
- shell/mode.go: print the current mode via `displayName()` in the `.mode` banner and add `json-typed`/`ndjson-typed` to the printed mode list.
- shell/compare.go, shell/shell.go: reuse the existing `outputModeJSONTyped`/`outputModeNDJSONTyped` constants in place of duplicated string literals.
- shell/shell_test.go: add regression tests for the prompt prefix across json-typed/ndjson-typed/json and for the `.mode` banner and list including the typed variants.
- shell/testdata/golden/mode_without_arg.golden: update the `.mode` golden fixture to include the new typed entries.
- spec/mode_banner_spec.sh: add a shellspec case that switches to `.mode json-typed` and verifies both the typed banner text on stderr and typed JSON output.
- CHANGELOG.md, doc/pages/markdown/sqly_helper_command.md: document the fix and update the documented `.mode` list.

## Design Decisions

The `displayName()` helper that distinguishes the typed variants already existed; the bug was that the prompt and `.mode` command still called `String()`. Wiring `displayName()` into those two call sites is the minimal change and keeps the single source of truth for the user-facing mode name. The mode list lines mirror the existing `excel`/`parquet` annotation style so the help output stays uniform.

Closes #595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed JSON output modes to the interactive shell: `json-typed` and `ndjson-typed`.
  * The `.mode` command and mode listing now show these new options and label the current mode more clearly.
  * The shell prompt and mode banner now reflect the active typed mode name.

* **Bug Fixes**
  * Improved consistency in mode-related messages and completions so typed JSON modes are shown correctly throughout the shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->