### PR TITLE
fix(shell): bind documented Ctrl+L clear-screen key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* Clear-Screen Control Key: the interactive shell now binds the documented Ctrl+L key to clear the screen, redrawing the prompt with the current input preserved.
 * History Control Keys: the interactive shell now binds the documented Ctrl+P and Ctrl+N keys to previous/next command history, matching the arrow keys.
 * Cursor Movement Control Keys: the interactive shell now binds the documented Ctrl+F and Ctrl+B keys to move the cursor forward/backward one character, matching the arrow keys.
 * Cursor-Aware Completion: tab completion now uses the text before the cursor instead of the whole line, so moving the cursor back into an earlier path, table name, or SQL identifier and pressing TAB completes the token under the cursor rather than the line ending.
@@ -31,6 +32,7 @@
 * Symlink-Resolved System-Path Guard: import path validation now rejects a symlink whose canonical target is a blocked system location (such as a link to `/etc/hosts`), not only a directly typed system path. It also normalizes the macOS `/private` prefix, while standard Unix pseudo-files (`/dev/stdin`, `/proc/self/fd/*`) keep importing.
 
 ### Dependencies
+* Prompt: upgrade `github.com/nao1215/prompt` to v0.0.8 for the `ActionClearScreen` key action that backs the Ctrl+L clear-screen binding.
 * Prompt: upgrade `github.com/nao1215/prompt` to v0.0.7 for the `WithIsComplete` multiline submit predicate and the `WithWordEscape` option that lets completion treat backslash-escaped whitespace as part of a word.
 
 ## [v0.24.0](https://github.com/nao1215/sqly/compare/v0.23.0...v0.24.0) (2026-06-06)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/nao1215/filesql v0.14.0
-	github.com/nao1215/prompt v0.0.7
+	github.com/nao1215/prompt v0.0.8
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/nao1215/fileparser v0.5.2 h1:IXhH5m3UJf/TMidfTcVen8CSlZ4KEFEgBz6+2o+5
 github.com/nao1215/fileparser v0.5.2/go.mod h1:Jb16QbtYfgzQ2BR+UOVNSa1WeKMP2o+xnwBYFUNAG2Y=
 github.com/nao1215/filesql v0.14.0 h1:nPemOKx2jhcYXFoNGtvTwT7uipj/Bn0bOYZNOuaPhgw=
 github.com/nao1215/filesql v0.14.0/go.mod h1:3KmrO1UA7rBQZGBiKXwwXf9fH/13Vx4J0Q5nBR/GF/0=
-github.com/nao1215/prompt v0.0.7 h1:lpHrVXz3dIxMIKX0gtNghNWM85jG2PLWdK7Jlt8kIVM=
-github.com/nao1215/prompt v0.0.7/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
+github.com/nao1215/prompt v0.0.8 h1:5Oa8AAb53IAqgTuHnZ5X/5maNgmYrIh+aPaEuUauyPs=
+github.com/nao1215/prompt v0.0.8/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -364,14 +364,15 @@ func (s *Shell) communicate(ctx context.Context) error {
 // sqlyKeyMap returns the prompt key map with the Emacs-style control shortcuts
 // the sqly shell documents on top of the prompt library defaults. The library
 // already binds Ctrl+A/E/K/U/W/R and the arrow keys; this adds the control-key
-// equivalents the docs advertise: Ctrl+P/Ctrl+N for history navigation and
-// Ctrl+F/Ctrl+B for character movement.
+// equivalents the docs advertise: Ctrl+P/Ctrl+N for history navigation,
+// Ctrl+F/Ctrl+B for character movement, and Ctrl+L to clear the screen.
 func sqlyKeyMap() *prompt.KeyMap {
 	km := prompt.NewDefaultKeyMap()
 	km.Bind('\x10', prompt.ActionHistoryUp)   // Ctrl+P: previous command
 	km.Bind('\x0e', prompt.ActionHistoryDown) // Ctrl+N: next command
 	km.Bind('\x06', prompt.ActionMoveRight)   // Ctrl+F: forward one character
 	km.Bind('\x02', prompt.ActionMoveLeft)    // Ctrl+B: backward one character
+	km.Bind('\x0c', prompt.ActionClearScreen) // Ctrl+L: clear the screen
 	return km
 }
 

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -3357,6 +3357,7 @@ func TestSqlyKeyMap(t *testing.T) {
 		{name: "Ctrl+N navigates to the next command", key: '\x0e', want: prompt.ActionHistoryDown},
 		{name: "Ctrl+F moves the cursor forward one character", key: '\x06', want: prompt.ActionMoveRight},
 		{name: "Ctrl+B moves the cursor backward one character", key: '\x02', want: prompt.ActionMoveLeft},
+		{name: "Ctrl+L clears the screen", key: '\x0c', want: prompt.ActionClearScreen},
 		{name: "Ctrl+A still moves to the line start (default preserved)", key: '\x01', want: prompt.ActionMoveHome},
 	}
 


### PR DESCRIPTION
## Summary

The shell documentation advertises Ctrl+L as clear-screen, but the prompt library had no clear-screen action, so the key did nothing.

This upgrades `github.com/nao1215/prompt` to v0.0.8 (which adds `ActionClearScreen`) and binds Ctrl+L to it in `sqlyKeyMap`. The screen clears and the prompt redraws with the current input preserved, working consistently across platforms without an external command.

## Tests

`shell/shell_test.go`'s `TestSqlyKeyMap` is extended to assert Ctrl+L binds to `prompt.ActionClearScreen`.

Closes #617