### PR TITLE
perf(shell): cache table/column metadata for SQL completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* Cached Completion Metadata: interactive SQL completion now caches table and column suggestions keyed on the current table-name set, so it no longer queries every table's header on each keystroke. A line still typing a dot-command skips schema lookups entirely, and the cache refreshes when the table set changes or after an import.
 * No Stray Config Directory: `NewConfig` no longer creates the default XDG config directory when `SQLY_HISTORY_DB_PATH` is set, so routing history elsewhere has no unnecessary filesystem side effect.
 * Clear-Screen Control Key: the interactive shell now binds the documented Ctrl+L key to clear the screen, redrawing the prompt with the current input preserved.
 * History Control Keys: the interactive shell now binds the documented Ctrl+P and Ctrl+N keys to previous/next command history, matching the arrow keys.

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -1508,6 +1508,66 @@ func TestShell_getRegularCompletions_dependsOnMetadataUsecase(t *testing.T) {
 	}
 }
 
+func TestShell_getRegularCompletions_cachesTableHeaders(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	metadata := mock.NewMockMetadataUsecase(ctrl)
+
+	tables := []*model.Table{
+		model.NewTable("users", nil, nil),
+		model.NewTable("orders", nil, nil),
+	}
+	// TablesName is cheap and may run per keystroke, but each table's header must
+	// be fetched only once across repeated completions thanks to the cache.
+	metadata.EXPECT().TablesName(gomock.Any()).Return(tables, nil).AnyTimes()
+	metadata.EXPECT().Header(gomock.Any(), "users").Return(
+		model.NewTable("users", model.NewHeader([]string{"id", "name"}), nil), nil).Times(1)
+	metadata.EXPECT().Header(gomock.Any(), "orders").Return(
+		model.NewTable("orders", model.NewHeader([]string{"id", "total"}), nil), nil).Times(1)
+
+	s := newBoundaryTestShell(t, Usecases{metadata: metadata})
+
+	// Simulate many keystrokes; gomock fails if Header runs more than once per table.
+	for i := 0; i < 6; i++ {
+		_ = s.getRegularCompletions(context.Background(), "SEL")
+	}
+}
+
+func TestShell_getRegularCompletions_skipsMetadataForDotCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// No TablesName/Header expectations: a dot-command line must not query schema,
+	// so any such call fails the test via gomock's unexpected-call check.
+	metadata := mock.NewMockMetadataUsecase(ctrl)
+
+	s := newBoundaryTestShell(t, Usecases{metadata: metadata})
+
+	completions := s.getRegularCompletions(context.Background(), ".he")
+	if !hasSuggestionText(completions, ".help") {
+		t.Fatalf("expected .help command suggestion for \".he\", got %#v", completions)
+	}
+}
+
+func BenchmarkRegularCompletionManyTables(b *testing.B) {
+	ctrl := gomock.NewController(b)
+	metadata := mock.NewMockMetadataUsecase(ctrl)
+
+	const tableCount = 50
+	tables := make([]*model.Table, 0, tableCount)
+	for i := 0; i < tableCount; i++ {
+		name := "table" + strconv.Itoa(i)
+		tables = append(tables, model.NewTable(name, nil, nil))
+		metadata.EXPECT().Header(gomock.Any(), name).Return(
+			model.NewTable(name, model.NewHeader([]string{"col_a", "col_b", "col_c", "col_d"}), nil), nil).AnyTimes()
+	}
+	metadata.EXPECT().TablesName(gomock.Any()).Return(tables, nil).AnyTimes()
+
+	s := newBoundaryTestShell(&testing.T{}, Usecases{metadata: metadata})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.getRegularCompletions(context.Background(), "SEL")
+	}
+}
+
 func TestShell_getFilePathCompletions_dependsOnImportUsecase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	importer := mock.NewMockImportUsecase(ctrl)

--- a/shell/completion_test.go
+++ b/shell/completion_test.go
@@ -1527,7 +1527,7 @@ func TestShell_getRegularCompletions_cachesTableHeaders(t *testing.T) {
 	s := newBoundaryTestShell(t, Usecases{metadata: metadata})
 
 	// Simulate many keystrokes; gomock fails if Header runs more than once per table.
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		_ = s.getRegularCompletions(context.Background(), "SEL")
 	}
 }
