### PR TITLE
fix(shell): scope .import completion to the typed path prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Prefix-Scoped Import Completion: `.import` tab completion now reads only the directory named by the typed path prefix instead of walking the whole working tree on every keystroke. Directories are offered with a trailing slash so the path can be completed one level at a time, keeping latency proportional to the targeted subtree rather than repository size.
 * Compare Input Order: `--compare` without `--compare-tables` now keeps the left/right direction in the order the inputs were given on the command line, instead of sorting the table names alphabetically.
 * Typed JSON Mode Shell UX: switching to `.mode json-typed`/`.mode ndjson-typed` now shows the typed mode name in the prompt label and the `.mode` current-mode banner instead of the plain `json`/`ndjson`, and `.mode` lists both typed variants.
 * Content-Aware Import Cache Key: `--cache` now keys invalidation on each input file's path, size, and a SHA-256 content hash instead of path, size, and modification time. A source rewritten in place with different but same-length content and its original mtime restored is now detected and the cache rebuilt, so a warm run can no longer return stale rows for a modified file.

--- a/shell/commands_test.go
+++ b/shell/commands_test.go
@@ -381,8 +381,9 @@ func TestShell_getFilePathCompletions_errorHandling(t *testing.T) {
 		}()
 	}
 
-	// Test completion - should work normally
-	completions := shell.getFilePathCompletions(".import ")
+	// Test completion - should work normally. An empty prefix scopes to the
+	// current directory.
+	completions := shell.getFilePathCompletions("")
 
 	if len(completions) == 0 {
 		t.Error("Expected some completions in test directory")
@@ -471,27 +472,36 @@ func TestShell_getFilePathCompletions_edgeCases(t *testing.T) {
 		}()
 	}()
 
-	// Test completion
-	completions := shell.getFilePathCompletions(".import ")
+	// An empty prefix scopes to the current directory: the subdirectory is
+	// offered (so the user can descend) while the hidden directory is skipped.
+	topLevel := shell.getFilePathCompletions("")
+	foundSubdir := false
+	foundHiddenDir := false
+	for _, comp := range topLevel {
+		switch filepath.ToSlash(comp.Text) {
+		case "subdir/":
+			foundSubdir = true
+		case ".hidden/":
+			foundHiddenDir = true
+		}
+	}
+	if !foundSubdir {
+		t.Error("Expected to find subdir/ at the top level")
+	}
+	if foundHiddenDir {
+		t.Error("Should not find .hidden/ directory at the top level")
+	}
 
-	// Should find nested file but not hidden file
+	// Descending into the subdirectory lists its importable files.
+	nested := shell.getFilePathCompletions("subdir/")
 	foundNested := false
-	foundHidden := false
-
-	for _, comp := range completions {
+	for _, comp := range nested {
 		if filepath.ToSlash(comp.Text) == "subdir/nested.csv" {
 			foundNested = true
 		}
-		if filepath.ToSlash(comp.Text) == ".hidden/hidden.csv" {
-			foundHidden = true
-		}
 	}
-
 	if !foundNested {
-		t.Error("Expected to find nested.csv in subdir")
-	}
-	if foundHidden {
-		t.Error("Should not find hidden.csv in .hidden directory")
+		t.Error("Expected to find nested.csv when scoping to subdir/")
 	}
 }
 

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -20,6 +21,117 @@ func hasSuggestionText(suggestions []Suggest, text string) bool {
 		}
 	}
 	return false
