### PR TITLE
fix(shell): make .import completion quote-aware for in-progress quoted paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Quoted Import Completion: `.import` tab completion now works while typing a quoted path. After an opening quote (for example `.import "my`), completion matches the path fragment inside the quote and keeps it quoted, closing the quote on a file and leaving it open on a directory so the accepted command stays a single argument.
 * Home-Directory Expansion in Helpers: `.cd`, `.ls`, `.import`, `.dump`, and `.save` now expand a leading `~` (and `~/...`) to the user's home directory before running, so `.cd ~` and `.import ~/data.csv` work instead of failing on a literal `~`. Forms like `~user` or a `~` later in the path are left untouched.
 * Boundary-Safe Home Abbreviation: the prompt now replaces the home directory with `~` only when the working directory equals home or is a real descendant at a path-separator boundary. A sibling such as `/home/nao2` (or `C:\Users\nao-backup` on Windows) that merely shares a byte prefix with `/home/nao` is no longer rewritten into a misleading `~2`.
 * Strict Helper Argument Validation: `.pwd`, `.clear`, and `.exit` now reject unexpected trailing arguments with a clear error instead of ignoring them, matching the other helper commands. A typo such as `.exit now` no longer silently terminates a batch run with status 0.

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -232,6 +232,78 @@ func TestCompletionEscapesSpaceContainingPaths(t *testing.T) {
 	})
 }
 
