### PR TITLE
fix(shell): descend into space-containing directories in .import completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Idempotent SQLite Driver Registration: `config.InitSQLite3()` now guards driver registration with a package-level `sync.Once` instead of a function-local one, so calling it more than once no longer panics with `sql: Register called twice for driver sqlite3`.
 * Prefix-Scoped Import Completion: `.import` tab completion now reads only the directory named by the typed path prefix instead of walking the whole working tree on every keystroke. Directories are offered with a trailing slash so the path can be completed one level at a time, keeping latency proportional to the targeted subtree rather than repository size.
 * Space-Safe Import Completion: `.import` tab completion now backslash-escapes spaces and shell-special characters, so accepting a path like `my data.csv` inserts `my\ data.csv` and reaches `.import` as a single argument. Escaping (not quoting) is used so the suggestion still prefix-matches the typed word.
+* Completion Into Space-Containing Directories: `.import` tab completion now descends into a directory whose name contains a space. The escaped prefix (for example `my\ dir/`) is decoded to read the real directory while the escaped form is kept on each suggestion, so nested files complete and still round-trip through the command parser.
 * Compare Input Order: `--compare` without `--compare-tables` now keeps the left/right direction in the order the inputs were given on the command line, instead of sorting the table names alphabetically.
 * Typed JSON Mode Shell UX: switching to `.mode json-typed`/`.mode ndjson-typed` now shows the typed mode name in the prompt label and the `.mode` current-mode banner instead of the plain `json`/`ndjson`, and `.mode` lists both typed variants.
 * Content-Aware Import Cache Key: `--cache` now keys invalidation on each input file's path, size, and a SHA-256 content hash instead of path, size, and modification time. A source rewritten in place with different but same-length content and its original mtime restored is now detected and the cache rebuilt, so a warm run can no longer return stale rows for a modified file.
@@ -14,7 +15,7 @@
 * Symlink-Resolved System-Path Guard: import path validation now rejects a symlink whose canonical target is a blocked system location (such as a link to `/etc/hosts`), not only a directly typed system path. It also normalizes the macOS `/private` prefix, while standard Unix pseudo-files (`/dev/stdin`, `/proc/self/fd/*`) keep importing.
 
 ### Dependencies
-* Prompt: upgrade `github.com/nao1215/prompt` to v0.0.6 for the `WithIsComplete` multiline submit predicate that powers multi-line SQL buffering.
+* Prompt: upgrade `github.com/nao1215/prompt` to v0.0.7 for the `WithIsComplete` multiline submit predicate and the `WithWordEscape` option that lets completion treat backslash-escaped whitespace as part of a word.
 
 ## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0) (2026-06-06)
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/nao1215/filesql v0.14.0
-	github.com/nao1215/prompt v0.0.6
+	github.com/nao1215/prompt v0.0.7
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/nao1215/fileparser v0.5.2 h1:IXhH5m3UJf/TMidfTcVen8CSlZ4KEFEgBz6+2o+5
 github.com/nao1215/fileparser v0.5.2/go.mod h1:Jb16QbtYfgzQ2BR+UOVNSa1WeKMP2o+xnwBYFUNAG2Y=
 github.com/nao1215/filesql v0.14.0 h1:nPemOKx2jhcYXFoNGtvTwT7uipj/Bn0bOYZNOuaPhgw=
 github.com/nao1215/filesql v0.14.0/go.mod h1:3KmrO1UA7rBQZGBiKXwwXf9fH/13Vx4J0Q5nBR/GF/0=
-github.com/nao1215/prompt v0.0.6 h1:MctFKsn+DILf8DTwRlLtzRjNeVx5EOyLE8IDp3XGQzw=
-github.com/nao1215/prompt v0.0.6/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
+github.com/nao1215/prompt v0.0.7 h1:lpHrVXz3dIxMIKX0gtNghNWM85jG2PLWdK7Jlt8kIVM=
+github.com/nao1215/prompt v0.0.7/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -232,6 +232,58 @@ func TestCompletionEscapesSpaceContainingPaths(t *testing.T) {
 	})
 }
 
