### PR TITLE
feat(shell): buffer multi-line SQL until a complete statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Multi-line Interactive SQL: the shell now buffers a SQL statement across lines and submits on Enter only when it ends with `;`, so a typed or pasted multi-line statement (for example `SELECT ... UNION ALL SELECT ...;`) runs once instead of executing each line separately. Dot-commands stay single-line, and pressing Enter on a blank line force-runs a query typed without `;`.
 * Idempotent SQLite Driver Registration: `config.InitSQLite3()` now guards driver registration with a package-level `sync.Once` instead of a function-local one, so calling it more than once no longer panics with `sql: Register called twice for driver sqlite3`.
 * Prefix-Scoped Import Completion: `.import` tab completion now reads only the directory named by the typed path prefix instead of walking the whole working tree on every keystroke. Directories are offered with a trailing slash so the path can be completed one level at a time, keeping latency proportional to the targeted subtree rather than repository size.
 * Compare Input Order: `--compare` without `--compare-tables` now keeps the left/right direction in the order the inputs were given on the command line, instead of sorting the table names alphabetically.
@@ -10,6 +11,9 @@
 * Content-Aware Import Cache Key: `--cache` now keys invalidation on each input file's path, size, and a SHA-256 content hash instead of path, size, and modification time. A source rewritten in place with different but same-length content and its original mtime restored is now detected and the cache rebuilt, so a warm run can no longer return stale rows for a modified file.
 * Clean Ctrl-D Exit: pressing Ctrl-D (EOF) in the interactive shell now exits cleanly like `.exit` instead of printing a raw `EOF` line. Both EOF spellings the prompt library reports (Ctrl-D on an empty line and a closed input stream) are treated as a normal termination.
 * Symlink-Resolved System-Path Guard: import path validation now rejects a symlink whose canonical target is a blocked system location (such as a link to `/etc/hosts`), not only a directly typed system path. It also normalizes the macOS `/private` prefix, while standard Unix pseudo-files (`/dev/stdin`, `/proc/self/fd/*`) keep importing.
+
+### Dependencies
+* Prompt: upgrade `github.com/nao1215/prompt` to v0.0.6 for the `WithIsComplete` multiline submit predicate that powers multi-line SQL buffering.
 
 ## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0) (2026-06-06)
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ $ sqly --sql "SELECT p.name, p.price, s.quantity, ROUND(p.price * s.quantity, 2)
 
 Run `sqly` without `--sql` to open the shell. It behaves like `sqlite3` or `mysql`: type SQL, or a helper command that begins with a dot. Tab completes keywords and table names, and history is kept across sessions.
 
+A SQL statement is buffered until it ends with `;`, so a multi-line or pasted query runs as one statement instead of executing each line. Dot-commands are single-line and run on Enter. To run a query without typing `;`, press Enter on a blank line.
+
 ![shell demo](./doc/img/shell-demo.gif)
 
 ```shell

--- a/doc/pages/markdown/sqly_shell.md
+++ b/doc/pages/markdown/sqly_shell.md
@@ -39,6 +39,26 @@ actor:Morgan Freeman    best_movie:The Dark Knight
 ```
 
 
+### Multi-line SQL input
+
+The sqly shell buffers a SQL statement across lines so a multi-line or pasted
+query runs as one statement. Enter submits when the statement ends with `;`;
+otherwise the newline continues the statement. A line beginning with a dot
+(`.tables`, `.import`, ...) is a single-line command and runs on Enter. To run a
+query without typing `;`, press Enter on a blank continuation line.
+
+```shell
+sqly:~/github/github.com/nao1215/sqly(table)$  SELECT actor
+                                               FROM actor
+                                               ORDER BY actor
+                                               LIMIT 1;
++---------------+
+|     actor     |
++---------------+
+| Harrison Ford |
++---------------+
+```
+
 ### Key Binding for sqly-shell
 
 |Key Binding	|Description|

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/nao1215/filesql v0.14.0
-	github.com/nao1215/prompt v0.0.5
+	github.com/nao1215/prompt v0.0.6
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/nao1215/filesql v0.14.0 h1:nPemOKx2jhcYXFoNGtvTwT7uipj/Bn0bOYZNOuaPhg
 github.com/nao1215/filesql v0.14.0/go.mod h1:3KmrO1UA7rBQZGBiKXwwXf9fH/13Vx4J0Q5nBR/GF/0=
 github.com/nao1215/prompt v0.0.5 h1:W3B7rgrotlpxheJW9IMYTbfNZCXNm1lEHx1Gu8rpMzw=
 github.com/nao1215/prompt v0.0.5/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
