### PR TITLE
feat(shell): complete Excel sheet names for .import --sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### New Features
+* Sheet-Name Completion: `.import WORKBOOK.xlsx --sheet ` (and the joined `--sheet=` form) now tab-completes the workbook's sheet names. Names with spaces or non-ASCII characters are completed in a quoted or backslash-escaped form that stays a single argument, and sheet completion does not fall back to file-path suggestions.
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### New Features
-* Sheet-Name Completion: `.import WORKBOOK.xlsx --sheet ` (and the joined `--sheet=` form) now tab-completes the workbook's sheet names. Names with spaces or non-ASCII characters are completed in a quoted or backslash-escaped form that stays a single argument, and sheet completion does not fall back to file-path suggestions.
+* Sheet-Name Completion: `.import WORKBOOK.xlsx --sheet` (and the joined `--sheet=` form) now tab-completes the workbook's sheet names. Names with spaces or non-ASCII characters are completed in a quoted or backslash-escaped form that stays a single argument, and sheet completion does not fall back to file-path suggestions.
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes

--- a/doc/pages/markdown/sqly_helper_command.md
+++ b/doc/pages/markdown/sqly_helper_command.md
@@ -88,6 +88,8 @@ sqly:~/github/github.com/nao1215/sqly(table)$ .import
   - JSON/JSONL data is stored in a 'data' column; use json_extract() to query fields
 ```
 
+After `--sheet`, press TAB to complete the sheet names of the first Excel workbook on the line. Quoted and backslash-escaped names with spaces are completed in a form that stays a single argument.
+
 ### ls command
 
 List directory contents (sorted, with a trailing `/` on directories). It runs in-process rather than calling the external `ls`/`dir`, so output is identical on every OS.

--- a/infrastructure/filesql/adapter.go
+++ b/infrastructure/filesql/adapter.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/nao1215/filesql"
 	"github.com/nao1215/sqly/domain/model"
+	"github.com/xuri/excelize/v2"
 )
 
 const (
@@ -601,6 +602,19 @@ func IsExcelFile(filePath string) bool {
 	}
 
 	return strings.HasSuffix(lower, ".xlsx")
+}
+
+// SheetNames returns the worksheet names of an Excel (.xlsx) workbook in their
+// in-workbook order. It is used for interactive --sheet completion. Compressed
+// workbooks are not opened here (excelize reads a plain .xlsx), so they return
+// an error and the caller simply offers no sheet suggestions.
+func SheetNames(filePath string) ([]string, error) {
+	f, err := excelize.OpenFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open Excel file %s: %w", filePath, err)
+	}
+	defer func() { _ = f.Close() }()
+	return f.GetSheetList(), nil
 }
 
 // generateRandomName generates a random 4-byte hex string.

--- a/infrastructure/filesql/adapter.go
+++ b/infrastructure/filesql/adapter.go
@@ -604,16 +604,31 @@ func IsExcelFile(filePath string) bool {
 	return strings.HasSuffix(lower, ".xlsx")
 }
 
-// SheetNames returns the worksheet names of an Excel (.xlsx) workbook in their
-// in-workbook order. It is used for interactive --sheet completion. Compressed
-// workbooks are not opened here (excelize reads a plain .xlsx), so they return
-// an error and the caller simply offers no sheet suggestions.
-func SheetNames(filePath string) ([]string, error) {
-	f, err := excelize.OpenFile(filePath)
+// SheetNames returns the worksheet names of an Excel workbook in their
+// in-workbook order. It is used for interactive --sheet completion. The workbook
+// is read through the adapter's decompressing reader, so compressed variants
+// (.xlsx.gz, .xlsx.zst, ...) are supported the same way as a plain .xlsx.
+func SheetNames(filePath string) (names []string, err error) {
+	r, cleanup, err := NewDecompressingReaderForFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open Excel file %s: %w", filePath, err)
 	}
-	defer func() { _ = f.Close() }()
+	defer func() {
+		if cerr := cleanup(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	f, err := excelize.OpenReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Excel file %s: %w", filePath, err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
 	return f.GetSheetList(), nil
 }
 

--- a/interactor/mock/import.go
+++ b/interactor/mock/import.go
@@ -194,6 +194,45 @@ func (c *MockImportUsecaseIsSupportedFileCall) DoAndReturn(f func(string) bool) 
 	return c
 }
 
+// ListExcelSheetNames mocks base method.
+func (m *MockImportUsecase) ListExcelSheetNames(filePath string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListExcelSheetNames", filePath)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListExcelSheetNames indicates an expected call of ListExcelSheetNames.
+func (mr *MockImportUsecaseMockRecorder) ListExcelSheetNames(filePath any) *MockImportUsecaseListExcelSheetNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExcelSheetNames", reflect.TypeOf((*MockImportUsecase)(nil).ListExcelSheetNames), filePath)
+	return &MockImportUsecaseListExcelSheetNamesCall{Call: call}
+}
+
+// MockImportUsecaseListExcelSheetNamesCall wrap *gomock.Call
+type MockImportUsecaseListExcelSheetNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportUsecaseListExcelSheetNamesCall) Return(arg0 []string, arg1 error) *MockImportUsecaseListExcelSheetNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportUsecaseListExcelSheetNamesCall) Do(f func(string) ([]string, error)) *MockImportUsecaseListExcelSheetNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportUsecaseListExcelSheetNamesCall) DoAndReturn(f func(string) ([]string, error)) *MockImportUsecaseListExcelSheetNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // LoadFiles mocks base method.
 func (m *MockImportUsecase) LoadFiles(ctx context.Context, filePaths ...string) error {
 	m.ctrl.T.Helper()

--- a/interactor/sqlite3.go
+++ b/interactor/sqlite3.go
@@ -171,6 +171,11 @@ func (si *SQLite3Interactor) IsExcelFile(filePath string) bool {
 	return filesql.IsExcelFile(filePath)
 }
 
+// ListExcelSheetNames returns the worksheet names of an Excel workbook.
+func (si *SQLite3Interactor) ListExcelSheetNames(filePath string) ([]string, error) {
+	return filesql.SheetNames(filePath)
+}
+
 // SanitizeForSQL sanitizes a string to be SQL-safe.
 func (si *SQLite3Interactor) SanitizeForSQL(name string) string {
 	return filesql.SanitizeForSQL(name)

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"compress/gzip"
 	"context"
 	"os"
 	"path/filepath"
@@ -304,6 +305,59 @@ func TestSheetNameCompletion(t *testing.T) {
 			if strings.Contains(text, "testdata") || strings.HasSuffix(text, ".csv") {
 				t.Errorf("sheet completion must not offer file paths, got %v", got)
 			}
+		}
+	})
+
+	t.Run("resolves a quoted workbook path containing spaces", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "dir with space")
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(spaced)
+		if err != nil {
+			t.Fatal(err)
+		}
+		book := filepath.Join(dir, "book.xlsx")
+		if err := os.WriteFile(book, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		got := complete(`.import "` + book + `" --sheet `)
+		var found bool
+		for _, text := range got {
+			if argv, err := splitArgs(".import wb.xlsx --sheet " + text); err == nil && len(argv) == 4 && argv[3] == "A test" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected sheet A test for a quoted spaced workbook path, got %v", got)
+		}
+	})
+
+	t.Run("reads sheet names from a compressed workbook", func(t *testing.T) {
+		data, err := os.ReadFile(simple)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gzPath := filepath.Join(t.TempDir(), "sample.xlsx.gz")
+		f, err := os.Create(gzPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gw := gzip.NewWriter(f)
+		if _, err := gw.Write(data); err != nil {
+			t.Fatal(err)
+		}
+		if err := gw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		got := complete(".import " + gzPath + " --sheet ")
+		if !slices.Contains(got, "test_sheet") {
+			t.Errorf("expected test_sheet from compressed workbook, got %v", got)
 		}
 	})
 }

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -242,6 +242,72 @@ func TestCompletionEscapesSpaceContainingPaths(t *testing.T) {
 	})
 }
 
+func TestSheetNameCompletion(t *testing.T) {
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	complete := func(text string) []string {
+		return completionTexts(shell.getCompletions(context.Background(), text))
+	}
+
+	simple := filepath.Join("testdata", "sample.xlsx")            // sheet: test_sheet
+	spaced := filepath.Join("testdata", "sheet_with_spaces.xlsx") // sheet: A test
+
+	t.Run("suggests sheet names after --sheet", func(t *testing.T) {
+		got := complete(".import " + simple + " --sheet ")
+		if !slices.Contains(got, "test_sheet") {
+			t.Errorf("expected sheet name test_sheet, got %v", got)
+		}
+	})
+
+	t.Run("filters sheet names by the typed prefix", func(t *testing.T) {
+		got := complete(".import " + simple + " --sheet te")
+		if !slices.Contains(got, "test_sheet") {
+			t.Errorf("expected test_sheet for prefix te, got %v", got)
+		}
+	})
+
+	t.Run("suggests sheet names for the joined --sheet= form", func(t *testing.T) {
+		got := complete(".import " + simple + " --sheet=te")
+		if !slices.Contains(got, "--sheet=test_sheet") {
+			t.Errorf("expected --sheet=test_sheet, got %v", got)
+		}
+	})
+
+	t.Run("escapes a space-containing sheet name so it round-trips", func(t *testing.T) {
+		got := complete(".import " + spaced + " --sheet ")
+		var found string
+		for _, text := range got {
+			argv, err := splitArgs(".import wb.xlsx --sheet " + text)
+			if err == nil && len(argv) == 4 && argv[3] == "A test" {
+				found = text
+			}
+		}
+		if found == "" {
+			t.Fatalf("no sheet suggestion round-trips to \"A test\", got %v", got)
+		}
+	})
+
+	t.Run("honors a quoted sheet-name fragment", func(t *testing.T) {
+		got := complete(".import " + spaced + ` --sheet "A`)
+		if !slices.Contains(got, `"A test"`) {
+			t.Errorf("expected quoted \"A test\", got %v", got)
+		}
+	})
+
+	t.Run("does not fall back to file-path suggestions for an unmatched sheet", func(t *testing.T) {
+		got := complete(".import " + simple + " --sheet zzz")
+		for _, text := range got {
+			if strings.Contains(text, "testdata") || strings.HasSuffix(text, ".csv") {
+				t.Errorf("sheet completion must not offer file paths, got %v", got)
+			}
+		}
+	})
+}
+
 func TestCompletionRespectsCursorPositionForHelperPath(t *testing.T) {
 	// Note: cannot use t.Parallel() with t.Chdir().
 	tmpDir := t.TempDir()

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -46,6 +46,7 @@ const (
 
 	msgImportableFile = "Importable file"
 	msgImportableDir  = "Directory"
+	msgExcelSheet     = "Excel sheet"
 )
 
 // Shell is main class of the sqly command.
@@ -609,6 +610,15 @@ func (s *Shell) getCompletions(ctx context.Context, input string) []Suggest {
 	// escaped word boundary (enabled with WithWordEscape) used to accept the
 	// completion, so the directory portion is not lost when descending.
 	currentWord := currentCompletionWord(text)
+
+	// .import --sheet completion: when the in-progress token is the value of the
+	// --sheet flag, suggest the workbook's sheet names instead of file paths. This
+	// runs before path completion so the sheet value is not treated as a path.
+	if cmdWords := strings.Fields(text); len(cmdWords) >= 1 && cmdWords[0] == importCommand {
+		if wb, partial, quote, joined, ok := s.sheetCompletionContext(cmdWords, currentWord); ok {
+			return s.getSheetCompletions(wb, partial, quote, joined)
+		}
+	}
 
 	// Command-aware path completion: the path-taking helper commands complete
 	// filesystem paths at their path argument. .cd and .save target a directory,
@@ -1175,6 +1185,87 @@ func keepDirsOnly(suggestions []Suggest, dirsOnly bool) []Suggest {
 		}
 	}
 	return filtered
+}
+
+// sheetCompletionContext reports whether the in-progress token is the value of
+// a .import --sheet flag (separated "--sheet NAME" or joined "--sheet=NAME"),
+// and if so returns the workbook to read sheet names from, the typed sheet
+// fragment, the opening quote rune (0 if unquoted), and whether the joined form
+// is used. The workbook is the first Excel file among the typed arguments, so
+// the behavior is deterministic when several files are present.
+func (s *Shell) sheetCompletionContext(words []string, currentWord string) (workbook, partial string, quote rune, joined, ok bool) {
+	switch {
+	case strings.HasPrefix(currentWord, sheetFlagAssign): // --sheet=...
+		joined = true
+		raw := strings.TrimPrefix(currentWord, sheetFlagAssign)
+		quote, partial = decodeSheetPartial(raw)
+	default:
+		// Separated form: the token immediately before the in-progress word is
+		// --sheet. A trailing space leaves currentWord empty with --sheet last.
+		prev := ""
+		if currentWord == "" {
+			prev = words[len(words)-1]
+		} else if len(words) >= 2 {
+			prev = words[len(words)-2]
+		}
+		if prev != sheetFlag {
+			return "", "", 0, false, false
+		}
+		quote, partial = decodeSheetPartial(currentWord)
+	}
+
+	for _, w := range words[1:] {
+		if w == sheetFlag || strings.HasPrefix(w, sheetFlagAssign) || strings.HasPrefix(w, "--") {
+			continue
+		}
+		token, err := expandTilde(unescapeCompletionPath(strings.Trim(w, `"'`)))
+		if err == nil && s.usecases.importer.IsExcelFile(token) {
+			workbook = token
+			break
+		}
+	}
+	if workbook == "" {
+		return "", "", 0, false, false
+	}
+	return workbook, partial, quote, joined, true
+}
+
+// decodeSheetPartial decodes a typed --sheet fragment into the opening quote
+// rune (0 if unquoted) and the literal sheet-name prefix to match.
+func decodeSheetPartial(raw string) (quote rune, partial string) {
+	if q, inner, openOK := openQuotePrefix(raw); openOK {
+		return q, decodeQuotedPath(inner, q)
+	}
+	return 0, unescapeCompletionPath(raw)
+}
+
+// getSheetCompletions returns sheet-name suggestions for a workbook, matching
+// the typed partial. Suggestions preserve the input style so the accepted
+// command stays valid: a quoted fragment is re-quoted, an unquoted fragment is
+// backslash-escaped, and the joined form keeps the --sheet= prefix.
+func (s *Shell) getSheetCompletions(workbook, partial string, quote rune, joined bool) []Suggest {
+	names, err := s.usecases.importer.ListExcelSheetNames(workbook)
+	if err != nil {
+		return nil
+	}
+	var suggestions []Suggest
+	for _, name := range names {
+		if !strings.HasPrefix(name, partial) {
+			continue
+		}
+		var text string
+		if quote != 0 {
+			q := string(quote)
+			text = q + name + q
+		} else {
+			text = escapeCompletionPath(name)
+		}
+		if joined {
+			text = sheetFlagAssign + text
+		}
+		suggestions = append(suggestions, Suggest{Text: text, Description: msgExcelSheet})
+	}
+	return suggestions
 }
 
 // getFilePathCompletions returns importable-file and directory suggestions

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -611,11 +611,17 @@ func (s *Shell) getCompletions(ctx context.Context, input string) []Suggest {
 	// completion, so the directory portion is not lost when descending.
 	currentWord := currentCompletionWord(text)
 
+	// Split the already-typed part of the line into shell-aware tokens so a
+	// quoted or escaped earlier argument (for example a workbook path with
+	// spaces) stays one token. completed excludes the in-progress word; its index
+	// is therefore len(completed).
+	completed := completedCommandWords(text, currentWord)
+
 	// .import --sheet completion: when the in-progress token is the value of the
 	// --sheet flag, suggest the workbook's sheet names instead of file paths. This
 	// runs before path completion so the sheet value is not treated as a path.
-	if cmdWords := strings.Fields(text); len(cmdWords) >= 1 && cmdWords[0] == importCommand {
-		if wb, partial, quote, joined, ok := s.sheetCompletionContext(cmdWords, currentWord); ok {
+	if len(completed) >= 1 && completed[0] == importCommand {
+		if wb, partial, quote, joined, ok := s.sheetCompletionContext(completed, currentWord); ok {
 			return s.getSheetCompletions(wb, partial, quote, joined)
 		}
 	}
@@ -625,12 +631,9 @@ func (s *Shell) getCompletions(ctx context.Context, input string) []Suggest {
 	// so only directories are offered; .ls/.dump/.import also offer importable
 	// files. This runs before the generic path detection so a directory-only
 	// command is never given file suggestions.
-	if cmdWords := strings.Fields(text); len(cmdWords) >= 1 {
-		if pathArg, multi, dirsOnly, ok := pathCommandSpec(cmdWords[0]); ok {
-			argIndex := len(cmdWords) - 1
-			if currentWord == "" {
-				argIndex = len(cmdWords) // a trailing space starts the next argument
-			}
+	if len(completed) >= 1 {
+		if pathArg, multi, dirsOnly, ok := pathCommandSpec(completed[0]); ok {
+			argIndex := len(completed) // the in-progress word is the next argument
 			if argIndex == pathArg || (multi && argIndex >= pathArg) {
 				if quote, rawInner, ok := openQuotePrefix(currentWord); ok {
 					return keepDirsOnly(s.getQuotedFilePathCompletions(rawInner, quote), dirsOnly)
@@ -1191,34 +1194,27 @@ func keepDirsOnly(suggestions []Suggest, dirsOnly bool) []Suggest {
 // a .import --sheet flag (separated "--sheet NAME" or joined "--sheet=NAME"),
 // and if so returns the workbook to read sheet names from, the typed sheet
 // fragment, the opening quote rune (0 if unquoted), and whether the joined form
-// is used. The workbook is the first Excel file among the typed arguments, so
-// the behavior is deterministic when several files are present.
-func (s *Shell) sheetCompletionContext(words []string, currentWord string) (workbook, partial string, quote rune, joined, ok bool) {
+// is used. completed holds the already-typed tokens (shell-decoded, excluding
+// the in-progress word). The workbook is the first Excel file among them, so the
+// behavior is deterministic when several files are present.
+func (s *Shell) sheetCompletionContext(completed []string, currentWord string) (workbook, partial string, quote rune, joined, ok bool) {
 	switch {
 	case strings.HasPrefix(currentWord, sheetFlagAssign): // --sheet=...
 		joined = true
-		raw := strings.TrimPrefix(currentWord, sheetFlagAssign)
-		quote, partial = decodeSheetPartial(raw)
-	default:
-		// Separated form: the token immediately before the in-progress word is
-		// --sheet. A trailing space leaves currentWord empty with --sheet last.
-		prev := ""
-		if currentWord == "" {
-			prev = words[len(words)-1]
-		} else if len(words) >= 2 {
-			prev = words[len(words)-2]
-		}
-		if prev != sheetFlag {
-			return "", "", 0, false, false
-		}
+		quote, partial = decodeSheetPartial(strings.TrimPrefix(currentWord, sheetFlagAssign))
+	case completed[len(completed)-1] == sheetFlag: // separated "--sheet NAME"
 		quote, partial = decodeSheetPartial(currentWord)
+	default:
+		return "", "", 0, false, false
 	}
 
-	for _, w := range words[1:] {
+	// completed tokens are already shell-decoded, so a quoted/escaped workbook
+	// path with spaces is one intact token here.
+	for _, w := range completed[1:] {
 		if w == sheetFlag || strings.HasPrefix(w, sheetFlagAssign) || strings.HasPrefix(w, "--") {
 			continue
 		}
-		token, err := expandTilde(unescapeCompletionPath(strings.Trim(w, `"'`)))
+		token, err := expandTilde(w)
 		if err == nil && s.usecases.importer.IsExcelFile(token) {
 			workbook = token
 			break
@@ -1228,6 +1224,20 @@ func (s *Shell) sheetCompletionContext(words []string, currentWord string) (work
 		return "", "", 0, false, false
 	}
 	return workbook, partial, quote, joined, true
+}
+
+// completedCommandWords splits the already-typed portion of text (everything
+// before the in-progress word) into shell-aware tokens, so a quoted or escaped
+// earlier argument stays a single decoded token. It falls back to whitespace
+// splitting only if the prefix cannot be tokenized (an unterminated quote in an
+// earlier token), keeping completion functional rather than empty.
+func completedCommandWords(text, currentWord string) []string {
+	prefix := strings.TrimSuffix(text, currentWord)
+	args, err := splitArgs(prefix)
+	if err != nil {
+		return strings.Fields(prefix)
+	}
+	return args
 }
 
 // decodeSheetPartial decodes a typed --sheet fragment into the opening quote

--- a/usecase/import.go
+++ b/usecase/import.go
@@ -21,6 +21,9 @@ type ImportUsecase interface {
 	IsSupportedFile(filePath string) bool
 	// IsExcelFile checks if the file is an Excel format
 	IsExcelFile(filePath string) bool
+	// ListExcelSheetNames returns the worksheet names of an Excel workbook in
+	// workbook order, used for --sheet completion.
+	ListExcelSheetNames(filePath string) ([]string, error)
 	// SanitizeForSQL sanitizes a string to be SQL-safe
 	SanitizeForSQL(name string) string
 	// QuoteIdentifier safely quotes a SQL identifier


### PR DESCRIPTION
## Summary

`.import --sheet` had no completion, leaving the most error-prone part of the Excel import command fully manual.

This adds a `ListExcelSheetNames` import usecase (backed by excelize in the filesql adapter) and wires sheet-name completion into the shell. When the in-progress token is the value of `--sheet` (separated `--sheet NAME` or joined `--sheet=NAME`), the workbook's sheet names are suggested instead of file paths. The first Excel file on the line is used, so multi-file commands stay deterministic. Names with spaces or non-ASCII characters are completed in a quoted or backslash-escaped form that round-trips through `splitArgs`, and sheet completion does not fall back to file-path suggestions.

## Tests

`shell/completion_test.go` adds `TestSheetNameCompletion`: completion after `--sheet`, prefix filtering, the joined `--sheet=` form, a space-containing sheet name that round-trips to a single argument, a quoted sheet-name fragment, and a no-match case that does not offer file paths.

## Docs

`doc/pages/markdown/sqly_helper_command.md` notes the new sheet completion in the `.import` section.

Closes #615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive sheet-name completion for `.import` commands using `--sheet` and `--sheet=`.
  * Sheet names now appear in workbook order and handle spaces, quotes, and non-ASCII characters correctly.
* **Bug Fixes**
  * Completion no longer falls back to file-path suggestions when a sheet name prefix doesn’t match.
* **Documentation**
  * Updated command docs and changelog to describe the improved sheet completion behavior.
* **Tests**
  * Added coverage for sheet-name completion scenarios, including quoting and prefix filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->