### PR TITLE
fix(shell): bind documented Ctrl+F/Ctrl+B cursor-movement keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 * History Control Keys: the interactive shell now binds the documented Ctrl+P and Ctrl+N keys to previous/next command history, matching the arrow keys.
+* Cursor Movement Control Keys: the interactive shell now binds the documented Ctrl+F and Ctrl+B keys to move the cursor forward/backward one character, matching the arrow keys.
 * Cursor-Aware Completion: tab completion now uses the text before the cursor instead of the whole line, so moving the cursor back into an earlier path, table name, or SQL identifier and pressing TAB completes the token under the cursor rather than the line ending.
 * Home-Path Import Completion: `.import` tab completion now expands a leading `~/` to the home directory for the lookup while keeping the suggestion rendered as `~/file.csv`, so home-directory paths complete the same way relative and absolute paths do. The accepted `~/...` argument is expanded again at import time.
 * Directory Import Completion: `.import` tab completion offers directory candidates with a trailing slash, so a directory import target (for example `datadir/`) is discoverable and can be accepted and imported directly, not just descended into. Regression tests lock the directory-candidate behavior in.

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -364,11 +364,14 @@ func (s *Shell) communicate(ctx context.Context) error {
 // sqlyKeyMap returns the prompt key map with the Emacs-style control shortcuts
 // the sqly shell documents on top of the prompt library defaults. The library
 // already binds Ctrl+A/E/K/U/W/R and the arrow keys; this adds the control-key
-// equivalents the docs advertise: Ctrl+P/Ctrl+N for history navigation.
+// equivalents the docs advertise: Ctrl+P/Ctrl+N for history navigation and
+// Ctrl+F/Ctrl+B for character movement.
 func sqlyKeyMap() *prompt.KeyMap {
 	km := prompt.NewDefaultKeyMap()
 	km.Bind('\x10', prompt.ActionHistoryUp)   // Ctrl+P: previous command
 	km.Bind('\x0e', prompt.ActionHistoryDown) // Ctrl+N: next command
+	km.Bind('\x06', prompt.ActionMoveRight)   // Ctrl+F: forward one character
+	km.Bind('\x02', prompt.ActionMoveLeft)    // Ctrl+B: backward one character
 	return km
 }
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -3355,6 +3355,8 @@ func TestSqlyKeyMap(t *testing.T) {
 	}{
 		{name: "Ctrl+P navigates to the previous command", key: '\x10', want: prompt.ActionHistoryUp},
 		{name: "Ctrl+N navigates to the next command", key: '\x0e', want: prompt.ActionHistoryDown},
+		{name: "Ctrl+F moves the cursor forward one character", key: '\x06', want: prompt.ActionMoveRight},
+		{name: "Ctrl+B moves the cursor backward one character", key: '\x02', want: prompt.ActionMoveLeft},
 		{name: "Ctrl+A still moves to the line start (default preserved)", key: '\x01', want: prompt.ActionMoveHome},
 	}
 


### PR DESCRIPTION
## Summary

The shell documentation advertises Ctrl+F/Ctrl+B for character movement, but the prompt library's default keymap only wires the arrow keys.

This extends `sqlyKeyMap` with Ctrl+F -> move right and Ctrl+B -> move left, so the documented Emacs-style movement keys work like the arrow keys.

## Tests

`shell/shell_test.go`'s `TestSqlyKeyMap` is extended to assert Ctrl+F binds to `ActionMoveRight` and Ctrl+B to `ActionMoveLeft`.

Closes #620