+github.com/nao1215/prompt v0.0.6 h1:MctFKsn+DILf8DTwRlLtzRjNeVx5EOyLE8IDp3XGQzw=
+github.com/nao1215/prompt v0.0.6/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,6 @@ github.com/nao1215/fileparser v0.5.2 h1:IXhH5m3UJf/TMidfTcVen8CSlZ4KEFEgBz6+2o+5
 github.com/nao1215/fileparser v0.5.2/go.mod h1:Jb16QbtYfgzQ2BR+UOVNSa1WeKMP2o+xnwBYFUNAG2Y=
 github.com/nao1215/filesql v0.14.0 h1:nPemOKx2jhcYXFoNGtvTwT7uipj/Bn0bOYZNOuaPhgw=
 github.com/nao1215/filesql v0.14.0/go.mod h1:3KmrO1UA7rBQZGBiKXwwXf9fH/13Vx4J0Q5nBR/GF/0=
-github.com/nao1215/prompt v0.0.5 h1:W3B7rgrotlpxheJW9IMYTbfNZCXNm1lEHx1Gu8rpMzw=
-github.com/nao1215/prompt v0.0.5/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/nao1215/prompt v0.0.6 h1:MctFKsn+DILf8DTwRlLtzRjNeVx5EOyLE8IDp3XGQzw=
 github.com/nao1215/prompt v0.0.6/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/shell/feature_property_test.go
+++ b/shell/feature_property_test.go
@@ -227,3 +227,37 @@ func TestSplitCompletionPrefixProperties(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// TestSQLInputCompleteProperties checks the invariants of the interactive
+// multiline submit predicate: a ";"-terminated statement is always complete, a
+// blank continuation line always force-submits, and a bare single-line query
+// (no ";", not a dot-command) is never treated as complete on its own.
+func TestSQLInputCompleteProperties(t *testing.T) {
+	t.Parallel()
+
+	terminated := func(body string, trailing uint8) bool {
+		in := body + ";" + strings.Repeat(" ", int(trailing%4))
+		return sqlInputComplete(in)
+	}
+	if err := quick.Check(terminated, featureQuickConfig()); err != nil {
+		t.Errorf("semicolon-terminated input must be complete: %v", err)
+	}
+
+	blankLineSubmits := func(body string) bool {
+		return sqlInputComplete(body + "\n")
+	}
+	if err := quick.Check(blankLineSubmits, featureQuickConfig()); err != nil {
+		t.Errorf("blank continuation line must force submit: %v", err)
+	}
+
+	bareSingleLineContinues := func(word string) bool {
+		w := strings.TrimSpace(strings.NewReplacer("\n", "", ";", "").Replace(word))
+		if w == "" || strings.HasPrefix(w, ".") {
+			return true // empty and dot-commands are complete by design
+		}
+		return !sqlInputComplete(w)
+	}
+	if err := quick.Check(bareSingleLineContinues, featureQuickConfig()); err != nil {
+		t.Errorf("bare single-line query must continue, not submit: %v", err)
+	}
+}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -132,6 +132,7 @@ func NewShell(
 				prompt.WithMemoryHistory(historySize),
 				prompt.WithTheme(prompt.ThemeNightOwl),
 				prompt.WithMultiline(true),
+				prompt.WithIsComplete(sqlInputComplete),
 			)
 		},
 		stdin:          os.Stdin,
@@ -539,6 +540,35 @@ func (s *Shell) prompt(p promptSession) (string, error) {
 
 func (s *Shell) promptPrefix() string {
 	return fmt.Sprintf("sqly:%s(%s)$ ", s.state.shortCWD(), s.state.mode.displayName())
+}
+
+// sqlInputComplete reports whether the interactive buffer holds a statement
+// ready to run, so the prompt submits on Enter instead of continuing on a new
+// line. Without this, every newline submits, splitting a pasted or typed
+// multi-line statement into separate executions.
+//
+// SQL is complete when it ends with ";". A dot-command (".tables", ".import",
+// ...) and an empty buffer also submit. Pressing Enter on a blank continuation
+// line force-submits whatever is buffered, so a query typed without a trailing
+// ";" still runs without forcing the user to add one.
+func sqlInputComplete(input string) bool {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return true
+	}
+	if strings.HasPrefix(trimmed, ".") {
+		return true
+	}
+	if strings.HasSuffix(trimmed, ";") {
+		return true
+	}
+	// The current line is the text after the last newline. When it is blank the
+	// user pressed Enter on an empty continuation line, which force-submits.
+	lastLine := input
+	if i := strings.LastIndexByte(input, '\n'); i >= 0 {
+		lastLine = input[i+1:]
+	}
+	return strings.TrimSpace(lastLine) == ""
 }
 
 // Suggest is a local struct to maintain compatibility with old code structure

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -3804,3 +3804,35 @@ func TestRunDirectSQLAllowsSingleStatementWithTrailingSemicolon(t *testing.T) {
 		t.Fatalf("single statement with trailing semicolon should run, got: %v", runErr)
 	}
 }
