### PR TITLE
fix(shell): abbreviate home prefix only at a path boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Boundary-Safe Home Abbreviation: the prompt now replaces the home directory with `~` only when the working directory equals home or is a real descendant at a path-separator boundary. A sibling such as `/home/nao2` (or `C:\Users\nao-backup` on Windows) that merely shares a byte prefix with `/home/nao` is no longer rewritten into a misleading `~2`.
 * Strict Helper Argument Validation: `.pwd`, `.clear`, and `.exit` now reject unexpected trailing arguments with a clear error instead of ignoring them, matching the other helper commands. A typo such as `.exit now` no longer silently terminates a batch run with status 0.
 * Batch-Safe Clear: `.clear` now emits its ANSI clear-screen escapes only in an interactive TTY session. In batch mode (piped stdin) it is a no-op, so machine-readable stdout such as `--json`, `--ndjson`, and `--csv` is no longer corrupted by control sequences.
 * Multi-line Interactive SQL: the shell now buffers a SQL statement across lines and submits on Enter only when it ends with `;`, so a typed or pasted multi-line statement (for example `SELECT ... UNION ALL SELECT ...;`) runs once instead of executing each line separately. Dot-commands stay single-line, and pressing Enter on a blank line force-runs a query typed without `;`.

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -3279,6 +3279,70 @@ func TestShell_shortCWD(t *testing.T) {
 	}
 }
 
+func TestAbbreviateHome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cwd  string
+		home string
+		want string
+	}{
+		{
+			name: "cwd equal to home returns tilde",
+			cwd:  "/home/nao",
+			home: "/home/nao",
+			want: "~",
+		},
+		{
+			name: "cwd inside home is abbreviated at the separator boundary",
+			cwd:  "/home/nao/project",
+			home: "/home/nao",
+			want: "~/project",
+		},
+		{
+			name: "sibling sharing only the byte prefix is left unchanged",
+			cwd:  "/home/nao2/project",
+			home: "/home/nao",
+			want: "/home/nao2/project",
+		},
+		{
+			name: "windows cwd inside home is abbreviated",
+			cwd:  `C:\Users\nao\project`,
+			home: `C:\Users\nao`,
+			want: `~\project`,
+		},
+		{
+			name: "windows sibling sharing the prefix is left unchanged",
+			cwd:  `C:\Users\nao-backup\project`,
+			home: `C:\Users\nao`,
+			want: `C:\Users\nao-backup\project`,
+		},
+		{
+			name: "empty home leaves cwd unchanged",
+			cwd:  "/home/nao/project",
+			home: "",
+			want: "/home/nao/project",
+		},
+		{
+			name: "trailing separator on home still abbreviates a descendant",
+			cwd:  "/home/nao/project",
+			home: "/home/nao/",
+			want: "~/project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := abbreviateHome(tt.cwd, tt.home); got != tt.want {
+				t.Errorf("abbreviateHome(%q, %q) = %q, want %q", tt.cwd, tt.home, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestShellExec_SchemaQualifiedTempView covers the helper-command surface added
 // for v0.20.0 hardening: schema-qualified names, TEMP tables, and views.
 func TestShellExec_SchemaQualifiedTempView(t *testing.T) {

--- a/shell/state.go
+++ b/shell/state.go
@@ -37,10 +37,29 @@ func (s *state) shortCWD() string {
 	if err != nil || home == "" {
 		return s.cwd
 	}
-	if s.cwd == home {
+	return abbreviateHome(s.cwd, home)
+}
+
+// abbreviateHome replaces a leading home-directory prefix in cwd with "~". The
+// prefix is only replaced when cwd equals home or is a real descendant of home
+// at a path-separator boundary. Why not a plain string replace: that rewrites a
+// sibling such as "/home/nao2" into "~2" when home is "/home/nao". Both "/" and
+// "\\" are accepted as boundaries so the check is correct for Unix and Windows
+// paths regardless of the host OS.
+func abbreviateHome(cwd, home string) string {
+	home = strings.TrimRight(home, `/\`)
+	if home == "" {
+		return cwd
+	}
+	if cwd == home {
 		return "~"
 	}
-	return strings.Replace(s.cwd, home, "~", 1)
+	if strings.HasPrefix(cwd, home) {
+		if rest := cwd[len(home):]; rest[0] == '/' || rest[0] == '\\' {
+			return "~" + rest
+		}
+	}
+	return cwd
 }
 
 // Typed JSON output mode names accepted by .mode and shown in the prompt. They


### PR DESCRIPTION
## Summary

`state.shortCWD()` abbreviated the home directory with a plain string replace, so a sibling directory that only shared a byte prefix with home was rewritten too. With home `/home/nao`, the path `/home/nao2/project` became `~2/project`, and the same bug hit Windows paths like `C:\Users\nao` vs `C:\Users\nao-backup`.

The prefix is now replaced with `~` only when the working directory equals home or is a real descendant of home at a `/` or `\` boundary. The logic is extracted into a new `abbreviateHome` helper that handles both Unix and Windows separators regardless of the host OS.

## Tests

Table-driven unit tests in `shell/shell_test.go` cover `cwd == home`, a descendant inside home, a sibling false-prefix (`/home/nao2`), Windows descendant and false-prefix cases, an empty home, and a home with a trailing separator.

Closes #609