### PR TITLE
fix(config): make InitSQLite3 idempotent with a package-level sync.Once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Idempotent SQLite Driver Registration: `config.InitSQLite3()` now guards driver registration with a package-level `sync.Once` instead of a function-local one, so calling it more than once no longer panics with `sql: Register called twice for driver sqlite3`.
 * Prefix-Scoped Import Completion: `.import` tab completion now reads only the directory named by the typed path prefix instead of walking the whole working tree on every keystroke. Directories are offered with a trailing slash so the path can be completed one level at a time, keeping latency proportional to the targeted subtree rather than repository size.
 * Compare Input Order: `--compare` without `--compare-tables` now keeps the left/right direction in the order the inputs were given on the command line, instead of sorting the table names alphabetically.
 * Typed JSON Mode Shell UX: switching to `.mode json-typed`/`.mode ndjson-typed` now shows the typed mode name in the prompt label and the `.mode` current-mode banner instead of the plain `json`/`ndjson`, and `.mode` lists both typed variants.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,6 +49,19 @@ func isDir(t *testing.T, path string) bool {
 	return info.IsDir()
 }
 
+func TestInitSQLite3Idempotent(t *testing.T) {
+	// Registering the sqlite3 driver more than once must not panic with
+	// "sql: Register called twice". The driver registry is process-global, so
+	// this cannot run in parallel with code that registers drivers.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("InitSQLite3 panicked when called repeatedly: %v", r)
+		}
+	}()
+	InitSQLite3()
+	InitSQLite3()
+}
+
 func TestIsInputFromTTY(t *testing.T) {
 	// Under `go test` stdin is not a terminal, so this must report false and,
 	// most importantly, never panic. This guards the non-TTY batch-mode switch.

--- a/config/db.go
+++ b/config/db.go
@@ -56,10 +56,14 @@ func NewInMemHistoryDB() (HistoryDB, func(), error) {
 	return HistoryDB(db), func() { _ = db.Close() }, nil // #nosec G104
 }
 
-// InitSQLite3 registers the sqlite3 driver.
+// sqlite3RegisterOnce is package-level rather than function-local so repeated
+// InitSQLite3 calls register the sqlite3 driver exactly once; database/sql
+// panics with "Register called twice" otherwise.
+var sqlite3RegisterOnce sync.Once
+
+// InitSQLite3 registers the sqlite3 driver. It is safe to call multiple times.
 func InitSQLite3() {
-	var once sync.Once
-	once.Do(func() {
+	sqlite3RegisterOnce.Do(func() {
 		sql.Register("sqlite3", sqliteDriver{Driver: &sqlite.Driver{}})
 	})
 }


### PR DESCRIPTION
## Summary

`config.InitSQLite3()` was not idempotent: a second call panicked with `sql: Register called twice for driver sqlite3`. The `sync.Once` guarding driver registration was declared as a function-local variable, so a fresh `Once` was created on every call and the registration ran again. This made the helper fragile in tests and in any library-style reuse.

## Changes

- `config/db.go`: hoist the registration guard to a package-level `sqlite3RegisterOnce sync.Once` so `InitSQLite3` registers the driver exactly once across repeated calls.
- `config/config_test.go`: add `TestInitSQLite3Idempotent`, which calls `InitSQLite3()` twice and fails if it panics.
- `CHANGELOG.md`: add an Unreleased Bug Fixes entry.

## Design Decisions

A package-level `sync.Once` is the idiomatic guard for one-time driver registration: it is race-free and registers exactly once regardless of how many times `InitSQLite3` is called. An alternative of scanning `sql.Drivers()` before registering was rejected because it has a time-of-check/time-of-use race under concurrent calls and is less clear than `Once`.

This change has no CLI or shell-visible behavior; it only removes a panic on repeated/library-style use, so it is covered by a Go unit test rather than a shellspec integration test.

Closes #602