### PR TITLE
test(shell): cover hidden-directory import completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Hidden Path Import Completion: `.import` tab completion stays hidden-by-default but now traverses a hidden directory once its prefix is typed explicitly, so `.import .secret/` lists the importable files inside it. Regression tests lock this in for both hidden files and nested hidden directories.
 * Quoted Import Completion: `.import` tab completion now works while typing a quoted path. After an opening quote (for example `.import "my`), completion matches the path fragment inside the quote and keeps it quoted, closing the quote on a file and leaving it open on a directory so the accepted command stays a single argument.
 * Home-Directory Expansion in Helpers: `.cd`, `.ls`, `.import`, `.dump`, and `.save` now expand a leading `~` (and `~/...`) to the user's home directory before running, so `.cd ~` and `.import ~/data.csv` work instead of failing on a literal `~`. Forms like `~user` or a `~` later in the path are left untouched.
 * Boundary-Safe Home Abbreviation: the prompt now replaces the home directory with `~` only when the working directory equals home or is a real descendant at a path-separator boundary. A sibling such as `/home/nao2` (or `C:\Users\nao-backup` on Windows) that merely shares a byte prefix with `/home/nao` is no longer rewritten into a misleading `~2`.

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -255,22 +255,28 @@ func TestCompletionHiddenPaths(t *testing.T) {
 	}
 	defer cleanup()
 
+	// Drive assertions through the .import completion entrypoint the prompt uses,
+	// so the getCompletions routing into the file-path helper is covered too.
+	complete := func(text string) []string {
+		return completionTexts(shell.getCompletions(context.Background(), text))
+	}
+
 	t.Run("hidden directory is omitted by default", func(t *testing.T) {
-		got := completionTexts(shell.getFilePathCompletions(""))
+		got := complete(".import ")
 		if slices.Contains(got, ".secret/") {
 			t.Errorf("hidden directory should not be suggested by default, got %v", got)
 		}
 	})
 
 	t.Run("explicitly typed hidden prefix offers the hidden directory", func(t *testing.T) {
-		got := completionTexts(shell.getFilePathCompletions(".s"))
+		got := complete(".import .s")
 		if !slices.Contains(got, ".secret/") {
-			t.Errorf("expected .secret/ for prefix \".s\", got %v", got)
+			t.Errorf("expected .secret/ for \".import .s\", got %v", got)
 		}
 	})
 
 	t.Run("descending into a hidden directory lists its files", func(t *testing.T) {
-		got := completionTexts(shell.getFilePathCompletions(".secret/"))
+		got := complete(".import .secret/")
 		if !slices.Contains(got, ".secret/data.csv") {
 			t.Errorf("expected .secret/data.csv, got %v", got)
 		}
@@ -280,7 +286,7 @@ func TestCompletionHiddenPaths(t *testing.T) {
 	})
 
 	t.Run("descending into a hidden subdirectory lists its files", func(t *testing.T) {
-		got := completionTexts(shell.getFilePathCompletions(".secret/sub/"))
+		got := complete(".import .secret/sub/")
 		if !slices.Contains(got, ".secret/sub/nested.csv") {
 			t.Errorf("expected .secret/sub/nested.csv, got %v", got)
 		}

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -232,6 +232,61 @@ func TestCompletionEscapesSpaceContainingPaths(t *testing.T) {
 	})
 }
 
+func TestCompletionHiddenPaths(t *testing.T) {
+	// Note: cannot use t.Parallel() with t.Chdir().
+	tmpDir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+	t.Cleanup(func() { t.Chdir(orig) })
+
+	makeTree(t, []string{
+		".secret/data.csv",
+		".secret/sub/",
+		".secret/sub/nested.csv",
+		"visible.csv",
+	})
+
+	shell, cleanup, shellErr := newShell(t, []string{"sqly"})
+	if shellErr != nil {
+		t.Fatal(shellErr)
+	}
+	defer cleanup()
+
+	t.Run("hidden directory is omitted by default", func(t *testing.T) {
+		got := completionTexts(shell.getFilePathCompletions(""))
+		if slices.Contains(got, ".secret/") {
+			t.Errorf("hidden directory should not be suggested by default, got %v", got)
+		}
+	})
+
+	t.Run("explicitly typed hidden prefix offers the hidden directory", func(t *testing.T) {
+		got := completionTexts(shell.getFilePathCompletions(".s"))
+		if !slices.Contains(got, ".secret/") {
+			t.Errorf("expected .secret/ for prefix \".s\", got %v", got)
+		}
+	})
+
+	t.Run("descending into a hidden directory lists its files", func(t *testing.T) {
+		got := completionTexts(shell.getFilePathCompletions(".secret/"))
+		if !slices.Contains(got, ".secret/data.csv") {
+			t.Errorf("expected .secret/data.csv, got %v", got)
+		}
+		if !slices.Contains(got, ".secret/sub/") {
+			t.Errorf("expected nested directory .secret/sub/, got %v", got)
+		}
+	})
+
+	t.Run("descending into a hidden subdirectory lists its files", func(t *testing.T) {
+		got := completionTexts(shell.getFilePathCompletions(".secret/sub/"))
+		if !slices.Contains(got, ".secret/sub/nested.csv") {
+			t.Errorf("expected .secret/sub/nested.csv, got %v", got)
+		}
+	})
+}
+
 func TestCompletionInsideQuotedPath(t *testing.T) {
 	// Note: cannot use t.Parallel() with t.Chdir().
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary

`.import` tab completion already enumerates a hidden directory once its prefix is typed explicitly. The behavior the issue describes (an unconditional recursive walk that skipped hidden paths) was replaced by the prefix-scoped completion rewrite, which reads only the directory named by the typed prefix and includes hidden entries when the partial starts with a dot.

This change adds regression tests so the behavior cannot drift.

## Tests

`shell/completion_test.go` adds `TestCompletionHiddenPaths`: hidden directories stay omitted by default, become completable once the hidden prefix (`.s`) is typed, and completion descends into both a hidden directory (`.secret/`) and a nested hidden subdirectory (`.secret/sub/`).

Closes #612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab completion for hidden paths: hidden folders stay out of suggestions by default, but are included when a hidden prefix is typed explicitly.
  * Completion now correctly lists files inside hidden directories, including nested hidden folders.

* **Tests**
  * Added regression coverage for hidden files and hidden directory traversal in completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->