### PR TITLE
fix(config): skip default config dir when SQLY_HISTORY_DB_PATH is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* No Stray Config Directory: `NewConfig` no longer creates the default XDG config directory when `SQLY_HISTORY_DB_PATH` is set, so routing history elsewhere has no unnecessary filesystem side effect.
 * Clear-Screen Control Key: the interactive shell now binds the documented Ctrl+L key to clear the screen, redrawing the prompt with the current input preserved.
 * History Control Keys: the interactive shell now binds the documented Ctrl+P and Ctrl+N keys to previous/next command history, matching the arrow keys.
 * Cursor Movement Control Keys: the interactive shell now binds the documented Ctrl+F and Ctrl+B keys to move the cursor forward/backward one character, matching the arrow keys.

--- a/config/config.go
+++ b/config/config.go
@@ -31,11 +31,14 @@ func NewConfig() (*Config, error) {
 		return nil, err
 	}
 
-	if err := cfg.CreateDir(); err != nil {
-		return nil, err
-	}
-
+	// Only create the default config directory when history falls back to the
+	// default location. When SQLY_HISTORY_DB_PATH is set the caller routed
+	// history elsewhere, so creating the XDG directory would be a useless side
+	// effect.
 	if cfg.HistoryDBPath == "" {
+		if err := cfg.CreateDir(); err != nil {
+			return nil, err
+		}
 		cfg.HistoryDBPath = filepath.Join(cfg.Dir(), "history.db")
 	}
 	return &cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,30 @@ func TestConfigCreateDir(t *testing.T) {
 	})
 }
 
+func TestNewConfigSkipsDefaultDirWhenHistoryPathSet(t *testing.T) {
+	// Regression: NewConfig must not create the default XDG config directory
+	// when SQLY_HISTORY_DB_PATH routes history elsewhere.
+	configHome := t.TempDir()
+	orgConfigHome := xdg.ConfigHome
+	xdg.ConfigHome = configHome
+	t.Cleanup(func() { xdg.ConfigHome = orgConfigHome })
+
+	customPath := filepath.Join(t.TempDir(), "history.db")
+	t.Setenv("SQLY_HISTORY_DB_PATH", customPath)
+
+	c, err := NewConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.HistoryDBPath != customPath {
+		t.Errorf("HistoryDBPath = %q, want %q", c.HistoryDBPath, customPath)
+	}
+	if defaultDir := filepath.Join(configHome, "sqly"); isDir(t, defaultDir) {
+		t.Errorf("default config directory %s was created despite SQLY_HISTORY_DB_PATH being set", defaultDir)
+	}
+}
+
 func isDir(t *testing.T, path string) bool {
 	t.Helper()
 	info, err := os.Stat(path)


### PR DESCRIPTION
## Summary

`NewConfig` always created the default XDG config directory before checking `SQLY_HISTORY_DB_PATH`, so routing history elsewhere still left a stray directory behind.

The default directory is now created only when history falls back to the default location; when `SQLY_HISTORY_DB_PATH` is set, no directory is created.

## Tests

`config/config_test.go` adds `TestNewConfigSkipsDefaultDirWhenHistoryPathSet`, which sets the env var to a temp path and asserts the default XDG `sqly` directory is not created and `HistoryDBPath` uses the custom path.

Closes #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed config initialization so the default config directory is no longer created when a custom history database path is set.
  * Prevents an unnecessary filesystem side effect while still honoring the configured history path.
  * Added regression coverage to ensure the custom path is used and the default directory is not created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->