+func TestCompletionInsideQuotedPath(t *testing.T) {
+	// Note: cannot use t.Parallel() with t.Chdir().
+	tmpDir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+	t.Cleanup(func() { t.Chdir(orig) })
+
+	makeTree(t, []string{
+		"my data.csv",
+		"my dir/",
+		"my dir/inner.csv",
+	})
+
+	shell, cleanup, shellErr := newShell(t, []string{"sqly"})
+	if shellErr != nil {
+		t.Fatal(shellErr)
+	}
+	defer cleanup()
+
+	// A quoted suggestion must round-trip through splitArgs to one argument so the
+	// accepted command stays valid.
+	findSuggestion := func(t *testing.T, suggestions []Suggest, wantPath string) string {
+		t.Helper()
+		for _, s := range suggestions {
+			argv, err := splitArgs(".import " + s.Text)
+			if err != nil {
+				continue
+			}
+			if len(argv) == 2 && argv[1] == wantPath {
+				return s.Text
+			}
+		}
+		t.Fatalf("no completion round-trips to %q; got %v", wantPath, completionTexts(suggestions))
+		return ""
+	}
+
+	t.Run("double-quoted prefix completes a space-containing file", func(t *testing.T) {
+		got := shell.getCompletions(context.Background(), `.import "my`)
+		text := findSuggestion(t, got, "my data.csv")
+		if !strings.HasPrefix(text, `"my`) {
+			t.Errorf("suggestion %q should keep the opening double quote", text)
+		}
+		if !strings.HasSuffix(text, `"`) {
+			t.Errorf("suggestion %q should close the double quote on a file", text)
+		}
+	})
+
+	t.Run("single-quoted prefix completes a space-containing file", func(t *testing.T) {
+		got := shell.getCompletions(context.Background(), `.import 'my`)
+		text := findSuggestion(t, got, "my data.csv")
+		if !strings.HasPrefix(text, `'my`) {
+			t.Errorf("suggestion %q should keep the opening single quote", text)
+		}
+	})
+
+	t.Run("quoted directory keeps the quote open to descend", func(t *testing.T) {
+		got := shell.getCompletions(context.Background(), `.import "my`)
+		var dirText string
+		for _, s := range got {
+			if s.Text == `"my dir/` {
+				dirText = s.Text
+			}
+		}
+		if dirText == "" {
+			t.Fatalf("expected an open-quoted directory suggestion, got %v", completionTexts(got))
+		}
+	})
+}
+
 func TestCompletionDescendsIntoSpaceContainingDirectory(t *testing.T) {
 	// Note: cannot use t.Parallel() with t.Chdir().
 	tmpDir := t.TempDir()

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -639,6 +639,13 @@ func (s *Shell) getCompletions(ctx context.Context, input string) []Suggest {
 	if len(words) > 0 {
 		// If the line starts with .import, always provide file completions for the last argument
 		if len(words) >= 1 && words[0] == importCommand {
+			// When the in-progress word opens a quote (e.g. .import "my), complete
+			// the path fragment inside the quote and keep it quoted so the accepted
+			// command stays valid. This is the scenario that needs quoting in the
+			// first place: a path with spaces.
+			if quote, rawInner, ok := openQuotePrefix(currentWord); ok {
+				return s.getQuotedFilePathCompletions(rawInner, quote)
+			}
 			fileCompletions := s.getFilePathCompletions(currentWord)
 
 			// For new full-path completion behavior, return all files without filtering
@@ -1171,4 +1178,116 @@ func (s *Shell) getFilePathCompletions(prefix string) []Suggest {
 		}
 	}
 	return suggestions
+}
+
+// openQuotePrefix reports whether word begins a still-open quoted argument (a
+// leading ' or ") with no matching closing quote yet. It returns the opening
+// quote rune and the raw text typed after it. Inside a double quote, a \" or \\
+// escape does not close the quote. A word whose quote is already closed is not
+// an in-progress quoted path, so ok is false.
+func openQuotePrefix(word string) (quote rune, rawInner string, ok bool) {
+	runes := []rune(word)
+	if len(runes) == 0 {
+		return 0, "", false
+	}
+	q := runes[0]
+	if q != '\'' && q != '"' {
+		return 0, "", false
+	}
+	for i := 1; i < len(runes); i++ {
+		if q == '"' && runes[i] == '\\' && i+1 < len(runes) {
+			if next := runes[i+1]; next == '"' || next == '\\' {
+				i++ // skip the escaped character
+				continue
+			}
+		}
+		if runes[i] == q {
+			return 0, "", false // the quote is closed; not an in-progress quoted word
+		}
+	}
+	return q, string(runes[1:]), true
+}
+
+// getQuotedFilePathCompletions returns importable-file and directory suggestions
+// for a path fragment typed inside an open quote. Each suggestion keeps the same
+// quote: a directory keeps the quote open (so the user descends one level at a
+// time) while a file closes it, so the accepted command parses back to a single
+// argument through splitArgs.
+func (s *Shell) getQuotedFilePathCompletions(rawInner string, quote rune) []Suggest {
+	inner := decodeQuotedPath(rawInner, quote)
+	readDir, base, partial := splitDecodedPrefix(inner)
+
+	entries, err := os.ReadDir(readDir)
+	if err != nil {
+		return nil
+	}
+
+	q := string(quote)
+	includeHidden := strings.HasPrefix(partial, ".")
+	var suggestions []Suggest
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") && !includeHidden {
+			continue
+		}
+		if !strings.HasPrefix(name, partial) {
+			continue
+		}
+		// Inside quotes the path is literal, so base and name need no escaping
+		// (filenames containing the quote character itself are not handled).
+		if entry.IsDir() {
+			suggestions = append(suggestions, Suggest{
+				Text:        q + base + name + "/",
+				Description: msgImportableDir,
+			})
+			continue
+		}
+		if s.isValidFileForCompletion(name) {
+			suggestions = append(suggestions, Suggest{
+				Text:        q + base + name + q,
+				Description: msgImportableFile,
+			})
+		}
+	}
+	return suggestions
+}
+
+// decodeQuotedPath decodes the raw text typed inside an open quote into the real
+// path. Single-quoted content is literal; double-quoted content unescapes \" and
+// \\, matching splitArgs.
+func decodeQuotedPath(s string, quote rune) string {
+	if quote != '"' {
+		return s
+	}
+	var b strings.Builder
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '\\' && i+1 < len(runes) {
+			if next := runes[i+1]; next == '"' || next == '\\' {
+				b.WriteRune(next)
+				i++
+				continue
+			}
+		}
+		b.WriteRune(runes[i])
+	}
+	return b.String()
+}
+
+// splitDecodedPrefix splits an already-decoded path fragment into the directory
+// to scan, the literal prefix to keep on each suggestion, and the partial entry
+// name to match. Both "/" and "\" are accepted as separators.
+func splitDecodedPrefix(p string) (readDir, base, partial string) {
+	idx := strings.LastIndexAny(p, `/\`)
+	if idx < 0 {
+		return ".", "", p
+	}
+	base = p[:idx+1]
+	partial = p[idx+1:]
+	readDir = filepath.FromSlash(strings.ReplaceAll(base, `\`, "/"))
+	if readDir == "" {
+		// A leading separator ("/foo") leaves base empty; scan the filesystem root.
+		readDir = string(os.PathSeparator)
+	}
+	return readDir, base, partial
 }


### PR DESCRIPTION
## Summary

`.import` tab completion did nothing once the user opened a quote (for example `.import "my`), so the exact scenario that needs quoting a space-containing path could not be completed.

When the in-progress word opens a single or double quote, completion now matches the path fragment inside the quote and emits quoted suggestions: a file closes the quote and a directory keeps it open, so the accepted command round-trips through `splitArgs` to a single argument and stays executable.

The first-level quoted completion works with the escape-aware prompt because the typed word (`"my`) contains no unescaped space. Descending into a quoted directory whose typed prefix already contains a space would additionally require quote-aware word boundaries in the prompt library; that is left for a separate change.

## Tests

`shell/completion_test.go` adds `TestCompletionInsideQuotedPath`, covering double-quoted and single-quoted prefixes completing a space-containing file (each suggestion round-trips through `splitArgs` to one argument) and a quoted directory suggestion that keeps the quote open.

Closes #611