### PR TITLE
fix(shell): complete the token under the cursor, not the line end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* Cursor-Aware Completion: tab completion now uses the text before the cursor instead of the whole line, so moving the cursor back into an earlier path, table name, or SQL identifier and pressing TAB completes the token under the cursor rather than the line ending.
 * Home-Path Import Completion: `.import` tab completion now expands a leading `~/` to the home directory for the lookup while keeping the suggestion rendered as `~/file.csv`, so home-directory paths complete the same way relative and absolute paths do. The accepted `~/...` argument is expanded again at import time.
 * Directory Import Completion: `.import` tab completion offers directory candidates with a trailing slash, so a directory import target (for example `datadir/`) is discoverable and can be accepted and imported directly, not just descended into. Regression tests lock the directory-candidate behavior in.
 * Hidden Path Import Completion: `.import` tab completion stays hidden-by-default but now traverses a hidden directory once its prefix is typed explicitly, so `.import .secret/` lists the importable files inside it. Regression tests lock this in for both hidden files and nested hidden directories.

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -9,10 +9,20 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nao1215/prompt"
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/interactor/mock"
 	"go.uber.org/mock/gomock"
 )
+
+// promptSuggestionTexts extracts the Text of each prompt.Suggestion.
+func promptSuggestionTexts(suggestions []prompt.Suggestion) []string {
+	texts := make([]string, 0, len(suggestions))
+	for _, s := range suggestions {
+		texts = append(texts, s.Text)
+	}
+	return texts
+}
 
 func hasSuggestionText(suggestions []Suggest, text string) bool {
 	for _, suggestion := range suggestions {
@@ -230,6 +240,68 @@ func TestCompletionEscapesSpaceContainingPaths(t *testing.T) {
 			t.Errorf("plain file should be suggested verbatim, got %v", got)
 		}
 	})
+}
+
+func TestCompletionRespectsCursorPositionForHelperPath(t *testing.T) {
+	// Note: cannot use t.Parallel() with t.Chdir().
+	tmpDir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmpDir)
+	t.Cleanup(func() { t.Chdir(orig) })
+
+	makeTree(t, []string{
+		"datadir/",
+		"datadir/inner.csv",
+	})
+
+	shell, cleanup, shellErr := newShell(t, []string{"sqly"})
+	if shellErr != nil {
+		t.Fatal(shellErr)
+	}
+	defer cleanup()
+
+	// Cursor sits right after the first argument "data", with trailing text still
+	// present. Completion must target the token under the cursor, not the line end.
+	text := ".import data other.csv"
+	cursor := len(".import data")
+	d := prompt.Document{Text: text, CursorPosition: cursor}
+
+	got := promptSuggestionTexts(shell.completeDocument(context.Background(), d))
+	if !slices.Contains(got, "datadir/") {
+		t.Errorf("expected datadir/ when completing the token under the cursor, got %v", got)
+	}
+}
+
+func TestCompletionRespectsCursorPositionForSQLIdentifier(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if err := shell.commands.importCommand(context.Background(), shell, []string{filepath.Join("testdata", "user.csv")}); err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+
+	// Cursor is inside the earlier identifier "identi", before " FROM user".
+	text := "SELECT identi FROM user"
+	cursor := len("SELECT identi")
+	d := prompt.Document{Text: text, CursorPosition: cursor}
+
+	got := promptSuggestionTexts(shell.completeDocument(context.Background(), d))
+	if !slices.Contains(got, "identifier") {
+		t.Errorf("expected the identifier column completing the token at the cursor, got %v", got)
+	}
+
+	// Completing the whole line (cursor ignored) filters by the trailing "user",
+	// so it would not surface "identifier"; this contrast proves cursor-awareness.
+	full := promptSuggestionTexts(shell.completerNew(context.Background(), text))
+	if slices.Contains(full, "identifier") {
+		t.Errorf("line-end completion unexpectedly surfaced identifier: %v", full)
+	}
 }
 
 func TestPathCompletionForHelperCommands(t *testing.T) {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -361,7 +361,7 @@ func (s *Shell) communicate(ctx context.Context) error {
 
 func (s *Shell) newPromptSession(ctx context.Context) (promptSession, error) {
 	p, err := s.newPrompt(s.promptPrefix(), func(d prompt.Document) []prompt.Suggestion {
-		return s.completerNew(ctx, d.Text)
+		return s.completeDocument(ctx, d)
 	})
 	if err != nil {
 		return nil, err
@@ -592,6 +592,13 @@ func (s *Shell) completerNew(ctx context.Context, input string) []prompt.Suggest
 	}
 
 	return completions
+}
+
+// completeDocument returns completions for the token at the cursor. It uses the
+// text before the cursor (not the whole line) so editing an earlier token and
+// pressing TAB completes that token instead of the line ending.
+func (s *Shell) completeDocument(ctx context.Context, d prompt.Document) []prompt.Suggestion {
+	return s.completerNew(ctx, d.TextBeforeCursor())
 }
 
 // getCompletions returns suggestions for auto-completion.


### PR DESCRIPTION
## Summary

The completer received the whole line (`d.Text`) and always computed completions for the final token, so moving the cursor back into an earlier token and pressing TAB still completed the line ending.

Completion now uses the text before the cursor (`d.TextBeforeCursor()`) via a new `completeDocument` method, so the token under the cursor is completed. This applies to helper-command paths, table names, and SQL identifiers alike.

## Tests

`shell/completion_test.go` adds two regression tests: editing the first argument of a helper command while trailing text is present completes that argument (`.import data|...` -> `datadir/`), and a SQL line with the cursor inside an earlier identifier (`SELECT identi| FROM user`) completes `identifier`, with a contrast assertion that line-end completion does not surface it.

Closes #616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab completion to use the text before the cursor, so completing in the middle of a line now targets the token under the cursor instead of the line ending.
  * Fixed cursor-aware completion for helper-style paths and SQL identifiers.
* **Tests**
  * Added coverage for completion behavior when the cursor is moved within a token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->