### PR TITLE
fix(shell): expand ~ home-directory paths in helper commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Home-Directory Expansion in Helpers: `.cd`, `.ls`, `.import`, `.dump`, and `.save` now expand a leading `~` (and `~/...`) to the user's home directory before running, so `.cd ~` and `.import ~/data.csv` work instead of failing on a literal `~`. Forms like `~user` or a `~` later in the path are left untouched.
 * Boundary-Safe Home Abbreviation: the prompt now replaces the home directory with `~` only when the working directory equals home or is a real descendant at a path-separator boundary. A sibling such as `/home/nao2` (or `C:\Users\nao-backup` on Windows) that merely shares a byte prefix with `/home/nao` is no longer rewritten into a misleading `~2`.
 * Strict Helper Argument Validation: `.pwd`, `.clear`, and `.exit` now reject unexpected trailing arguments with a clear error instead of ignoring them, matching the other helper commands. A typo such as `.exit now` no longer silently terminates a batch run with status 0.
 * Batch-Safe Clear: `.clear` now emits its ANSI clear-screen escapes only in an interactive TTY session. In batch mode (piped stdin) it is a no-op, so machine-readable stdout such as `--json`, `--ndjson`, and `--csv` is no longer corrupted by control sequences.

--- a/shell/cd.go
+++ b/shell/cd.go
@@ -17,7 +17,11 @@ func (c CommandList) cdCommand(_ context.Context, s *Shell, argv []string) error
 
 	var target string
 	if len(argv) == 1 {
-		target = argv[0]
+		expanded, err := expandTilde(argv[0])
+		if err != nil {
+			return err
+		}
+		target = expanded
 	} else {
 		// Resolve the home directory cross-platform. os.UserHomeDir reads
 		// %USERPROFILE% on Windows, where $HOME is usually unset.

--- a/shell/commands_test.go
+++ b/shell/commands_test.go
@@ -353,6 +353,39 @@ func TestCommandList_cdCommand_StoresAbsolutePath(t *testing.T) {
 	}
 }
 
+func TestCommandList_cdCommand_ExpandsTilde(t *testing.T) {
+	// Regression for: .cd ~ must expand to the home directory instead of
+	// passing a literal "~" to os.Chdir.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot resolve home directory: %v", err)
+	}
+
+	// cdCommand calls os.Chdir directly, mutating the process working directory.
+	// Anchor to a temp dir so t.Chdir restores the original cwd after the test,
+	// keeping other tests' relative testdata/ paths valid.
+	t.Chdir(t.TempDir())
+
+	shell := newBoundaryTestShell(t, Usecases{})
+	commandList := NewCommands()
+
+	if err := commandList.cdCommand(context.Background(), shell, []string{"~"}); err != nil {
+		t.Fatalf("cdCommand(~) returned error: %v", err)
+	}
+
+	wantResolved, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotResolved, err := filepath.EvalSymlinks(shell.state.cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotResolved != wantResolved {
+		t.Fatalf("state.cwd resolved = %q, want home %q", gotResolved, wantResolved)
+	}
+}
+
 func TestShell_getFilePathCompletions_errorHandling(t *testing.T) {
 	shell, cleanup, err := newShell(t, []string{"sqly"})
 	if err != nil {

--- a/shell/dump.go
+++ b/shell/dump.go
@@ -37,6 +37,14 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 		return errors.New(".dump requires a non-empty destination path")
 	}
 
+	// Expand a leading "~" so `.dump table ~/out.csv` writes under the home
+	// directory instead of a literal "~" file.
+	expandedPath, err := expandTilde(userPath)
+	if err != nil {
+		return err
+	}
+	userPath = expandedPath
+
 	// Block round-trip export to ACH/Fedwire format before normalization. These
 	// formats require multi-record coordination that .dump cannot provide.
 	// Exporting ACH/Fedwire tables to CSV/TSV/etc via .dump is fine. The check

--- a/shell/import.go
+++ b/shell/import.go
@@ -185,7 +185,13 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 			continue
 		}
 
-		cleanPath, err := validatePath(path)
+		expanded, err := expandTilde(path)
+		if err != nil {
+			errorMessages = append(errorMessages, fmt.Sprintf("invalid path %s: %v", path, err))
+			continue
+		}
+
+		cleanPath, err := validatePath(expanded)
 		if err != nil {
 			errorMessages = append(errorMessages, fmt.Sprintf("invalid path %s: %v", path, err))
 			continue

--- a/shell/ls.go
+++ b/shell/ls.go
@@ -26,7 +26,11 @@ func (c CommandList) lsCommand(_ context.Context, _ *Shell, argv []string) error
 	}
 	path := "."
 	if len(argv) == 1 {
-		path = argv[0]
+		expanded, err := expandTilde(argv[0])
+		if err != nil {
+			return err
+		}
+		path = expanded
 	}
 
 	info, err := os.Stat(path)

