### PR TITLE
feat(shell): complete filesystem paths for .cd, .ls, .dump, and .save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### New Features
+* Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
+
 ### Bug Fixes
 * Home-Path Import Completion: `.import` tab completion now expands a leading `~/` to the home directory for the lookup while keeping the suggestion rendered as `~/file.csv`, so home-directory paths complete the same way relative and absolute paths do. The accepted `~/...` argument is expanded again at import time.
 * Directory Import Completion: `.import` tab completion offers directory candidates with a trailing slash, so a directory import target (for example `datadir/`) is discoverable and can be accepted and imported directly, not just descended into. Regression tests lock the directory-candidate behavior in.

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -232,6 +232,77 @@ func TestCompletionEscapesSpaceContainingPaths(t *testing.T) {
 	})
 }
 
+func TestPathCompletionForHelperCommands(t *testing.T) {
+	// Note: cannot use t.Parallel() with t.Chdir().
+	tmpDir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+	t.Cleanup(func() { t.Chdir(orig) })
+
+	makeTree(t, []string{
+		"datadir/",
+		"datadir/inner.csv",
+		"report.csv",
+	})
+
+	shell, cleanup, shellErr := newShell(t, []string{"sqly"})
+	if shellErr != nil {
+		t.Fatal(shellErr)
+	}
+	defer cleanup()
+
+	complete := func(text string) []string {
+		return completionTexts(shell.getCompletions(context.Background(), text))
+	}
+
+	t.Run(".cd completes directories only", func(t *testing.T) {
+		got := complete(".cd data")
+		if !slices.Contains(got, "datadir/") {
+			t.Errorf("expected datadir/ for \".cd data\", got %v", got)
+		}
+		if slices.Contains(got, "report.csv") {
+			t.Errorf(".cd should not offer files, got %v", got)
+		}
+	})
+
+	t.Run(".save completes directories only", func(t *testing.T) {
+		got := complete(".save data")
+		if !slices.Contains(got, "datadir/") {
+			t.Errorf("expected datadir/ for \".save data\", got %v", got)
+		}
+		if slices.Contains(got, "report.csv") {
+			t.Errorf(".save should not offer files, got %v", got)
+		}
+	})
+
+	t.Run(".ls completes files and directories", func(t *testing.T) {
+		got := complete(".ls ")
+		if !slices.Contains(got, "datadir/") {
+			t.Errorf("expected datadir/ for \".ls \", got %v", got)
+		}
+		if !slices.Contains(got, "report.csv") {
+			t.Errorf("expected report.csv for \".ls \", got %v", got)
+		}
+	})
+
+	t.Run(".dump completes the destination path after the table argument", func(t *testing.T) {
+		got := complete(".dump mytable data")
+		if !slices.Contains(got, "datadir/") {
+			t.Errorf("expected datadir/ for \".dump mytable data\", got %v", got)
+		}
+	})
+
+	t.Run(".dump does not path-complete the table-name argument", func(t *testing.T) {
+		got := complete(".dump data")
+		if slices.Contains(got, "datadir/") {
+			t.Errorf(".dump should not path-complete the table name, got %v", got)
+		}
+	})
+}
+
 func TestCompletionSuggestsDirectoryArguments(t *testing.T) {
 	// Note: cannot use t.Parallel() with t.Chdir().
 	tmpDir := t.TempDir()

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -602,6 +602,27 @@ func (s *Shell) getCompletions(ctx context.Context, input string) []Suggest {
 	// escaped word boundary (enabled with WithWordEscape) used to accept the
 	// completion, so the directory portion is not lost when descending.
 	currentWord := currentCompletionWord(text)
+
+	// Command-aware path completion: the path-taking helper commands complete
+	// filesystem paths at their path argument. .cd and .save target a directory,
+	// so only directories are offered; .ls/.dump/.import also offer importable
+	// files. This runs before the generic path detection so a directory-only
+	// command is never given file suggestions.
+	if cmdWords := strings.Fields(text); len(cmdWords) >= 1 {
+		if pathArg, multi, dirsOnly, ok := pathCommandSpec(cmdWords[0]); ok {
+			argIndex := len(cmdWords) - 1
+			if currentWord == "" {
+				argIndex = len(cmdWords) // a trailing space starts the next argument
+			}
+			if argIndex == pathArg || (multi && argIndex >= pathArg) {
+				if quote, rawInner, ok := openQuotePrefix(currentWord); ok {
+					return keepDirsOnly(s.getQuotedFilePathCompletions(rawInner, quote), dirsOnly)
+				}
+				return keepDirsOnly(s.getFilePathCompletions(currentWord), dirsOnly)
+			}
+		}
+	}
+
 	// Check if we're dealing with a file path (contains / or \ or starts with common path patterns)
 	isFilePath := strings.Contains(currentWord, "/") ||
 		strings.Contains(currentWord, `\`) || // Windows path separator support
@@ -634,25 +655,9 @@ func (s *Shell) getCompletions(ctx context.Context, input string) []Suggest {
 	}
 
 	// Check if this might be at the end where we expect a file path
-	// (after SQL query or after .import command)
+	// (after a SQL query). Helper-command path completion is handled above.
 	words := strings.Fields(text)
 	if len(words) > 0 {
-		// If the line starts with .import, always provide file completions for the last argument
-		if len(words) >= 1 && words[0] == importCommand {
-			// When the in-progress word opens a quote (e.g. .import "my), complete
-			// the path fragment inside the quote and keep it quoted so the accepted
-			// command stays valid. This is the scenario that needs quoting in the
-			// first place: a path with spaces.
-			if quote, rawInner, ok := openQuotePrefix(currentWord); ok {
-				return s.getQuotedFilePathCompletions(rawInner, quote)
-			}
-			fileCompletions := s.getFilePathCompletions(currentWord)
-
-			// For new full-path completion behavior, return all files without filtering
-			// This ensures users see all importable files regardless of input
-			return fileCompletions
-		}
-
 		// If we have a SQL query and the current word might be a filename
 		if strings.Contains(strings.ToUpper(text), "FROM") ||
 			strings.Contains(strings.ToUpper(text), "SELECT") {
@@ -1127,6 +1132,42 @@ func slashifyBase(base string) string {
 		b.WriteRune(runes[i])
 	}
 	return b.String()
+}
+
+// pathCommandSpec reports how a helper command participates in path completion:
+// the 0-based argument index where the path is typed (the command itself is
+// index 0), whether multiple trailing paths are accepted, and whether only
+// directories are offered. ok is false for commands that take no path.
+func pathCommandSpec(cmd string) (pathArg int, multi, dirsOnly, ok bool) {
+	switch cmd {
+	case importCommand: // .import FILE...
+		return 1, true, false, true
+	case lsCommand: // .ls PATH
+		return 1, false, false, true
+	case cdCommand: // .cd DIR
+		return 1, false, true, true
+	case saveCommand: // .save DIR
+		return 1, false, true, true
+	case dumpCommand: // .dump TABLE PATH
+		return 2, false, false, true
+	}
+	return 0, false, false, false
+}
+
+// keepDirsOnly drops file suggestions when a command targets a directory (.cd,
+// .save). Directory suggestions carry a trailing "/", so they are kept while
+// files are filtered out. When dirsOnly is false the suggestions pass through.
+func keepDirsOnly(suggestions []Suggest, dirsOnly bool) []Suggest {
+	if !dirsOnly {
+		return suggestions
+	}
+	filtered := make([]Suggest, 0, len(suggestions))
+	for _, sg := range suggestions {
+		if strings.HasSuffix(sg.Text, "/") {
+			filtered = append(filtered, sg)
+		}
+	}
+	return filtered
 }
 
 // getFilePathCompletions returns importable-file and directory suggestions


### PR DESCRIPTION
## Summary

Path completion was wired only for `.import`, leaving the other path-oriented helper commands without any path suggestions.

This adds a command-aware path-completion step that runs before the generic path detection:

- `.cd` and `.save` offer directories only.
- `.ls` offers files and directories.
- `.dump` completes the destination path after the table-name argument (and does not path-complete the table-name argument itself).
- `.import` keeps its existing multi-path behavior.

The lookup stays in-process and cross-platform, and reuses the existing quote-aware and tilde-aware path completion.

## Tests

`shell/completion_test.go` adds `TestPathCompletionForHelperCommands`: `.cd`/`.save` complete directories only (no files), `.ls` completes both, `.dump TABLE <prefix>` completes the destination path, and `.dump <prefix>` does not path-complete the table-name argument.

Closes #614