### PR TITLE
fix(shell): reject unexpected extra arguments in .pwd, .clear, and .exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Strict Helper Argument Validation: `.pwd`, `.clear`, and `.exit` now reject unexpected trailing arguments with a clear error instead of ignoring them, matching the other helper commands. A typo such as `.exit now` no longer silently terminates a batch run with status 0.
 * Batch-Safe Clear: `.clear` now emits its ANSI clear-screen escapes only in an interactive TTY session. In batch mode (piped stdin) it is a no-op, so machine-readable stdout such as `--json`, `--ndjson`, and `--csv` is no longer corrupted by control sequences.
 * Multi-line Interactive SQL: the shell now buffers a SQL statement across lines and submits on Enter only when it ends with `;`, so a typed or pasted multi-line statement (for example `SELECT ... UNION ALL SELECT ...;`) runs once instead of executing each line separately. Dot-commands stay single-line, and pressing Enter on a blank line force-runs a query typed without `;`.
 * Idempotent SQLite Driver Registration: `config.InitSQLite3()` now guards driver registration with a package-level `sync.Once` instead of a function-local one, so calling it more than once no longer panics with `sql: Register called twice for driver sqlite3`.

--- a/shell/clear.go
+++ b/shell/clear.go
@@ -19,7 +19,10 @@ import (
 // (piped stdin) the same stdout carries machine-readable payloads such as
 // --json/--csv, so writing control sequences there would corrupt the output;
 // .clear becomes a no-op instead.
-func (c CommandList) clearCommand(_ context.Context, s *Shell, _ []string) error {
+func (c CommandList) clearCommand(_ context.Context, s *Shell, argv []string) error {
+	if len(argv) > 0 {
+		return fmt.Errorf(".clear takes no arguments, got %d", len(argv))
+	}
 	if s != nil && s.isTTY != nil && !s.isTTY() {
 		return nil
 	}

--- a/shell/clear_test.go
+++ b/shell/clear_test.go
@@ -77,6 +77,19 @@ func Test_clearCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects unexpected extra arguments", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewCommands()
+		err := c[".clear"].execute(context.Background(), &Shell{}, []string{"extra"})
+		if err == nil {
+			t.Fatal("expected error for extra argument, got nil")
+		}
+		if !strings.Contains(err.Error(), ".clear") {
+			t.Errorf("error %q should mention .clear", err.Error())
+		}
+	})
+
 	t.Run("clear command executes without panic", func(t *testing.T) {
 		t.Parallel()
 

--- a/shell/exit.go
+++ b/shell/exit.go
@@ -1,8 +1,17 @@
 package shell
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // exitCommand return ErrExitSqly. The caller shall terminate the sqly command.
-func (c CommandList) exitCommand(_ context.Context, _ *Shell, _ []string) error {
+//
+// Unexpected trailing arguments are rejected rather than ignored, so a typo
+// like ".exit now" cannot silently terminate a batch run with status 0.
+func (c CommandList) exitCommand(_ context.Context, _ *Shell, argv []string) error {
+	if len(argv) > 0 {
+		return fmt.Errorf(".exit takes no arguments, got %d", len(argv))
+	}
 	return ErrExitSqly
 }

--- a/shell/exit_test.go
+++ b/shell/exit_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -14,6 +15,18 @@ func TestCommandListExitCommand(t *testing.T) {
 		got := c.exitCommand(context.Background(), nil, []string{})
 		if !errors.Is(got, want) {
 			t.Errorf("mismatch got=%v, want=%v", got, want)
+		}
+	})
+
+	t.Run("rejects unexpected extra arguments instead of exiting", func(t *testing.T) {
+		c := CommandList{}
+
+		got := c.exitCommand(context.Background(), nil, []string{"extra"})
+		if errors.Is(got, ErrExitSqly) {
+			t.Fatal("extra argument must not trigger a clean exit")
+		}
+		if got == nil || !strings.Contains(got.Error(), ".exit") {
+			t.Errorf("error %v should mention .exit", got)
 		}
 	})
 }

--- a/shell/pwd.go
+++ b/shell/pwd.go
@@ -9,7 +9,10 @@ import (
 )
 
 // pwdCommand print current working directory.
-func (c CommandList) pwdCommand(_ context.Context, _ *Shell, _ []string) error {
+func (c CommandList) pwdCommand(_ context.Context, _ *Shell, argv []string) error {
+	if len(argv) > 0 {
+		return fmt.Errorf(".pwd takes no arguments, got %d", len(argv))
+	}
 	dir, err := os.Getwd()
 	if err != nil {
 		return err

--- a/shell/pwd_test.go
+++ b/shell/pwd_test.go
@@ -39,4 +39,16 @@ func TestCommandList_pwdCommand(t *testing.T) {
 			t.Error(diff)
 		}
 	})
+
+	t.Run("rejects unexpected extra arguments", func(t *testing.T) {
+		c := CommandList{}
+
+		err := c.pwdCommand(context.Background(), nil, []string{"extra"})
+		if err == nil {
+			t.Fatal("expected error for extra argument, got nil")
+		}
+		if !strings.Contains(err.Error(), ".pwd") {
+			t.Errorf("error %q should mention .pwd", err.Error())
+		}
+	})
 }

--- a/spec/extra_args_spec.sh
+++ b/spec/extra_args_spec.sh
@@ -42,4 +42,32 @@ Describe 'sqly helper commands reject extra args'
     The status should be failure
     The stderr should include '.mode'
   End
+
+  It 'rejects .pwd with an extra argument'
+    Data
+      #|.pwd extra
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The stderr should include '.pwd'
+  End
+
+  It 'rejects .clear with an extra argument'
+    Data
+      #|.clear extra
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The stderr should include '.clear'
+  End
+
+  It 'does not let .exit with an extra argument silently terminate the batch'
+    Data
+      #|.exit extra
+      #|SELECT 1;
+    End
+    When run sqly testdata/user.csv
+    The status should be failure
+    The stderr should include '.exit'
+  End
 End


### PR DESCRIPTION
## Summary

`.pwd`, `.clear`, and `.exit` silently ignored trailing arguments while the other helper commands reject them. That made typos look successful, and `.exit extra` could terminate a batch run early with exit status 0.

Each command now returns a clear `takes no arguments` error on extra input, giving the helper-command surface one consistent argument-validation contract.

## Tests

Unit tests in `shell/pwd_test.go`, `shell/exit_test.go`, and `shell/clear_test.go` cover each command's validation path, including that `.exit extra` does not trigger a clean exit. The shellspec `extra_args_spec.sh` suite is extended to cover `.pwd`, `.clear`, and `.exit`, asserting `.exit extra` fails the batch instead of terminating it silently.

Closes #608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive helper commands now reject unexpected extra arguments instead of ignoring them.
  * `.pwd` and `.clear` now return an error when arguments are provided.
  * `.exit` no longer exits cleanly when extra arguments are passed; it reports an error instead.
  * Added coverage to verify these commands fail as expected in end-to-end and unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->