### PR TITLE
perf(shell): write history with a single insert via AUTOINCREMENT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* Single-Insert History Writes: each interactive command's history write is now a single insert that relies on SQLite AUTOINCREMENT, instead of scanning the entire history table to compute the next id. History preloading at startup still reads the table once.
 * Cached Completion Metadata: interactive SQL completion now caches table and column suggestions keyed on the current table-name set, so it no longer queries every table's header on each keystroke. A line still typing a dot-command skips schema lookups entirely, and the cache refreshes when the table set changes or after an import.
 * No Stray Config Directory: `NewConfig` no longer creates the default XDG config directory when `SQLY_HISTORY_DB_PATH` is set, so routing history elsewhere has no unnecessary filesystem side effect.
 * Clear-Screen Control Key: the interactive shell now binds the documented Ctrl+L key to clear the screen, redrawing the prompt with the current input preserved.

--- a/infrastructure/persistence/history.go
+++ b/infrastructure/persistence/history.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nao1215/sqly/config"
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/domain/repository"
-	infra "github.com/nao1215/sqly/infrastructure"
 )
 
 // _ historyRepository implement HistoryRepository
@@ -58,7 +57,11 @@ func (h *historyRepository) Create(ctx context.Context, t *model.Table) error {
 	defer func() { _ = tx.Rollback() }()
 
 	for _, v := range t.Records() {
-		if _, err := tx.ExecContext(ctx, infra.GenerateInsertStatement(t.Name(), v)); err != nil {
+		// Insert only the request and let SQLite's AUTOINCREMENT assign the id, so
+		// a write never depends on a caller-computed id from a full table scan. The
+		// request is the last column of the history table (id, request).
+		request := v[len(v)-1]
+		if _, err := tx.ExecContext(ctx, "INSERT INTO `history` (`request`) VALUES (?)", request); err != nil {
 			return err
 		}
 	}

--- a/infrastructure/persistence/history_test.go
+++ b/infrastructure/persistence/history_test.go
@@ -41,4 +41,61 @@ func TestHistoryRepositoryCreateTable(t *testing.T) {
 			t.Errorf("value is mismatch (-got +want):\n%s", diff)
 		}
 	})
+
+	t.Run("auto-assigns sequential ids when the caller supplies none", func(t *testing.T) {
+		t.Parallel()
+
+		historyDB, cleanup, err := config.NewInMemHistoryDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+
+		r := NewHistoryRepository(historyDB)
+		if err := r.CreateTable(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		// recordUserRequest now passes id 0 and relies on AUTOINCREMENT.
+		for _, req := range []string{"first", "second", "third"} {
+			in := model.Histories{model.NewHistory(0, req)}.ToTable()
+			if err := r.Create(context.Background(), in); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		want := model.Histories{
+			model.NewHistory(1, "first"),
+			model.NewHistory(2, "second"),
+			model.NewHistory(3, "third"),
+		}
+		got, err := r.List(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(got, want); diff != "" {
+			t.Errorf("value is mismatch (-got +want):\n%s", diff)
+		}
+	})
+}
+
+func BenchmarkHistoryRepositoryCreate(b *testing.B) {
+	historyDB, cleanup, err := config.NewInMemHistoryDB()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+
+	r := NewHistoryRepository(historyDB)
+	if err := r.CreateTable(context.Background()); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		in := model.Histories{model.NewHistory(0, "SELECT 1")}.ToTable()
+		if err := r.Create(context.Background(), in); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/shell/commands_test.go
+++ b/shell/commands_test.go
@@ -44,9 +44,9 @@ func TestExec_RuntimeHistoryFailureDisablesHistoryAndContinues(t *testing.T) {
 		model.NewRecord([]string{"1"}),
 	})
 
-	// First command: the history read succeeds but the write fails as if the DB
-	// became read-only after startup. The query must still run.
-	history.EXPECT().List(gomock.Any()).Return(model.Histories{}, nil)
+	// First command: the history write fails as if the DB became read-only after
+	// startup. The write is a single insert (no preceding List scan), and the
+	// query must still run.
 	history.EXPECT().Create(gomock.Any(), gomock.Any()).
 		Return(errors.New("attempt to write a readonly database"))
 	query.EXPECT().ExecSQL(gomock.Any(), "SELECT 1").Return(table, int64(0), nil)
@@ -74,7 +74,7 @@ func TestExec_RuntimeHistoryFailureDisablesHistoryAndContinues(t *testing.T) {
 	})
 }
 