+func TestCompletionDescendsIntoSpaceContainingDirectory(t *testing.T) {
+	// Note: cannot use t.Parallel() with t.Chdir().
+	tmpDir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+	t.Cleanup(func() { t.Chdir(orig) })
+
+	makeTree(t, []string{
+		"my dir/inner file.csv",
+		"my dir/plain.csv",
+	})
+
+	shell, cleanup, shellErr := newShell(t, []string{"sqly"})
+	if shellErr != nil {
+		t.Fatal(shellErr)
+	}
+	defer cleanup()
+
+	// After accepting "my\ dir/", the buffer holds an escaped prefix. Completion
+	// must decode it to read the real "my dir/" directory while keeping the escaped
+	// base on the suggestion so it round-trips through splitArgs.
+	roundTrips := func(t *testing.T, suggestions []Suggest, wantPath string) {
+		t.Helper()
+		for _, s := range suggestions {
+			argv, err := splitArgs(".import " + s.Text)
+			if err == nil && len(argv) == 2 && argv[1] == wantPath {
+				return
+			}
+		}
+		t.Fatalf("no completion round-trips to %q; got %v", wantPath, completionTexts(suggestions))
+	}
+
+	t.Run("listing an escaped space directory yields its files", func(t *testing.T) {
+		got := shell.getFilePathCompletions(`my\ dir/`)
+		roundTrips(t, got, "my dir/inner file.csv")
+		roundTrips(t, got, "my dir/plain.csv")
+	})
+
+	t.Run("partial inside an escaped space directory narrows to the match", func(t *testing.T) {
+		got := shell.getFilePathCompletions(`my\ dir/in`)
+		roundTrips(t, got, "my dir/inner file.csv")
+	})
+
+	t.Run("import completer descends into an escaped space directory", func(t *testing.T) {
+		got := shell.getCompletions(context.Background(), `.import my\ dir/in`)
+		roundTrips(t, got, "my dir/inner file.csv")
+	})
+}
+
 func TestImportCompleterDebug(t *testing.T) {
 	// Test the actual completer function behavior for .import commands
 	tmpDir := t.TempDir()

--- a/shell/parse_property_test.go
+++ b/shell/parse_property_test.go
@@ -100,6 +100,48 @@ func TestEscapeCompletionPath_RoundTripProperty(t *testing.T) {
 	}
 }
 
+// TestUnescapeCompletionPath_InvertsEscapeProperty asserts the metamorphic
+// relation unescapeCompletionPath(escapeCompletionPath(name)) == name, so the
+// completion code can escape a name for display and decode it for filesystem
+// lookups without drift.
+func TestUnescapeCompletionPath_InvertsEscapeProperty(t *testing.T) {
+	property := func(name pathName) bool {
+		return unescapeCompletionPath(escapeCompletionPath(string(name))) == string(name)
+	}
+	if err := quick.Check(property, shellQuickConfig()); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestSplitCompletionPrefix_SplitsAtRealSeparator asserts that an escaped space
+// before a "/" does not fool the splitter into cutting at the escaping backslash:
+// the base keeps the escaped directory and the partial is the entry fragment.
+func TestSplitCompletionPrefix_SplitsAtRealSeparator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		prefix      string
+		wantBase    string
+		wantPartial string
+	}{
+		{name: "escaped space then slash splits at the slash", prefix: `my\ dir/in`, wantBase: `my\ dir/`, wantPartial: "in"},
+		{name: "escaped space without a slash is one partial", prefix: `my\ dir`, wantBase: "", wantPartial: `my\ dir`},
+		{name: "plain nested path splits at the slash", prefix: "testdata/ac", wantBase: "testdata/", wantPartial: "ac"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, base, partial := splitCompletionPrefix(tt.prefix)
+			if base != tt.wantBase || partial != tt.wantPartial {
+				t.Errorf("splitCompletionPrefix(%q) = base %q, partial %q; want base %q, partial %q",
+					tt.prefix, base, partial, tt.wantBase, tt.wantPartial)
+			}
+		})
+	}
+}
+
 // TestSplitArgs_NeverPanicsProperty asserts splitArgs returns (slice,nil) or
 // (nil,err) for arbitrary input without panicking. Robustness guard for the
 // tokenizer against untrusted shell input.

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -133,6 +133,7 @@ func NewShell(
 				prompt.WithTheme(prompt.ThemeNightOwl),
 				prompt.WithMultiline(true),
 				prompt.WithIsComplete(sqlInputComplete),
+				prompt.WithWordEscape(),
 			)
 		},
 		stdin:          os.Stdin,
