### PR TITLE
test(shell): cover directory candidates in .import completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Directory Import Completion: `.import` tab completion offers directory candidates with a trailing slash, so a directory import target (for example `datadir/`) is discoverable and can be accepted and imported directly, not just descended into. Regression tests lock the directory-candidate behavior in.
 * Hidden Path Import Completion: `.import` tab completion stays hidden-by-default but now traverses a hidden directory once its prefix is typed explicitly, so `.import .secret/` lists the importable files inside it. Regression tests lock this in for both hidden files and nested hidden directories.
 * Quoted Import Completion: `.import` tab completion now works while typing a quoted path. After an opening quote (for example `.import "my`), completion matches the path fragment inside the quote and keeps it quoted, closing the quote on a file and leaving it open on a directory so the accepted command stays a single argument.
 * Home-Directory Expansion in Helpers: `.cd`, `.ls`, `.import`, `.dump`, and `.save` now expand a leading `~` (and `~/...`) to the user's home directory before running, so `.cd ~` and `.import ~/data.csv` work instead of failing on a literal `~`. Forms like `~user` or a `~` later in the path are left untouched.

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -232,6 +232,71 @@ func TestCompletionEscapesSpaceContainingPaths(t *testing.T) {
 	})
 }
 
+func TestCompletionSuggestsDirectoryArguments(t *testing.T) {
+	// Note: cannot use t.Parallel() with t.Chdir().
+	tmpDir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+	t.Cleanup(func() { t.Chdir(orig) })
+
+	if err := os.MkdirAll("datadir", 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("datadir", "a.csv"), []byte("id,name\n1,foo\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("plain.csv", []byte("id\n1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	shell, cleanup, shellErr := newShell(t, []string{"sqly"})
+	if shellErr != nil {
+		t.Fatal(shellErr)
+	}
+	defer cleanup()
+
+	t.Run("partial directory name is offered as a directory candidate", func(t *testing.T) {
+		got := shell.getCompletions(context.Background(), ".import data")
+		var dir *Suggest
+		for i := range got {
+			if got[i].Text == "datadir/" {
+				dir = &got[i]
+			}
+		}
+		if dir == nil {
+			t.Fatalf("expected directory candidate \"datadir/\", got %v", completionTexts(got))
+		}
+		// A directory candidate is distinguished from a file by the trailing slash
+		// and the directory description.
+		if dir.Description != msgImportableDir {
+			t.Errorf("directory description = %q, want %q", dir.Description, msgImportableDir)
+		}
+	})
+
+	t.Run("a completed directory argument can be imported directly", func(t *testing.T) {
+		got := shell.getCompletions(context.Background(), ".import data")
+		var dirArg string
+		for _, s := range got {
+			if s.Text == "datadir/" {
+				argv, err := splitArgs(".import " + s.Text)
+				if err != nil || len(argv) != 2 {
+					t.Fatalf("directory suggestion does not round-trip: %v", err)
+				}
+				dirArg = argv[1]
+			}
+		}
+		if dirArg == "" {
+			t.Fatal("no directory suggestion found")
+		}
+		if err := shell.commands.importCommand(context.Background(), shell, []string{dirArg}); err != nil {
+			t.Fatalf("importing completed directory %q failed: %v", dirArg, err)
+		}
+	})
+}
+
 func TestCompletionHiddenPaths(t *testing.T) {
 	// Note: cannot use t.Parallel() with t.Chdir().
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary

`.import` tab completion already offers directory candidates with a trailing slash. The behavior the issue describes (only file suggestions returned) was the old recursive walk; the prefix-scoped completion rewrite now returns directories too, distinguished by a trailing `/` and the `Directory` description.

This change adds regression tests so directory import stays discoverable from completion.

## Tests

`shell/completion_test.go` adds `TestCompletionSuggestsDirectoryArguments`: a partial directory name is offered as a directory candidate (trailing slash, directory description), and the completed directory argument round-trips through `splitArgs` and imports directly.

Closes #613