--- a/shell/pathexpand.go
+++ b/shell/pathexpand.go
@@ -1,0 +1,47 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// expandTilde expands a leading "~" or "~/..." in path to the current user's
+// home directory. A bare "~" maps to home; "~/sub" (and the Windows "~\sub")
+// maps to home joined with "sub". Why resolve here: helper commands pass the
+// argument straight to os.Chdir/os.Stat, which do not understand "~", so the
+// shell prompt advertises "~" while the commands rejected it.
+//
+// Forms other than "~" and "~<separator>..." (for example "~user" or a "~" that
+// appears later in the path) are returned unchanged, so they fail as a literal
+// path rather than silently resolving to the wrong location.
+func expandTilde(path string) (string, error) {
+	if !hasTildePrefix(path) {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return expandTildeWithHome(path, home), nil
+}
+
+// hasTildePrefix reports whether path is a bare "~" or starts with "~" followed
+// by a path separator ("/" on every OS, plus the native separator on Windows).
+func hasTildePrefix(path string) bool {
+	return path == "~" ||
+		strings.HasPrefix(path, "~/") ||
+		strings.HasPrefix(path, "~"+string(os.PathSeparator))
+}
+
+// expandTildeWithHome performs the expansion against an explicit home directory
+// so the rule is unit-testable without depending on the host account.
+func expandTildeWithHome(path, home string) string {
+	if !hasTildePrefix(path) {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, path[2:])
+}

--- a/shell/pathexpand_test.go
+++ b/shell/pathexpand_test.go
@@ -1,0 +1,93 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandTildeWithHome(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(string(filepath.Separator)+"home", "nao")
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "bare tilde maps to home",
+			path: "~",
+			want: home,
+		},
+		{
+			name: "tilde slash subdir joins home",
+			path: "~/project/data.csv",
+			want: filepath.Join(home, "project", "data.csv"),
+		},
+		{
+			name: "tilde user form is left unchanged",
+			path: "~other/data.csv",
+			want: "~other/data.csv",
+		},
+		{
+			name: "tilde later in the path is left unchanged",
+			path: "data/~backup/file.csv",
+			want: "data/~backup/file.csv",
+		},
+		{
+			name: "plain relative path is left unchanged",
+			path: "testdata/user.csv",
+			want: "testdata/user.csv",
+		},
+		{
+			name: "absolute path is left unchanged",
+			path: filepath.Join(home, "file.csv"),
+			want: filepath.Join(home, "file.csv"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := expandTildeWithHome(tt.path, home); got != tt.want {
+				t.Errorf("expandTildeWithHome(%q, %q) = %q, want %q", tt.path, home, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandTilde(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot resolve home directory: %v", err)
+	}
+
+	t.Run("bare tilde resolves to the real home directory", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := expandTilde("~")
+		if err != nil {
+			t.Fatalf("expandTilde returned error: %v", err)
+		}
+		if got != home {
+			t.Errorf("expandTilde(\"~\") = %q, want %q", got, home)
+		}
+	})
+
+	t.Run("non-tilde path is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := expandTilde("testdata/user.csv")
+		if err != nil {
+			t.Fatalf("expandTilde returned error: %v", err)
+		}
+		if got != "testdata/user.csv" {
+			t.Errorf("expandTilde = %q, want unchanged", got)
+		}
+	})
+}

--- a/shell/save.go
+++ b/shell/save.go
@@ -45,7 +45,13 @@ func (c CommandList) saveCommand(ctx context.Context, s *Shell, argv []string) e
 	if argv[0] == forceArg {
 		return s.writeBack(ctx, "")
 	}
-	return s.writeBack(ctx, argv[0])
+	// Expand a leading "~" so `.save ~/out` writes under the home directory
+	// instead of a literal "~" directory.
+	destDir, err := expandTilde(argv[0])
+	if err != nil {
+		return err
+	}
+	return s.writeBack(ctx, destDir)
 }
 
 // validateSaveFlags checks the --save/--save-dir/--force combination before any

--- a/spec/helpers_spec.sh
+++ b/spec/helpers_spec.sh
@@ -20,6 +20,40 @@ Describe 'sqly shell helper commands'
     End
   End
 
+  Describe '~ home-directory expansion'
+    # Point HOME at a throwaway directory so the expansion is verifiable
+    # without touching the real home. A CSV lives inside it for .import.
+    setup() {
+      TILDE_HOME="$(mktemp -d)"
+      export TILDE_HOME
+      export HOME="$TILDE_HOME"
+      printf 'id,name\n1,foo\n' > "$TILDE_HOME/sqly_tilde.csv"
+    }
+    cleanup() { rm -rf "${TILDE_HOME:-}"; }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'expands a bare ~ in .cd to the home directory'
+      Data
+        #|.cd ~
+        #|.pwd
+      End
+      When run sqly
+      The status should be success
+      The output should include "$(basename "$TILDE_HOME")"
+    End
+
+    It 'expands ~/file in .import'
+      Data
+        #|.import ~/sqly_tilde.csv
+        #|.tables
+      End
+      When run sqly
+      The status should be success
+      The output should include 'sqly_tilde'
+    End
+  End
+
   Describe '.clear'
     It 'emits no ANSI escapes to stdout in batch mode'
       # Piped stdin is non-TTY batch mode, where stdout may carry


### PR DESCRIPTION
## Summary

`.cd`, `.ls`, `.import`, `.dump`, and `.save` passed a literal `~` straight to `os.Chdir`/`os.Stat`, so `.cd ~` and `.import ~/data.csv` failed even though the prompt and the completer already treat `~` as the home directory.

This adds a shared `expandTilde` helper that expands a bare `~` and `~/...` (and the Windows `~\...` form) to the user's home directory, applied at each command's path entry point. `~user` and a `~` that appears later in the path are left unchanged so they fail as literal paths instead of resolving to the wrong location.

## Tests

Table-driven unit tests in `shell/pathexpand_test.go` cover bare `~`, `~/subdir`, `~user`, a `~` later in the path, and plain/absolute paths. `shell/commands_test.go` adds a `.cd ~` regression that asserts the working directory resolves to home. The shellspec `helpers_spec.sh` suite drives the built binary with `HOME` pointed at a throwaway directory and verifies `.cd ~` and `.import ~/file.csv`.

Closes #610