### PR TITLE
fix(shell): expand ~/ home paths in .import completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Home-Path Import Completion: `.import` tab completion now expands a leading `~/` to the home directory for the lookup while keeping the suggestion rendered as `~/file.csv`, so home-directory paths complete the same way relative and absolute paths do. The accepted `~/...` argument is expanded again at import time.
 * Directory Import Completion: `.import` tab completion offers directory candidates with a trailing slash, so a directory import target (for example `datadir/`) is discoverable and can be accepted and imported directly, not just descended into. Regression tests lock the directory-candidate behavior in.
 * Hidden Path Import Completion: `.import` tab completion stays hidden-by-default but now traverses a hidden directory once its prefix is typed explicitly, so `.import .secret/` lists the importable files inside it. Regression tests lock this in for both hidden files and nested hidden directories.
 * Quoted Import Completion: `.import` tab completion now works while typing a quoted path. After an opening quote (for example `.import "my`), completion matches the path fragment inside the quote and keeps it quoted, closing the quote on a file and leaving it open on a directory so the accepted command stays a single argument.

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -297,6 +297,62 @@ func TestCompletionSuggestsDirectoryArguments(t *testing.T) {
 	})
 }
 
+func TestCompletionExpandsTildeHomePaths(t *testing.T) {
+	// Note: cannot use t.Parallel() with t.Setenv/t.Chdir.
+	home := t.TempDir()
+	// os.UserHomeDir reads $HOME on Unix and %USERPROFILE% on Windows; set both so
+	// the expansion targets the temp home on every platform.
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	if err := os.WriteFile(filepath.Join(home, "home.csv"), []byte("id\n1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "homedir"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run from an unrelated directory so "~/" is the only way to reach the file.
+	t.Chdir(t.TempDir())
+
+	shell, cleanup, shellErr := newShell(t, []string{"sqly"})
+	if shellErr != nil {
+		t.Fatal(shellErr)
+	}
+	defer cleanup()
+
+	complete := func(text string) []string {
+		return completionTexts(shell.getCompletions(context.Background(), text))
+	}
+
+	t.Run("tilde-slash prefix completes a home-directory file", func(t *testing.T) {
+		got := complete(".import ~/h")
+		if !slices.Contains(got, "~/home.csv") {
+			t.Errorf("expected ~/home.csv for \".import ~/h\", got %v", got)
+		}
+		if !slices.Contains(got, "~/homedir/") {
+			t.Errorf("expected ~/homedir/ for \".import ~/h\", got %v", got)
+		}
+	})
+
+	t.Run("bare tilde-slash lists the home directory", func(t *testing.T) {
+		got := complete(".import ~/")
+		if !slices.Contains(got, "~/home.csv") {
+			t.Errorf("expected ~/home.csv for \".import ~/\", got %v", got)
+		}
+	})
+
+	t.Run("a completed tilde path imports after expansion", func(t *testing.T) {
+		got := complete(".import ~/h")
+		if !slices.Contains(got, "~/home.csv") {
+			t.Fatalf("missing ~/home.csv suggestion: %v", got)
+		}
+		if err := shell.commands.importCommand(context.Background(), shell, []string{"~/home.csv"}); err != nil {
+			t.Fatalf("importing completed ~/home.csv failed: %v", err)
+		}
+	})
+}
+
 func TestCompletionHiddenPaths(t *testing.T) {
 	// Note: cannot use t.Parallel() with t.Chdir().
 	tmpDir := t.TempDir()

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -1145,6 +1145,15 @@ func (s *Shell) getFilePathCompletions(prefix string) []Suggest {
 	readDir = filepath.FromSlash(strings.ReplaceAll(unescapeCompletionPath(readDir), `\`, "/"))
 	partial = unescapeCompletionPath(partial)
 
+	// Expand a leading "~" so a home-directory prefix enumerates the real home
+	// directory for the lookup. base keeps the typed "~/" so suggestions render as
+	// "~/file.csv"; .import expands the tilde again at execution time.
+	expandedReadDir, err := expandTilde(readDir)
+	if err != nil {
+		return nil
+	}
+	readDir = expandedReadDir
+
 	entries, err := os.ReadDir(readDir)
 	if err != nil {
 		return nil


### PR DESCRIPTION
## Summary

The completer treated `~/` as a path-like prefix but never expanded it, so `.import ~/h<TAB>` read a literal `~/` directory, found nothing, and did not complete.

Completion now expands a leading `~` to the home directory for the directory scan while keeping the typed `~/` on each suggestion, so completions render as `~/file.csv` and stay executable (`.import` expands the tilde again at run time). Home-path completion now behaves consistently with relative and absolute path completion.

## Tests

`shell/completion_test.go` adds `TestCompletionExpandsTildeHomePaths` with `HOME`/`USERPROFILE` pointed at a temp directory: `~/h` completes a home file and directory, bare `~/` lists the home directory, and a completed `~/home.csv` imports after expansion.

Closes #619