@@ -1552,7 +1552,7 @@ func BenchmarkRegularCompletionManyTables(b *testing.B) {
 
 	const tableCount = 50
 	tables := make([]*model.Table, 0, tableCount)
-	for i := 0; i < tableCount; i++ {
+	for i := range tableCount {
 		name := "table" + strconv.Itoa(i)
 		tables = append(tables, model.NewTable(name, nil, nil))
 		metadata.EXPECT().Header(gomock.Any(), name).Return(
@@ -1563,7 +1563,7 @@ func BenchmarkRegularCompletionManyTables(b *testing.B) {
 	s := newBoundaryTestShell(&testing.T{}, Usecases{metadata: metadata})
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = s.getRegularCompletions(context.Background(), "SEL")
 	}
 }

--- a/shell/import.go
+++ b/shell/import.go
@@ -243,6 +243,12 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 		return fmt.Errorf("sheet %q not found in any of the imported workbooks", sheetName)
 	}
 
+	// A successful import can change a table's columns without changing the
+	// table-name set (re-import), so drop the cached completion suggestions.
+	if successCount > 0 {
+		s.invalidateCompletionCache()
+	}
+
 	if len(errorMessages) > 0 {
 		statusOut := s.importStatusWriter()
 		if successCount > 0 {

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -96,6 +96,13 @@ type Shell struct {
 	// to stdout only after write-back succeeds, so a run that fails during
 	// write-back leaves stdout free of success counts.
 	pendingAffected []string
+	// completionTableKey fingerprints the table-name set the cached table/column
+	// completion suggestions were built from. completionTableCols holds those
+	// suggestions. Together they let interactive completion reuse table and column
+	// metadata across keystrokes instead of querying every table's header on each
+	// one, rebuilding only when the table set changes (or after an import).
+	completionTableKey  string
+	completionTableCols []Suggest
 }
 
 type promptSession interface {
@@ -778,43 +785,12 @@ func (s *Shell) getRegularCompletions(ctx context.Context, input string) []Sugge
 		})
 	}
 
-	tables, err := s.usecases.metadata.TablesName(ctx)
-	if err != nil {
-		// Get current word for filtering
-		lastSpace := strings.LastIndex(input, " ")
-		var currentWord string
-		if lastSpace >= 0 {
-			currentWord = input[lastSpace+1:]
-		} else {
-			currentWord = input
-		}
-		return filterHasPrefix(suggest, currentWord, true)
+	// A line still typing a dot-command (no argument yet) never references tables
+	// or columns, so skip the table/column metadata entirely for it.
+	if !isTypingDotCommand(input) {
+		suggest = append(suggest, s.tableColumnSuggestions(ctx)...)
 	}
-	for _, v := range tables {
-		suggest = append(suggest, Suggest{
-			Text:        v.Name(),
-			Description: "table: " + v.Name(),
-		})
 
-		table, err := s.usecases.metadata.Header(ctx, v.Name())
-		if err != nil {
-			// Get current word for filtering
-			lastSpace := strings.LastIndex(input, " ")
-			var currentWord string
-			if lastSpace >= 0 {
-				currentWord = input[lastSpace+1:]
-			} else {
-				currentWord = input
-			}
-			return filterHasPrefix(suggest, currentWord, true)
-		}
-		for _, h := range table.Header() {
-			suggest = append(suggest, Suggest{
-				Text:        h,
-				Description: "header: " + h + " column in " + v.Name() + " table",
-			})
-		}
-	}
 	// Get current word for filtering
 	lastSpace := strings.LastIndex(input, " ")
 	var currentWord string
@@ -824,6 +800,72 @@ func (s *Shell) getRegularCompletions(ctx context.Context, input string) []Sugge
 		currentWord = input
 	}
 	return filterHasPrefix(suggest, currentWord, true)
+}
+
+// isTypingDotCommand reports whether input is a helper dot-command name still
+// being typed (starts with "." and has no whitespace yet), such as ".he". Such a
+// line cannot reference a table or column, so completion can skip schema lookups.
+func isTypingDotCommand(input string) bool {
+	trimmed := strings.TrimSpace(input)
+	return strings.HasPrefix(trimmed, ".") && !strings.ContainsAny(trimmed, " \t")
+}
+
+// tableColumnSuggestions returns table-name and column-header completion
+// suggestions, cached by the current table-name set. The headers are fetched
+// only when that set changes, so consecutive keystrokes reuse the cache instead
+// of querying every table's header on each one. Returns nil if the table list
+// cannot be read.
+func (s *Shell) tableColumnSuggestions(ctx context.Context) []Suggest {
+	tables, err := s.usecases.metadata.TablesName(ctx)
+	if err != nil {
+		return nil
+	}
+
+	key := completionTableKey(tables)
+	if key == s.completionTableKey && s.completionTableCols != nil {
+		return s.completionTableCols
+	}
+
+	var out []Suggest
+	for _, v := range tables {
+		out = append(out, Suggest{
+			Text:        v.Name(),
+			Description: "table: " + v.Name(),
+		})
+
+		header, err := s.usecases.metadata.Header(ctx, v.Name())
+		if err != nil {
+			continue
+		}
+		for _, h := range header.Header() {
+			out = append(out, Suggest{
+				Text:        h,
+				Description: "header: " + h + " column in " + v.Name() + " table",
+			})
+		}
+	}
+
+	s.completionTableKey = key
+	s.completionTableCols = out
+	return out
+}
+
+// completionTableKey builds a fingerprint of the table-name set used to decide
+// whether the cached completion suggestions are still valid.
+func completionTableKey(tables []*model.Table) string {
+	names := make([]string, 0, len(tables))
+	for _, t := range tables {
+		names = append(names, t.Name())
+	}
+	return strings.Join(names, "\x00")
+}
+
+// invalidateCompletionCache drops the cached table/column completion
+// suggestions, forcing the next completion to rebuild them. It is called after an
+// import, which can change a table's columns without changing the table-name set.
+func (s *Shell) invalidateCompletionCache() {
+	s.completionTableKey = ""
+	s.completionTableCols = nil
 }
 
 // exec execute sqly helper command or sql query.


### PR DESCRIPTION
## Summary

`getRegularCompletions` loaded every table name and then every table's header on each keystroke, so completion cost grew with both table count and schema width even for a short prefix.

Completion now caches the table and column suggestions keyed on the current table-name set, so headers are fetched only when that set changes. A line still typing a dot-command name skips schema lookups entirely. The cache is invalidated after an import, which can change a table's columns without changing the table-name set.

## Tests

`shell/completion_test.go` adds:
- `TestShell_getRegularCompletions_cachesTableHeaders`: many completions fetch each table's header only once (gomock `Times(1)`).
- `TestShell_getRegularCompletions_skipsMetadataForDotCommand`: a dot-command line performs no `TablesName`/`Header` queries.
- `BenchmarkRegularCompletionManyTables`: completion with 50 tables and wide headers.

Closes #598