+
+func TestSQLInputComplete(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty buffer submits", "", true},
+		{"whitespace-only buffer submits", "   \n\t", true},
+		{"dot command submits on enter", ".tables", true},
+		{"single statement without terminator continues", "SELECT 1", false},
+		{"statement ending with semicolon submits", "SELECT 1;", true},
+		{"semicolon after trailing spaces submits", "SELECT 1;   ", true},
+		{"first line of multiline statement continues", "SELECT 1", false},
+		{"middle line of multiline statement continues", "SELECT 1\nUNION ALL", false},
+		{"multiline statement terminated by semicolon submits", "SELECT 1\nUNION ALL\nSELECT 2;", true},
+		{"blank continuation line force-submits buffered query", "SELECT 1\n", true},
+		{"blank continuation line with spaces force-submits", "SELECT 1\n   ", true},
+		{"open paren without terminator continues", "SELECT * FROM (", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sqlInputComplete(tt.input); got != tt.want {
+				t.Errorf("sqlInputComplete(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/spec/batch_spec.sh
+++ b/spec/batch_spec.sh
@@ -71,6 +71,21 @@ Describe 'sqly batch mode (piped stdin)'
       The output should include 'booker12'
     End
 
+    It 'runs a multiline UNION ALL across bare newlines as one statement'
+      Data
+        #|.mode csv
+        #|SELECT 1 AS n
+        #|UNION ALL
+        #|SELECT 2;
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The line 1 should equal 'n'
+      The line 2 should equal '1'
+      The line 3 should equal '2'
+      The stderr should include 'Change output mode'
+    End
+
     It 'runs a multiline WITH (CTE) query'
       Data
         #|WITH x AS (


### PR DESCRIPTION
## Summary

In the interactive shell a bare newline always submitted, so a typed or pasted multi-line SQL statement ran each line on its own. For example `SELECT 1` / `UNION ALL` / `SELECT 2;` executed as three separate statements, two of them syntax errors. The shell now buffers a statement until it is complete and runs it once.

## Changes

- `shell/shell.go`: add `sqlInputComplete`, a predicate that reports whether the buffer is ready to run, and pass it to the prompt via the new `prompt.WithIsComplete` option. A statement is complete when it ends with `;`; a dot-command or an empty buffer also submits, and pressing Enter on a blank continuation line force-submits a query typed without `;`.
- `go.mod`: upgrade `github.com/nao1215/prompt` to v0.0.6, which adds the `WithIsComplete` multiline submit predicate.
- `shell/shell_test.go`, `shell/feature_property_test.go`: table tests and property tests for the predicate (semicolon terminates, blank line force-submits, a bare single-line query continues).
- `spec/batch_spec.sh`: a binary-level case asserting a piped multi-line `UNION ALL` runs as one statement.
- `README.md`, `doc/pages/markdown/sqly_shell.md`, `CHANGELOG.md`: document the multi-line submit contract.

## Design Decisions

The completeness rule lives in sqly, not the prompt library: the library calls back with the whole buffer and sqly decides, keeping the library SQL-agnostic. The contract matches standard SQL REPLs (`;` terminates) while keeping the no-semicolon habit usable through a blank-line force-submit, so the default interaction stays predictable for both typed and pasted SQL. Backslash continuation and bracketed paste in the prompt library are unaffected.

The interactive submit path needs a TTY in raw mode, which shellspec (piped stdin, batch mode) cannot drive, so it is covered by the prompt library's mock-terminal test plus the sqly predicate unit and property tests. The shellspec case covers the user-visible batch path, which already buffered multi-line statements.

Closes #604