-func TestExec_HistoryReadFailureAlsoDisablesHistory(t *testing.T) {
+func TestExec_HistoryWriteDoesNotScanHistory(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	history := mock.NewMockHistoryUsecase(ctrl)
 	query := mock.NewMockQueryUsecase(ctrl)
@@ -83,9 +83,9 @@ func TestExec_HistoryReadFailureAlsoDisablesHistory(t *testing.T) {
 		model.NewRecord([]string{"1"}),
 	})
 
-	// The history read itself fails (e.g. the DB file vanished); the command must
-	// still run and history is disabled for the rest of the session.
-	history.EXPECT().List(gomock.Any()).Return(model.Histories{}, errors.New("disk I/O error"))
+	// A history write is a single insert: it must not call List to compute an id.
+	// No List expectation is set, so gomock fails the test if List is called.
+	history.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
 	query.EXPECT().ExecSQL(gomock.Any(), "SELECT 1").Return(table, int64(0), nil)
 
 	s := newBoundaryTestShell(t, Usecases{history: history, query: query})
@@ -93,12 +93,12 @@ func TestExec_HistoryReadFailureAlsoDisablesHistory(t *testing.T) {
 
 	_ = captureStdout(t, func() {
 		if err := s.exec(context.Background(), "SELECT 1"); err != nil {
-			t.Fatalf("exec aborted on a best-effort history read failure: %v", err)
+			t.Fatalf("exec returned error: %v", err)
 		}
 	})
 
-	if s.historyEnabled {
-		t.Error("historyEnabled should be false after a runtime history read failure")
+	if !s.historyEnabled {
+		t.Error("historyEnabled should remain true after a successful history write")
 	}
 }
 

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -1030,12 +1030,12 @@ func ensureNotDirectory(path string) error {
 }
 
 // recordUserRequest record user request in DB.
+//
+// The row id is left to SQLite's AUTOINCREMENT instead of being computed from a
+// full history scan, so each write costs a single insert rather than reading the
+// whole table first.
 func (s *Shell) recordUserRequest(ctx context.Context, request string) error {
-	histories, err := s.usecases.history.List(ctx)
-	if err != nil {
-		return err
-	}
-	if err := s.usecases.history.Create(ctx, model.NewHistory(len(histories)+1, request)); err != nil {
+	if err := s.usecases.history.Create(ctx, model.NewHistory(0, request)); err != nil {
 		return fmt.Errorf("failed to store user input history: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

`recordUserRequest` read the entire history table on every command to compute `len(histories)+1` for the next id, adding latency that grew with history size even though the table already uses AUTOINCREMENT.

History writes now insert only the request and let SQLite assign the id, so each write is a single insert. The id passed by the caller is ignored at the persistence layer. Startup history preloading still reads the table once.

## Tests

- `shell/commands_test.go`: `TestExec_HistoryWriteDoesNotScanHistory` asserts a write performs no `List` scan; the existing runtime-failure test is updated for the single-insert path.
- `infrastructure/persistence/history_test.go`: a subtest verifies AUTOINCREMENT assigns sequential ids when the caller supplies id 0, plus `BenchmarkHistoryRepositoryCreate`.

Closes #601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command history is now saved with a faster single-step database insert, improving reliability for repeated command entry.
  * History IDs are now assigned automatically by the database, avoiding extra lookup work during save operations.
  * Existing history loading behavior at startup remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->