### PR TITLE
fix(shell): bind documented Ctrl+P/Ctrl+N history keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* History Control Keys: the interactive shell now binds the documented Ctrl+P and Ctrl+N keys to previous/next command history, matching the arrow keys.
 * Cursor-Aware Completion: tab completion now uses the text before the cursor instead of the whole line, so moving the cursor back into an earlier path, table name, or SQL identifier and pressing TAB completes the token under the cursor rather than the line ending.
 * Home-Path Import Completion: `.import` tab completion now expands a leading `~/` to the home directory for the lookup while keeping the suggestion rendered as `~/file.csv`, so home-directory paths complete the same way relative and absolute paths do. The accepted `~/...` argument is expanded again at import time.
 * Directory Import Completion: `.import` tab completion offers directory candidates with a trailing slash, so a directory import target (for example `datadir/`) is discoverable and can be accepted and imported directly, not just descended into. Regression tests lock the directory-candidate behavior in.

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -135,6 +135,7 @@ func NewShell(
 				prompt.WithMultiline(true),
 				prompt.WithIsComplete(sqlInputComplete),
 				prompt.WithWordEscape(),
+				prompt.WithKeyMap(sqlyKeyMap()),
 			)
 		},
 		stdin:          os.Stdin,
@@ -358,6 +359,17 @@ func (s *Shell) communicate(ctx context.Context) error {
 			continue
 		}
 	}
+}
+
+// sqlyKeyMap returns the prompt key map with the Emacs-style control shortcuts
+// the sqly shell documents on top of the prompt library defaults. The library
+// already binds Ctrl+A/E/K/U/W/R and the arrow keys; this adds the control-key
+// equivalents the docs advertise: Ctrl+P/Ctrl+N for history navigation.
+func sqlyKeyMap() *prompt.KeyMap {
+	km := prompt.NewDefaultKeyMap()
+	km.Bind('\x10', prompt.ActionHistoryUp)   // Ctrl+P: previous command
+	km.Bind('\x0e', prompt.ActionHistoryDown) // Ctrl+N: next command
+	return km
 }
 
 func (s *Shell) newPromptSession(ctx context.Context) (promptSession, error) {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -3343,6 +3343,32 @@ func TestAbbreviateHome(t *testing.T) {
 	}
 }
 
+func TestSqlyKeyMap(t *testing.T) {
+	t.Parallel()
+
+	km := sqlyKeyMap()
+
+	tests := []struct {
+		name string
+		key  rune
+		want prompt.KeyAction
+	}{
+		{name: "Ctrl+P navigates to the previous command", key: '\x10', want: prompt.ActionHistoryUp},
+		{name: "Ctrl+N navigates to the next command", key: '\x0e', want: prompt.ActionHistoryDown},
+		{name: "Ctrl+A still moves to the line start (default preserved)", key: '\x01', want: prompt.ActionMoveHome},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := km.GetAction(tt.key); got != tt.want {
+				t.Errorf("GetAction(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestShellExec_SchemaQualifiedTempView covers the helper-command surface added
 // for v0.20.0 hardening: schema-qualified names, TEMP tables, and views.
 func TestShellExec_SchemaQualifiedTempView(t *testing.T) {


### PR DESCRIPTION
## Summary

The shell documentation advertises Ctrl+P/Ctrl+N for history navigation, but the prompt library's default keymap only wires the arrow keys.

This installs a custom key map (`sqlyKeyMap`) that adds Ctrl+P -> previous history and Ctrl+N -> next history on top of the library defaults, so the documented control keys work like the arrow keys.

## Tests

`shell/shell_test.go` adds `TestSqlyKeyMap`, asserting Ctrl+P binds to `ActionHistoryUp`, Ctrl+N to `ActionHistoryDown`, and that a default binding (Ctrl+A) is preserved.

Closes #618