+}
+
+// makeTree creates files and directories under the current working directory.
+// A trailing slash marks a directory; everything else is created as an empty file.
+func makeTree(t *testing.T, paths []string) {
+	t.Helper()
+	for _, p := range paths {
+		if strings.HasSuffix(p, "/") {
+			if err := os.MkdirAll(filepath.Clean(p), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.Create(filepath.Clean(p))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func completionTexts(suggestions []Suggest) []string {
+	texts := make([]string, 0, len(suggestions))
+	for _, s := range suggestions {
+		texts = append(texts, s.Text)
+	}
+	return texts
+}
+
+func TestGetFilePathCompletionsScopedToTypedPrefix(t *testing.T) {
+	// Note: cannot use t.Parallel() with t.Chdir().
+	tmpDir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+	t.Cleanup(func() { t.Chdir(orig) })
+
+	makeTree(t, []string{
+		"top.csv",
+		"testdata/actor.csv",
+		"testdata/sample.tsv",
+		"testdata/nested/deep.csv",
+		"other/ignore.csv",
+	})
+
+	tests := []struct {
+		name    string
+		prefix  string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "empty prefix lists only the current directory, not nested files",
+			prefix:  "",
+			want:    []string{"top.csv", "testdata/", "other/"},
+			notWant: []string{"testdata/actor.csv", "testdata/nested/deep.csv"},
+		},
+		{
+			name:    "directory prefix lists entries inside that directory only",
+			prefix:  "testdata/",
+			want:    []string{"testdata/actor.csv", "testdata/sample.tsv", "testdata/nested/"},
+			notWant: []string{"testdata/nested/deep.csv", "top.csv", "other/"},
+		},
+		{
+			name:    "partial filename narrows to matching entries in the directory",
+			prefix:  "testdata/ac",
+			want:    []string{"testdata/actor.csv"},
+			notWant: []string{"testdata/sample.tsv", "testdata/nested/"},
+		},
+		{
+			name:    "partial directory name suggests the directory, not its nested files",
+			prefix:  "testd",
+			want:    []string{"testdata/"},
+			notWant: []string{"testdata/actor.csv", "testdata/nested/deep.csv"},
+		},
+		{
+			name:    "nested directory prefix scopes traversal to that subtree",
+			prefix:  "testdata/nested/",
+			want:    []string{"testdata/nested/deep.csv"},
+			notWant: []string{"testdata/actor.csv", "top.csv"},
+		},
+	}
+
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := completionTexts(shell.getFilePathCompletions(tt.prefix))
+			for _, w := range tt.want {
+				if !slices.Contains(got, w) {
+					t.Errorf("prefix %q: want completion %q, got %v", tt.prefix, w, got)
+				}
+			}
+			for _, nw := range tt.notWant {
+				if slices.Contains(got, nw) {
+					t.Errorf("prefix %q: did not want completion %q, got %v", tt.prefix, nw, got)
+				}
+			}
+		})
+	}
 }
 
 func TestImportCompleterDebug(t *testing.T) {
@@ -65,60 +177,53 @@ func TestImportCompleterDebug(t *testing.T) {
 	}
 	defer shellCleanup()
 
-	// Test different states of completion
+	// Completion is scoped to the directory named by the typed prefix: a bare
+	// ".import" or a partial directory name offers the directory, and only after
+	// descending into it do the files inside appear.
 	testCases := []struct {
-		name              string
-		text              string
-		expectedFilenames []string
+		name     string
+		text     string
+		expected []string
 	}{
 		{
-			name:              "All importable files should be shown",
-			text:              ".import ",
-			expectedFilenames: []string{"testdata/actor.csv", "testdata/sample.csv"},
+			name:     "bare .import offers the top-level directory",
+			text:     ".import ",
+			expected: []string{"testdata/"},
 		},
 		{
-			name:              "All importable files should be shown (any input)",
-			text:              ".import testdata/",
-			expectedFilenames: []string{"testdata/actor.csv", "testdata/sample.csv"},
+			name:     "directory prefix lists the files inside it",
+			text:     ".import testdata/",
+			expected: []string{"testdata/actor.csv", "testdata/sample.csv"},
 		},
 		{
-			name:              "All importable files should be shown (partial input)",
-			text:              ".import testd",
-			expectedFilenames: []string{"testdata/actor.csv", "testdata/sample.csv"},
+			name:     "partial directory name offers the directory",
+			text:     ".import testd",
+			expected: []string{"testdata/"},
 		},
 		{
-			name:              "All importable files should be shown (any path)",
-			text:              ".import testdata",
-			expectedFilenames: []string{"testdata/actor.csv", "testdata/sample.csv"},
+			name:     "directory name without separator offers the directory",
+			text:     ".import testdata",
+			expected: []string{"testdata/"},
 		},
 		{
-			name:              "All importable files should be shown (partial filename)",
-			text:              ".import testdata/a",
-			expectedFilenames: []string{"testdata/actor.csv", "testdata/sample.csv"},
+			name:     "partial filename narrows to the matching file",
+			text:     ".import testdata/a",
+			expected: []string{"testdata/actor.csv"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fileCompletions := shell.getFilePathCompletions(tc.text)
+			completions := shell.getCompletions(context.Background(), tc.text)
 
 			t.Logf("Input: '%s'", tc.text)
-			t.Logf("Completions: %d", len(fileCompletions))
-			for i, c := range fileCompletions {
+			for i, c := range completions {
 				t.Logf("  %d: Text='%s', Desc='%s'", i, c.Text, c.Description)
 			}
 
-			// Verify expected files are present
-			for _, expectedFile := range tc.expectedFilenames {
-				found := false
-				for _, completion := range fileCompletions {
-					if completion.Text == expectedFile {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("Expected completion '%s' not found in results for input '%s'", expectedFile, tc.text)
+			for _, expected := range tc.expected {
+				if !hasSuggestionText(completions, expected) {
+					t.Errorf("Expected completion '%s' not found for input '%s'", expected, tc.text)
 				}
 			}
 		})
@@ -359,84 +464,43 @@ func TestGoPromptCompletionBehavior(t *testing.T) {
 }
 
 func TestRealDirectoryCompletion(t *testing.T) {
-	// Test with actual directory structure using new full-path completion behavior
+	// Exercise scoped completion against the real package directory, which has a
+	// testdata/ subdirectory holding importable sample files.
 
-	// Create a shell instance
 	shell, shellCleanup, shellErr := newShell(t, []string{"sqly"})
 	if shellErr != nil {
 		t.Fatal(shellErr)
 	}
 	defer shellCleanup()
 
-	// Test cases for new full-path completion behavior
-	// All inputs should show the same complete list of importable files
-	testCases := []struct {
-		name               string
-		input              string
-		minExpectedFiles   int      // Minimum number of files expected
-		mustContainSamples []string // Sample files that must be present
-	}{
-		{
-			name:               "All importable files should be shown regardless of input",
-			input:              ".import ",
-			minExpectedFiles:   1,                               // Should find at least some importable files
-			mustContainSamples: []string{"testdata/sample.csv"}, // This file should exist
-		},
-		{
-			name:               "All importable files should be shown with any input",
-			input:              ".import testdata",
-			minExpectedFiles:   1,
-			mustContainSamples: []string{"testdata/sample.csv"},
-		},
-		{
-			name:               "All importable files shown even with non-matching prefix",
-			input:              ".import nonexistent",
-			minExpectedFiles:   1, // Still shows all files
-			mustContainSamples: []string{"testdata/sample.csv"},
-		},
-	}
+	t.Run("bare .import offers the testdata directory, not its files", func(t *testing.T) {
+		got := completionTexts(shell.getFilePathCompletions(""))
+		if !slices.Contains(got, "testdata/") {
+			t.Errorf("expected testdata/ directory in completions, got %v", got)
+		}
+		if slices.Contains(got, "testdata/sample.csv") {
+			t.Errorf("did not expect nested file testdata/sample.csv at the top level, got %v", got)
+		}
+	})
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			completions := shell.getFilePathCompletions(tc.input)
-
-			t.Logf("Input: '%s'", tc.input)
-			t.Logf("Got %d completions:", len(completions))
-			for i, c := range completions {
-				t.Logf("  %d: '%s' - %s", i, c.Text, c.Description)
+	t.Run("descending into testdata lists its importable files", func(t *testing.T) {
+		completions := shell.getFilePathCompletions("testdata/")
+		got := completionTexts(completions)
+		if !slices.Contains(got, "testdata/sample.csv") {
+			t.Errorf("expected testdata/sample.csv in completions, got %v", got)
+		}
+		for _, comp := range completions {
+			if !strings.HasSuffix(comp.Text, "/") && comp.Description != msgImportableFile {
+				t.Errorf("file %q has description %q, want %q", comp.Text, comp.Description, msgImportableFile)
 			}
+		}
+	})
 
-			// Verify minimum number of files
-			if len(completions) < tc.minExpectedFiles {
-				t.Errorf("Expected at least %d completions, got %d", tc.minExpectedFiles, len(completions))
-			}
-
-			// Verify all completions are files with correct description
-			for _, comp := range completions {
-				if comp.Description != "Importable file" {
-					t.Errorf("Expected description 'Importable file', got '%s'", comp.Description)
-				}
-				// Should not be directories (ending with /)
-				if strings.HasSuffix(comp.Text, "/") {
-					t.Errorf("Expected file path but got directory: '%s'", comp.Text)
-				}
-			}
-
-			// Check required sample files are present
-			for _, expectedFile := range tc.mustContainSamples {
-				found := false
-				for _, comp := range completions {
-					if comp.Text == expectedFile {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("Expected to find sample file '%s' in completions", expectedFile)
-				}
-			}
-		})
-	}
+	t.Run("non-matching prefix yields no completions", func(t *testing.T) {
+		if got := shell.getFilePathCompletions("nonexistent"); len(got) != 0 {
+			t.Errorf("expected no completions for non-matching prefix, got %v", completionTexts(got))
+		}
+	})
 }
 
 func TestFilePathCompletions(t *testing.T) {
@@ -497,20 +561,16 @@ func TestFilePathCompletions(t *testing.T) {
 		name     string
 		input    string
 		expected []string
+		excluded []string
 	}{
 		{
-			name:  "All importable files should be shown",
-			input: "",
-			expected: []string{
-				"testdata/sample.csv",
-				"testdata/sample.tsv",
-				"testdata/sample.ltsv",
-				"testdata/sample.xlsx",
-				"testdata/compressed.csv.gz",
-			},
+			name:     "empty prefix lists top-level directories only",
+			input:    "",
+			expected: []string{"testdata/", "docs/"},
+			excluded: []string{"testdata/sample.csv", "config.yaml"},
 		},
 		{
-			name:  "All importable files should be shown (with directory input)",
+			name:  "directory prefix lists importable files inside it",
 			input: "testdata/",
 			expected: []string{
 				"testdata/sample.csv",
@@ -521,74 +581,42 @@ func TestFilePathCompletions(t *testing.T) {
 			},
 		},
 		{
-			name:  "All importable files should be shown (with partial filename)",
+			name:  "partial filename narrows to matching files",
 			input: "testdata/sample",
 			expected: []string{
 				"testdata/sample.csv",
 				"testdata/sample.tsv",
 				"testdata/sample.ltsv",
 				"testdata/sample.xlsx",
-				"testdata/compressed.csv.gz",
 			},
+			excluded: []string{"testdata/compressed.csv.gz"},
 		},
 		{
-			name:  "All importable files should be shown (with partial directory)",
-			input: "test",
-			expected: []string{
-				"testdata/sample.csv",
-				"testdata/sample.tsv",
-				"testdata/sample.ltsv",
-				"testdata/sample.xlsx",
-				"testdata/compressed.csv.gz",
-			},
+			name:     "partial directory name offers the directory only",
+			input:    "test",
+			expected: []string{"testdata/"},
+			excluded: []string{"testdata/sample.csv"},
 		},
 		{
-			name:  "All importable files should be shown (with .import command)",
-			input: ".import testdata/",
-			expected: []string{
-				"testdata/sample.csv",
-				"testdata/sample.tsv",
-				"testdata/sample.ltsv",
-				"testdata/sample.xlsx",
-				"testdata/compressed.csv.gz",
-			},
+			name:     "directory without importable files yields no file suggestions",
+			input:    "docs/",
+			excluded: []string{"docs/readme.md"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			completions := shell.getFilePathCompletions(tt.input)
+			results := completionTexts(shell.getFilePathCompletions(tt.input))
+			t.Logf("Input %q -> %v", tt.input, results)
 
-			// Debug: log what files actually exist
-			entries, err := os.ReadDir(".")
-			if err != nil {
-				t.Logf("Failed to read current directory: %v", err)
-				return
-			}
-			t.Logf("Current directory contents:")
-			for _, entry := range entries {
-				t.Logf("  %s (dir: %v)", entry.Name(), entry.IsDir())
-			}
-
-			if testDataEntries, err := os.ReadDir("testdata"); err == nil {
-				t.Logf("testdata directory contents:")
-				for _, entry := range testDataEntries {
-					t.Logf("  testdata/%s (dir: %v, valid: %v)", entry.Name(), entry.IsDir(), shell.isValidFileForCompletion(entry.Name()))
+			for _, expected := range tt.expected {
+				if !slices.Contains(results, expected) {
+					t.Errorf("Expected completion '%s' not found in results: %v", expected, results)
 				}
 			}
-
-			// Extract completion texts
-			var results []string
-			for _, c := range completions {
-				results = append(results, c.Text)
-			}
-			t.Logf("Got %d completions: %v", len(completions), results)
-
-			// Check if all expected completions are present
-			for _, expected := range tt.expected {
-				found := slices.Contains(results, expected)
-				if !found {
-					t.Errorf("Expected completion '%s' not found in results: %v", expected, results)
+			for _, excluded := range tt.excluded {
+				if slices.Contains(results, excluded) {
+					t.Errorf("Did not expect completion '%s' in results: %v", excluded, results)
 				}
 			}
 		})
@@ -652,63 +680,59 @@ func TestCompleterIntegration(t *testing.T) {
 	defer cleanup()
 
 	testCases := []struct {
-		name             string
-		input            string
-		minExpectedFiles int
-		mustHaveFileType bool // Must contain at least one importable file
+		name     string
+		input    string
+		wantDir  bool // expect at least one directory suggestion
+		wantFile bool // expect at least one importable-file suggestion
+		wantText string
 	}{
 		{
-			name:             "Import command should show all importable files",
-			input:            ".import ",
-			minExpectedFiles: 1,
-			mustHaveFileType: true,
+			name:     "bare .import offers the testdata directory",
+			input:    ".import ",
+			wantDir:  true,
+			wantText: "testdata/",
 		},
 		{
-			name:             "Import with prefix should still show all importable files",
-			input:            ".import testdata",
-			minExpectedFiles: 1,
-			mustHaveFileType: true,
+			name:     "partial directory name offers the directory",
+			input:    ".import testd",
+			wantDir:  true,
+			wantText: "testdata/",
 		},
 		{
-			name:             "Import with any prefix shows all importable files",
-			input:            ".import golden",
-			minExpectedFiles: 1,
-			mustHaveFileType: true,
+			name:     "descending into testdata offers importable files",
+			input:    ".import testdata/",
+			wantFile: true,
+			wantText: "testdata/sample.csv",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Use the new getCompletions method
 			completions := shell.getCompletions(context.Background(), tc.input)
 
 			t.Logf("Input: '%s'", tc.input)
-			t.Logf("Got %d completions:", len(completions))
 			for i, c := range completions {
 				t.Logf("  %d: '%s' - %s", i, c.Text, c.Description)
 			}
 
-			// Verify minimum number of completions
-			if len(completions) < tc.minExpectedFiles {
-				t.Errorf("Expected at least %d completions, got %d", tc.minExpectedFiles, len(completions))
+			if !hasSuggestionText(completions, tc.wantText) {
+				t.Errorf("expected completion %q for input %q", tc.wantText, tc.input)
 			}
 
-			// If we expect importable files, verify they exist
-			if tc.mustHaveFileType {
-				foundImportableFile := false
-				for _, comp := range completions {
-					if comp.Description == "Importable file" {
-						foundImportableFile = true
-						// Verify it's a file path, not directory
-						if strings.HasSuffix(comp.Text, "/") {
-							t.Errorf("Expected file path but got directory: '%s'", comp.Text)
-						}
-						break
-					}
+			hasDir, hasFile := false, false
+			for _, comp := range completions {
+				switch comp.Description {
+				case msgImportableDir:
+					hasDir = true
+				case msgImportableFile:
+					hasFile = true
 				}
-				if !foundImportableFile {
-					t.Error("Expected to find at least one importable file completion")
-				}
+			}
+			if tc.wantDir && !hasDir {
+				t.Error("expected at least one directory suggestion")
+			}
+			if tc.wantFile && !hasFile {
+				t.Error("expected at least one importable file suggestion")
 			}
 		})
 	}
@@ -901,4 +925,47 @@ func TestCompleterEdgeCases(t *testing.T) {
 			// Just verify we got a valid response (len cannot be negative)
 		})
 	}
+}
+
+// BenchmarkGetFilePathCompletions measures completion against a large synthetic
+// directory tree. The fix scopes traversal to the targeted directory, so latency
+// should track that single directory rather than the whole tree. The benchmark
+// compares completing inside one leaf directory against listing the shallow root,
+// making any regression to whole-tree scanning measurable.
+func BenchmarkGetFilePathCompletions(b *testing.B) {
+	b.Chdir(b.TempDir())
+
+	// Build a wide and deep tree: 50 top-level directories, each with 50 files.
+	const dirs, filesPerDir = 50, 50
+	for d := range dirs {
+		dir := filepath.Join("data", "dir"+strconv.Itoa(d))
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			b.Fatal(err)
+		}
+		for f := range filesPerDir {
+			name := filepath.Join(dir, "file"+strconv.Itoa(f)+".csv")
+			if err := os.WriteFile(name, []byte("a\n"), 0o600); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	shell, cleanup, err := newShell(b, []string{"sqly"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+
+	leaf := filepath.ToSlash(filepath.Join("data", "dir25")) + "/"
+
+	b.Run("leaf directory", func(b *testing.B) {
+		for b.Loop() {
+			_ = shell.getFilePathCompletions(leaf)
+		}
+	})
+	b.Run("root directory", func(b *testing.B) {
+		for b.Loop() {
+			_ = shell.getFilePathCompletions("")
+		}
+	})
 }

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -109,6 +109,14 @@ func TestGetFilePathCompletionsScopedToTypedPrefix(t *testing.T) {
 			want:    []string{"testdata/nested/deep.csv"},
 			notWant: []string{"testdata/actor.csv", "top.csv"},
 		},
+		{
+			// The directory must resolve even though the prefix uses a backslash;
+			// suggestions keep the separator the user typed.
+			name:    "backslash separator resolves the directory on every OS",
+			prefix:  `testdata\`,
+			want:    []string{"testdata/actor.csv", "testdata/sample.tsv"},
+			notWant: []string{"top.csv"},
+		},
 	}
 
 	shell, cleanup, err := newShell(t, []string{"sqly"})
@@ -117,16 +125,23 @@ func TestGetFilePathCompletionsScopedToTypedPrefix(t *testing.T) {
 	}
 	defer cleanup()
 
+	// slash normalizes separators so the backslash case asserts the same way on
+	// every OS (filepath.ToSlash rewrites "\" to "/" only on Windows).
+	slash := func(s string) string { return strings.ReplaceAll(s, `\`, "/") }
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := completionTexts(shell.getFilePathCompletions(tt.prefix))
+			var got []string
+			for _, text := range completionTexts(shell.getFilePathCompletions(tt.prefix)) {
+				got = append(got, slash(text))
+			}
 			for _, w := range tt.want {
-				if !slices.Contains(got, w) {
+				if !slices.Contains(got, slash(w)) {
 					t.Errorf("prefix %q: want completion %q, got %v", tt.prefix, w, got)
 				}
 			}
 			for _, nw := range tt.notWant {
-				if slices.Contains(got, nw) {
+				if slices.Contains(got, slash(nw)) {
 					t.Errorf("prefix %q: did not want completion %q, got %v", tt.prefix, nw, got)
 				}
 			}

--- a/shell/feature_property_test.go
+++ b/shell/feature_property_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"testing/quick"
 
@@ -196,4 +197,33 @@ func equalStringSet(a, b []string) bool {
 	sort.Strings(as)
 	sort.Strings(bs)
 	return reflect.DeepEqual(as, bs)
+}
+
+// TestSplitCompletionPrefixProperties checks the invariants splitCompletionPrefix
+// must hold for any typed prefix: the kept base concatenated with the partial
+// reconstructs the input exactly, the partial never spans a directory separator,
+// and the base is either empty or ends on a separator. These guarantee that
+// suggestions built as base+name preserve precisely what the user typed.
+func TestSplitCompletionPrefixProperties(t *testing.T) {
+	t.Parallel()
+
+	property := func(prefix string) bool {
+		readDir, base, partial := splitCompletionPrefix(prefix)
+
+		if base+partial != prefix {
+			return false
+		}
+		if strings.ContainsAny(partial, `/\`) {
+			return false
+		}
+		if base != "" && !strings.HasSuffix(base, "/") && !strings.HasSuffix(base, `\`) {
+			return false
+		}
+		// readDir is the base when present, otherwise the current directory or
+		// the filesystem root for a lone leading separator; it is never empty.
+		return readDir != ""
+	}
+	if err := quick.Check(property, featureQuickConfig()); err != nil {
+		t.Error(err)
+	}
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,6 +45,7 @@ const (
 	saveCommand     = ".save"
 
 	msgImportableFile = "Importable file"
+	msgImportableDir  = "Directory"
 )
 
 // Shell is main class of the sqly command.
@@ -934,37 +934,66 @@ func (s *Shell) isValidFileForCompletion(filename string) bool {
 	return s.usecases.importer.IsSupportedFile(filename)
 }
 
-// getFilePathCompletions returns file path completions for importable files (recursive)
-func (s *Shell) getFilePathCompletions(_ string) []Suggest {
+// splitCompletionPrefix splits a typed path prefix into the directory to scan,
+// the leading text to keep on each suggestion (so completions preserve exactly
+// what the user typed), and the partial entry name to match.
+//
+// It accepts both "/" and "\" as separators so completion behaves the same on
+// every OS. Examples (POSIX): "" -> ".", "", ""; "testdata/sa" -> "testdata/",
+// "testdata/", "sa"; "testdata" -> ".", "", "testdata".
+func splitCompletionPrefix(prefix string) (readDir, base, partial string) {
+	idx := strings.LastIndexAny(prefix, `/\`)
+	if idx < 0 {
+		return ".", "", prefix
+	}
+	base = prefix[:idx+1]
+	partial = prefix[idx+1:]
+	readDir = base
+	if readDir == "" {
+		// A leading separator ("/foo") leaves base empty; scan the filesystem root.
+		readDir = string(os.PathSeparator)
+	}
+	return readDir, base, partial
+}
+
+// getFilePathCompletions returns importable-file and directory suggestions
+// scoped to the directory named by prefix. It reads only that directory rather
+// than walking the whole working tree, so latency tracks the targeted subtree,
+// not repository size. Directories are suggested with a trailing slash so the
+// user can descend one level at a time, the same way a shell completes paths.
+// Hidden entries are skipped unless the user types a leading dot.
+func (s *Shell) getFilePathCompletions(prefix string) []Suggest {
+	readDir, base, partial := splitCompletionPrefix(prefix)
+
+	entries, err := os.ReadDir(readDir)
+	if err != nil {
+		return nil
+	}
+
+	includeHidden := strings.HasPrefix(partial, ".")
 	var suggestions []Suggest
-
-	// Walk the current directory tree to find all importable files
-	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err // Return error to stop walking
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") && !includeHidden {
+			continue
+		}
+		if !strings.HasPrefix(name, partial) {
+			continue
 		}
 
-		// Skip hidden directories and files (unless explicitly requested)
-		// But don't skip the current directory "."
-		if strings.HasPrefix(d.Name(), ".") && d.Name() != "." {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		// For files, check if they are importable
-		if !d.IsDir() && s.isValidFileForCompletion(d.Name()) {
+		if entry.IsDir() {
 			suggestions = append(suggestions, Suggest{
-				Text:        filepath.ToSlash(path),
+				Text:        filepath.ToSlash(base + name + "/"),
+				Description: msgImportableDir,
+			})
+			continue
+		}
+		if s.isValidFileForCompletion(name) {
+			suggestions = append(suggestions, Suggest{
+				Text:        filepath.ToSlash(base + name),
 				Description: msgImportableFile,
 			})
 		}
-
-		return nil
-	})
-	if err != nil {
-		return nil
 	}
 	return suggestions
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -965,6 +965,12 @@ func splitCompletionPrefix(prefix string) (readDir, base, partial string) {
 func (s *Shell) getFilePathCompletions(prefix string) []Suggest {
 	readDir, base, partial := splitCompletionPrefix(prefix)
 
+	// splitCompletionPrefix accepts both separators so Windows paths work, but
+	// the raw readDir may still carry a backslash on POSIX (e.g. "testdata\").
+	// Convert it to the local separator so os.ReadDir resolves the real directory
+	// instead of silently failing on a literal name.
+	readDir = filepath.FromSlash(strings.ReplaceAll(readDir, `\`, "/"))
+
 	entries, err := os.ReadDir(readDir)
 	if err != nil {
 		return nil

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1070,8 +1070,8 @@ func TestShellExec(t *testing.T) {
 	})
 }
 
-func newShell(t *testing.T, args []string) (*Shell, func(), error) {
-	t.Helper()
+func newShell(tb testing.TB, args []string) (*Shell, func(), error) {
+	tb.Helper()
 	arg, err := config.NewArg(args)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

`.import` tab completion walked the entire working tree with `filepath.WalkDir(".")` on every keystroke and ignored the typed prefix, so completion latency scaled with repository size rather than with the subtree the user was targeting. This change scopes traversal to the directory named by the typed prefix.

## Changes

- `shell/shell.go`: rewrite `getFilePathCompletions` to read only the directory named by the typed prefix via `os.ReadDir` instead of recursively walking `.`. Add `splitCompletionPrefix` to split a typed prefix into the directory to scan, the leading text to keep on each suggestion, and the partial name to match. Subdirectories are now offered with a trailing slash (new `msgImportableDir` description) so the path completes one level at a time, the same way a shell completes paths. Hidden entries are skipped unless the user types a leading dot.
- `shell/completion_test.go`: add `TestGetFilePathCompletionsScopedToTypedPrefix` asserting non-recursive, prefix-scoped behavior, add `BenchmarkGetFilePathCompletions` against a large synthetic tree, and update the existing completion tests that encoded the old recursive "show every file" behavior.
- `shell/feature_property_test.go`: add `TestSplitCompletionPrefixProperties`, a property-based check that base+partial reconstructs the input, the partial never spans a separator, and the kept base ends on a separator.
- `shell/commands_test.go`: update the completion edge-case tests to the new scoped behavior.
- `shell/shell_test.go`: widen `newShell` to accept `testing.TB` so the benchmark can build a shell.
- `CHANGELOG.md`: add an Unreleased Bug Fixes entry.

## Design Decisions

Completion now follows the standard shell model: each invocation lists a single directory level and offers subdirectories so the user descends one level at a time. The suggestion `Text` keeps the exact prefix the user typed, which matches how the prompt library applies a completion (`strings.HasPrefix(suggestion.Text, wordBeforeCursor)`), so a full-path suggestion still completes correctly. This intentionally replaces the previous behavior of recursively listing every importable file under the working tree on every keystroke, which was the source of the latency problem and is what the issue asked to remove.

Completion is reached only through the interactive prompt callback; there is no batch or CLI flag path to it (a piped stdin runs in batch mode where the completer never runs), so the behavior is covered by Go tests at the `getCompletions` callback level rather than by a shellspec integration test.

Closes #597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-path completion so suggestions are limited to the directory implied by what you’ve typed, making completions faster and more relevant.
  * Directory suggestions now appear with trailing slashes, and hidden items are only shown when you start typing a hidden name.
  * Completion behavior for nested paths is more accurate, including better handling of partial directory names and platform-specific separators.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->