### PR TITLE
fix(shell): make .clear a no-op in batch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Batch-Safe Clear: `.clear` now emits its ANSI clear-screen escapes only in an interactive TTY session. In batch mode (piped stdin) it is a no-op, so machine-readable stdout such as `--json`, `--ndjson`, and `--csv` is no longer corrupted by control sequences.
 * Multi-line Interactive SQL: the shell now buffers a SQL statement across lines and submits on Enter only when it ends with `;`, so a typed or pasted multi-line statement (for example `SELECT ... UNION ALL SELECT ...;`) runs once instead of executing each line separately. Dot-commands stay single-line, and pressing Enter on a blank line force-runs a query typed without `;`.
 * Idempotent SQLite Driver Registration: `config.InitSQLite3()` now guards driver registration with a package-level `sync.Once` instead of a function-local one, so calling it more than once no longer panics with `sql: Register called twice for driver sqlite3`.
 * Prefix-Scoped Import Completion: `.import` tab completion now reads only the directory named by the typed path prefix instead of walking the whole working tree on every keystroke. Directories are offered with a trailing slash so the path can be completed one level at a time, keeping latency proportional to the targeted subtree rather than repository size.

--- a/shell/clear.go
+++ b/shell/clear.go
@@ -14,7 +14,15 @@ import (
 // headless CI and ties behavior to platform binaries. config.Stdout is a
 // go-colorable writer, which translates these escapes to the Windows console
 // API, so a single sequence works across supported operating systems.
-func (c CommandList) clearCommand(_ context.Context, _ *Shell, _ []string) error {
+//
+// The escapes are emitted only in interactive (TTY) sessions. In batch mode
+// (piped stdin) the same stdout carries machine-readable payloads such as
+// --json/--csv, so writing control sequences there would corrupt the output;
+// .clear becomes a no-op instead.
+func (c CommandList) clearCommand(_ context.Context, s *Shell, _ []string) error {
+	if s != nil && s.isTTY != nil && !s.isTTY() {
+		return nil
+	}
 	fmt.Fprint(config.Stdout, "\x1b[H\x1b[2J\x1b[3J")
 	return nil
 }

--- a/shell/clear_test.go
+++ b/shell/clear_test.go
@@ -39,7 +39,7 @@ func Test_clearCommand(t *testing.T) {
 		}
 	})
 
-	t.Run("writes ANSI clear sequence to stdout in-process", func(t *testing.T) {
+	t.Run("writes ANSI clear sequence to stdout in an interactive TTY session", func(t *testing.T) {
 		// Regression for: .clear must clear the screen in-process via ANSI
 		// escapes instead of shelling out to clear/cls.
 		c := NewCommands()
@@ -49,11 +49,31 @@ func Test_clearCommand(t *testing.T) {
 		var buf bytes.Buffer
 		config.Stdout = &buf
 
-		if err := c[".clear"].execute(context.Background(), &Shell{}, []string{}); err != nil {
+		s := &Shell{isTTY: func() bool { return true }}
+		if err := c[".clear"].execute(context.Background(), s, []string{}); err != nil {
 			t.Fatalf("clear command returned error: %v", err)
 		}
 		if !strings.Contains(buf.String(), "\x1b[2J") {
 			t.Fatalf("clear output = %q, want it to contain the ANSI clear-screen escape", buf.String())
+		}
+	})
+
+	t.Run("emits nothing to stdout in non-TTY batch mode", func(t *testing.T) {
+		// Regression: in batch mode (piped stdin) stdout carries machine-readable
+		// payloads such as --json/--csv, so .clear must not inject ANSI escapes.
+		c := NewCommands()
+
+		backup := config.Stdout
+		defer func() { config.Stdout = backup }()
+		var buf bytes.Buffer
+		config.Stdout = &buf
+
+		s := &Shell{isTTY: func() bool { return false }}
+		if err := c[".clear"].execute(context.Background(), s, []string{}); err != nil {
+			t.Fatalf("clear command returned error: %v", err)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("clear output = %q, want no output in batch mode", buf.String())
 		}
 	})
 

--- a/spec/helpers_spec.sh
+++ b/spec/helpers_spec.sh
@@ -21,14 +21,25 @@ Describe 'sqly shell helper commands'
   End
 
   Describe '.clear'
-    It 'clears the screen in-process without an external command'
-      clear_seq=$(printf '\033[H\033[2J\033[3J')
+    It 'emits no ANSI escapes to stdout in batch mode'
+      # Piped stdin is non-TTY batch mode, where stdout may carry
+      # machine-readable payloads. .clear must stay silent there.
       Data
         #|.clear
       End
       When run sqly
       The status should be success
-      The output should equal "$clear_seq"
+      The output should equal ''
+    End
+
+    It 'keeps --json stdout parseable when .clear precedes a query'
+      Data
+        #|.clear
+        #|SELECT 1 AS x;
+      End
+      When run sqly --json testdata/user.csv
+      The status should be success
+      The line 1 should equal '['
     End
   End
 


### PR DESCRIPTION
## Summary

`.clear` wrote ANSI clear-screen escapes to stdout unconditionally. Running it in batch mode (piped stdin) injected control sequences into machine-readable output such as `--json`, `--ndjson`, and `--csv`, corrupting downstream pipelines.

This change gates the escapes on the interactive TTY session. In batch mode `.clear` now emits nothing, so machine-readable stdout stays valid. Interactive clear-screen behavior is unchanged.

## Tests

Go unit tests in `shell/clear_test.go` cover both the interactive (escapes emitted) and batch (no output) paths. The shellspec `helpers_spec.sh` E2E suite asserts that `.clear` produces no output in batch mode and that `--json` stdout stays parseable when `.clear` precedes a query.

Closes #607