@@ -596,14 +597,11 @@ func (s *Shell) completerNew(ctx context.Context, input string) []prompt.Suggest
 // getCompletions returns suggestions for auto-completion.
 func (s *Shell) getCompletions(ctx context.Context, input string) []Suggest {
 	text := input
-	// Get current word by finding last space and taking everything after
-	lastSpace := strings.LastIndex(text, " ")
-	var currentWord string
-	if lastSpace >= 0 {
-		currentWord = text[lastSpace+1:]
-	} else {
-		currentWord = text
-	}
+	// Get the current word, treating backslash-escaped whitespace as part of it so
+	// a path like "my\ dir/in" stays one word. This matches the prompt library's
+	// escaped word boundary (enabled with WithWordEscape) used to accept the
+	// completion, so the directory portion is not lost when descending.
+	currentWord := currentCompletionWord(text)
 	// Check if we're dealing with a file path (contains / or \ or starts with common path patterns)
 	isFilePath := strings.Contains(currentWord, "/") ||
 		strings.Contains(currentWord, `\`) || // Windows path separator support
@@ -965,14 +963,17 @@ func (s *Shell) isValidFileForCompletion(filename string) bool {
 }
 
 // splitCompletionPrefix splits a typed path prefix into the directory to scan,
-// the leading text to keep on each suggestion (so completions preserve exactly
-// what the user typed), and the partial entry name to match.
+// the leading text to keep on each suggestion (so completions preserve what the
+// user typed), and the partial entry name to match. The prefix may carry
+// backslash-escaped whitespace (for example "my\ dir/in"); the escaped base is
+// returned verbatim so suggestions keep round-tripping, while the partial is
+// matched after decoding.
 //
 // It accepts both "/" and "\" as separators so completion behaves the same on
 // every OS. Examples (POSIX): "" -> ".", "", ""; "testdata/sa" -> "testdata/",
 // "testdata/", "sa"; "testdata" -> ".", "", "testdata".
 func splitCompletionPrefix(prefix string) (readDir, base, partial string) {
-	idx := strings.LastIndexAny(prefix, `/\`)
+	idx := lastUnescapedSeparator(prefix)
 	if idx < 0 {
 		return ".", "", prefix
 	}
@@ -984,6 +985,88 @@ func splitCompletionPrefix(prefix string) (readDir, base, partial string) {
 		readDir = string(os.PathSeparator)
 	}
 	return readDir, base, partial
+}
+
+// currentCompletionWord returns the word at the end of input used to build
+// completions. Whitespace that is backslash-escaped (preceded by an odd number of
+// backslashes) is part of the word, so "my\ dir/in" is one word while an
+// unescaped space ends it. It mirrors the prompt library's escaped word boundary.
+func currentCompletionWord(text string) string {
+	runes := []rune(text)
+	if len(runes) == 0 {
+		return ""
+	}
+	last := len(runes) - 1
+	if isUnescapedWhitespace(runes, last) {
+		return ""
+	}
+	start := 0
+	for i := last; i >= 0; i-- {
+		if isUnescapedWhitespace(runes, i) {
+			start = i + 1
+			break
+		}
+	}
+	return string(runes[start:])
+}
+
+// isUnescapedWhitespace reports whether runes[i] is a space, tab, or newline that
+// is not backslash-escaped (an even number of backslashes precede it).
+func isUnescapedWhitespace(runes []rune, i int) bool {
+	if r := runes[i]; r != ' ' && r != '\t' && r != '\n' {
+		return false
+	}
+	backslashes := 0
+	for j := i - 1; j >= 0 && runes[j] == '\\'; j-- {
+		backslashes++
+	}
+	return backslashes%2 == 0
+}
+
+// lastUnescapedSeparator returns the byte index of the last path separator in an
+// escaped completion prefix, or -1. A backslash that escapes the following
+// character (whitespace, quote, or backslash) is not a separator; a lone
+// backslash is treated as a Windows separator. This keeps "my\ dir/in" splitting
+// at the "/" rather than at the escaping backslash.
+func lastUnescapedSeparator(prefix string) int {
+	last := -1
+	for i := 0; i < len(prefix); i++ {
+		switch prefix[i] {
+		case '\\':
+			if i+1 < len(prefix) {
+				switch prefix[i+1] {
+				case ' ', '\t', '\\', '\'', '"':
+					i++ // skip the escaped character
+					continue
+				}
+			}
+			last = i
+		case '/':
+			last = i
+		}
+	}
+	return last
+}
+
+// unescapeCompletionPath reverses escapeCompletionPath, decoding a typed or
+// accepted prefix back to a real path for filesystem lookups. It mirrors how
+// splitArgs consumes a backslash: only before whitespace, a quote, or another
+// backslash; a lone backslash stays literal (a Windows separator).
+func unescapeCompletionPath(s string) string {
+	var b strings.Builder
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '\\' && i+1 < len(runes) {
+			switch next := runes[i+1]; next {
+			case ' ', '\t', '\\', '\'', '"':
+				b.WriteRune(next)
+				i++
+				continue
+			}
+		}
+		b.WriteRune(runes[i])
+	}
+	return b.String()
 }
 
 // escapeCompletionPath backslash-escapes the characters that splitArgs treats as
@@ -1008,6 +1091,33 @@ func escapeCompletionPath(path string) string {
 	return b.String()
 }
 
+// slashifyBase normalizes the separators in a completion base to "/" without
+// disturbing the backslashes that escape whitespace or quotes. filepath.ToSlash
+// cannot be used here because on Windows it would rewrite an escape such as
+// "my\ dir/" into "my/ dir/", breaking the round-trip; this converts only genuine
+// separator backslashes.
+func slashifyBase(base string) string {
+	var b strings.Builder
+	runes := []rune(base)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '\\' {
+			if i+1 < len(runes) {
+				switch next := runes[i+1]; next {
+				case ' ', '\t', '\\', '\'', '"':
+					b.WriteRune('\\')
+					b.WriteRune(next)
+					i++
+					continue
+				}
+			}
+			b.WriteRune('/') // a lone backslash is a path separator
+			continue
+		}
+		b.WriteRune(runes[i])
+	}
+	return b.String()
+}
+
 // getFilePathCompletions returns importable-file and directory suggestions
 // scoped to the directory named by prefix. It reads only that directory rather
 // than walking the whole working tree, so latency tracks the targeted subtree,
@@ -1017,11 +1127,12 @@ func escapeCompletionPath(path string) string {
 func (s *Shell) getFilePathCompletions(prefix string) []Suggest {
 	readDir, base, partial := splitCompletionPrefix(prefix)
 
-	// splitCompletionPrefix accepts both separators so Windows paths work, but
-	// the raw readDir may still carry a backslash on POSIX (e.g. "testdata\").
-	// Convert it to the local separator so os.ReadDir resolves the real directory
-	// instead of silently failing on a literal name.
-	readDir = filepath.FromSlash(strings.ReplaceAll(readDir, `\`, "/"))
+	// readDir and partial come from the escaped prefix, so decode them before
+	// touching the filesystem: an escaped space ("my\ dir/") names the real
+	// directory "my dir/". base stays escaped so each suggestion round-trips
+	// through splitArgs; a remaining backslash is a Windows separator mapped to "/".
+	readDir = filepath.FromSlash(strings.ReplaceAll(unescapeCompletionPath(readDir), `\`, "/"))
+	partial = unescapeCompletionPath(partial)
 
 	entries, err := os.ReadDir(readDir)
 	if err != nil {
@@ -1043,14 +1154,14 @@ func (s *Shell) getFilePathCompletions(prefix string) []Suggest {
 		// library prefix-matches, so escaping it would corrupt the match.
 		if entry.IsDir() {
 			suggestions = append(suggestions, Suggest{
-				Text:        filepath.ToSlash(base) + escapeCompletionPath(name) + "/",
+				Text:        slashifyBase(base) + escapeCompletionPath(name) + "/",
 				Description: msgImportableDir,
 			})
 			continue
 		}
 		if s.isValidFileForCompletion(name) {
 			suggestions = append(suggestions, Suggest{
-				Text:        filepath.ToSlash(base) + escapeCompletionPath(name),
+				Text:        slashifyBase(base) + escapeCompletionPath(name),
 				Description: msgImportableFile,
 			})
 		}

--- a/spec/import_quoting_spec.sh
+++ b/spec/import_quoting_spec.sh
@@ -40,6 +40,17 @@ Describe 'sqly .import with space-containing paths'
     The output should include 'alpha'
   End
 
+  It 'imports a file inside a space-containing directory when escaped'
+    Data
+      #|.import testdata/space\ dir/nested.csv
+      #|SELECT label FROM nested ORDER BY score;
+    End
+    When run sqly
+    The status should be success
+    The output should include 'gamma'
+    The output should include 'delta'
+  End
+
   It 'splits an unquoted space path into two failing arguments'
     Data
       #|.import testdata/space name.csv

--- a/testdata/space dir/nested.csv
+++ b/testdata/space dir/nested.csv
@@ -1,0 +1,3 @@
+label,score
+gamma,3
+delta,4


### PR DESCRIPTION
## Summary

This is the follow-up flagged on PR #631: completing inside a directory whose name contains a space did not work, because completion split the current word at the literal escaped space and then tried to read the escaped prefix as a literal directory. This was a pre-existing limitation, not introduced by #631, but worth fixing. Completion now decodes the escaped prefix for the filesystem lookup while keeping the escaped form on each suggestion, and the prompt library is taught (via the new opt-in `WithWordEscape`) to treat backslash-escaped whitespace as part of a word.

## Changes

- Upgrade `github.com/nao1215/prompt` to v0.0.7 and enable `prompt.WithWordEscape()` so completion filtering and acceptance keep an escaped path like `my\ dir/in` as one word.
- `shell/shell.go`: detect the current completion word with `currentCompletionWord`, which treats backslash-escaped whitespace as part of the word; make `splitCompletionPrefix` split at the last real separator via `lastUnescapedSeparator` (an escaping backslash is not a separator); decode `readDir` and the partial with `unescapeCompletionPath` before the filesystem lookup, while keeping the escaped base on each suggestion via `slashifyBase` (which normalizes only genuine separator backslashes, never escape backslashes, so Windows is correct).
- `shell/completion_test.go`: `TestCompletionDescendsIntoSpaceContainingDirectory` covers listing, partial match, and the `.import` completer path inside `my dir/`.
- `shell/parse_property_test.go`: property test that `unescapeCompletionPath` inverts `escapeCompletionPath`, and a table test that `splitCompletionPrefix` cuts at the real separator.
- `spec/import_quoting_spec.sh` and `testdata/space dir/nested.csv`: binary-level test that a file inside a space-containing directory imports when escaped.
- `CHANGELOG.md`: note the fix and the dependency bump.

## Design Decisions

The prompt change is opt-in and off by default, so word boundaries for other apps and for navigation are unchanged; only sqly's completer enables it. On the sqly side, the base of each suggestion is preserved in its escaped form because the prompt library accepts a suggestion by prefix-matching it against the typed word, so the escaped path must stay byte-for-byte consistent. `slashifyBase` is used instead of `filepath.ToSlash` because on Windows `ToSlash` would rewrite an escape such as `my\ dir/` into `my/ dir/` and break the round-trip.

Refs #605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab completion for `.import` so paths with spaces work correctly and suggestions still paste back into the command as valid arguments.
  * Fixed file-path completion to better handle escaped spaces and nested directories across platforms.

* **Chores**
  * Updated a command-line dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->