### PR TITLE
perf(shell): aggregate --profile statistics in a single pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* Single-Pass Profiling: `--profile` now aggregates each column's statistics in a single pass over the rows instead of copying the whole table into a per-column values and nulls slice, so its memory no longer scales with columns times rows.
 * Single-Insert History Writes: each interactive command's history write is now a single insert that relies on SQLite AUTOINCREMENT, instead of scanning the entire history table to compute the next id. History preloading at startup still reads the table once.
 * Cached Completion Metadata: interactive SQL completion now caches table and column suggestions keyed on the current table-name set, so it no longer queries every table's header on each keystroke. A line still typing a dot-command skips schema lookups entirely, and the cache refreshes when the table set changes or after an import.
 * No Stray Config Directory: `NewConfig` no longer creates the default XDG config directory when `SQLY_HISTORY_DB_PATH` is set, so routing history elsewhere has no unnecessary filesystem side effect.

--- a/shell/feature_property_test.go
+++ b/shell/feature_property_test.go
@@ -164,7 +164,7 @@ func TestCompareKeyedRows_SwapProperty(t *testing.T) {
 func TestProfileColumnStats_PartitionProperty(t *testing.T) {
 	t.Parallel()
 	property := func(values []string, nulls []bool) bool {
-		pc := profileColumnStats("c", "TEXT", values, nulls)
+		pc := columnStats("c", "TEXT", values, nulls)
 		var nullN, blankN, nonEmpty int64
 		for i, v := range values {
 			switch {

--- a/shell/profile.go
+++ b/shell/profile.go
@@ -131,17 +131,28 @@ func (s *Shell) profileTable(ctx context.Context, name string) (profileTable, er
 
 	header := table.Header()
 	records := table.Records()
-	cols := make([]profileColumn, 0, len(header))
+
+	// Aggregate per column in a single pass over the rows. Why not build a
+	// per-column values/nulls slice first: that duplicated the whole table once
+	// per column. The accumulators hold only running counts (and the distinct set
+	// the report needs anyway), so profiling no longer scales memory with
+	// columns * rows.
+	profilers := make([]*columnProfiler, len(header))
 	for ci, colName := range header {
-		values := make([]string, len(records))
-		nulls := make([]bool, len(records))
-		for ri, rec := range records {
+		profilers[ci] = newColumnProfiler(colName, typeByName[colName])
+	}
+	for ri, rec := range records {
+		for ci := range header {
+			var v string
 			if ci < len(rec) {
-				values[ri] = rec[ci]
+				v = rec[ci]
 			}
-			nulls[ri] = table.IsNull(ri, ci)
+			profilers[ci].add(v, table.IsNull(ri, ci))
 		}
-		cols = append(cols, profileColumnStats(colName, typeByName[colName], values, nulls))
+	}
+	cols := make([]profileColumn, len(header))
+	for ci := range header {
+		cols[ci] = profilers[ci].result()
 	}
 
 	return profileTable{
@@ -160,50 +171,81 @@ var nullLikeTokens = map[string]struct{}{
 	"null": {}, "n/a": {}, "na": {}, "nil": {}, "none": {}, "#n/a": {}, "nan": {},
 }
 
-// profileColumnStats computes the data-quality summary for one column from its
-// values and NULL mask. It is pure so it can be unit-tested directly. Warnings
-// are only raised where they can be inferred safely: a mix of numeric and
-// non-numeric non-empty values, null-like placeholder text, and values with
-// leading or trailing whitespace.
-func profileColumnStats(name, typ string, values []string, nulls []bool) profileColumn {
-	pc := profileColumn{Name: name, Type: typ, Warnings: []string{}}
-	distinct := make(map[string]struct{})
-	var numeric, nonNumeric, nullLike, whitespace int64
-	for i, v := range values {
-		if i < len(nulls) && nulls[i] {
-			pc.NullCount++
-			continue
-		}
-		if v == "" {
-			pc.BlankCount++
-			continue
-		}
-		distinct[v] = struct{}{}
-		if isNumericValue(v) {
-			numeric++
-		} else {
-			nonNumeric++
-		}
-		if _, ok := nullLikeTokens[strings.ToLower(v)]; ok {
-			nullLike++
-		}
-		if v != strings.TrimSpace(v) {
-			whitespace++
-		}
-	}
-	pc.DistinctCount = int64(len(distinct))
-	pc.NumericCount = numeric
+// columnProfiler accumulates a column's data-quality statistics one value at a
+// time, so profiling can stream rows without copying each column into its own
+// full-length buffer. The distinct set is the only per-value memory it keeps,
+// which the distinct count requires regardless.
+type columnProfiler struct {
+	name, typ                                                      string
+	distinct                                                       map[string]struct{}
+	nullCount, blankCount, numeric, nonNumeric, nullLike, spacecnt int64
+}
 
-	if numeric > 0 && nonNumeric > 0 {
-		pc.Warnings = append(pc.Warnings, fmt.Sprintf("mixed numeric and non-numeric values (%d numeric, %d non-numeric)", numeric, nonNumeric))
+// newColumnProfiler returns a profiler for a single named, typed column.
+func newColumnProfiler(name, typ string) *columnProfiler {
+	return &columnProfiler{name: name, typ: typ, distinct: make(map[string]struct{})}
+}
+
+// add folds one cell value (and whether it is SQL NULL) into the running stats.
+func (c *columnProfiler) add(v string, isNull bool) {
+	if isNull {
+		c.nullCount++
+		return
 	}
-	if nullLike > 0 {
-		pc.Warnings = append(pc.Warnings, fmt.Sprintf("%d value(s) look like null placeholders (e.g. NULL, N/A)", nullLike))
+	if v == "" {
+		c.blankCount++
+		return
 	}
-	if whitespace > 0 {
-		pc.Warnings = append(pc.Warnings, fmt.Sprintf("%d value(s) have leading or trailing whitespace", whitespace))
+	c.distinct[v] = struct{}{}
+	if isNumericValue(v) {
+		c.numeric++
+	} else {
+		c.nonNumeric++
+	}
+	if _, ok := nullLikeTokens[strings.ToLower(v)]; ok {
+		c.nullLike++
+	}
+	if v != strings.TrimSpace(v) {
+		c.spacecnt++
+	}
+}
+
+// result finalizes the accumulated statistics into a profileColumn, raising the
+// same warnings as a full-buffer pass would.
+func (c *columnProfiler) result() profileColumn {
+	pc := profileColumn{
+		Name:          c.name,
+		Type:          c.typ,
+		NullCount:     c.nullCount,
+		BlankCount:    c.blankCount,
+		DistinctCount: int64(len(c.distinct)),
+		NumericCount:  c.numeric,
+		Warnings:      []string{},
+	}
+	if c.numeric > 0 && c.nonNumeric > 0 {
+		pc.Warnings = append(pc.Warnings, fmt.Sprintf("mixed numeric and non-numeric values (%d numeric, %d non-numeric)", c.numeric, c.nonNumeric))
+	}
+	if c.nullLike > 0 {
+		pc.Warnings = append(pc.Warnings, fmt.Sprintf("%d value(s) look like null placeholders (e.g. NULL, N/A)", c.nullLike))
+	}
+	if c.spacecnt > 0 {
+		pc.Warnings = append(pc.Warnings, fmt.Sprintf("%d value(s) have leading or trailing whitespace", c.spacecnt))
 	}
 	return pc
+}
+
+// profileColumnStats computes the data-quality summary for one column from its
+// values and NULL mask. It is pure so it can be unit-tested directly, and shares
+// the same accumulator the streaming path uses. Warnings are only raised where
+// they can be inferred safely: a mix of numeric and non-numeric non-empty
+// values, null-like placeholder text, and values with leading or trailing
+// whitespace.
+func profileColumnStats(name, typ string, values []string, nulls []bool) profileColumn {
+	p := newColumnProfiler(name, typ)
+	for i, v := range values {
+		p.add(v, i < len(nulls) && nulls[i])
+	}
+	return p.result()
 }
 
 // isNumericValue reports whether s is a finite decimal number. It rejects the

--- a/shell/profile.go
+++ b/shell/profile.go
@@ -234,20 +234,6 @@ func (c *columnProfiler) result() profileColumn {
 	return pc
 }
 
-// profileColumnStats computes the data-quality summary for one column from its
-// values and NULL mask. It is pure so it can be unit-tested directly, and shares
-// the same accumulator the streaming path uses. Warnings are only raised where
-// they can be inferred safely: a mix of numeric and non-numeric non-empty
-// values, null-like placeholder text, and values with leading or trailing
-// whitespace.
-func profileColumnStats(name, typ string, values []string, nulls []bool) profileColumn {
-	p := newColumnProfiler(name, typ)
-	for i, v := range values {
-		p.add(v, i < len(nulls) && nulls[i])
-	}
-	return p.result()
-}
-
 // isNumericValue reports whether s is a finite decimal number. It rejects the
 // Go-specific float spellings ParseFloat also accepts but data rarely means as
 // numbers: hexadecimal floats ("0x1p4"), underscore digit separators

--- a/shell/profile_test.go
+++ b/shell/profile_test.go
@@ -10,6 +10,17 @@ import (
 	"testing"
 )
 
+// columnStats folds the given values and NULL mask through the streaming
+// columnProfiler, so the unit tests exercise the same accumulator the profiling
+// path uses.
+func columnStats(name, typ string, values []string, nulls []bool) profileColumn {
+	p := newColumnProfiler(name, typ)
+	for i, v := range values {
+		p.add(v, i < len(nulls) && nulls[i])
+	}
+	return p.result()
+}
+
 func TestProfileColumnStats(t *testing.T) {
 	t.Parallel()
 
@@ -19,7 +30,7 @@ func TestProfileColumnStats(t *testing.T) {
 		nulls := []bool{false, false, false, false, false}
 		// Mark index 4 ("x") as a real NULL to separate null from blank.
 		nulls[4] = true
-		got := profileColumnStats("c", "TEXT", values, nulls)
+		got := columnStats("counts", "TEXT", values, nulls)
 		if got.NullCount != 1 {
 			t.Errorf("null_count = %d, want 1", got.NullCount)
 		}
@@ -37,7 +48,7 @@ func TestProfileColumnStats(t *testing.T) {
 
 	t.Run("warns on a mix of numeric and non-numeric values", func(t *testing.T) {
 		t.Parallel()
-		got := profileColumnStats("c", "TEXT", []string{"1", "2", "abc"}, []bool{false, false, false})
+		got := columnStats("c", "TEXT", []string{"1", "2", "abc"}, []bool{false, false, false})
 		if !hasWarningContaining(got.Warnings, "mixed numeric") {
 			t.Errorf("expected a mixed-type warning, got %v", got.Warnings)
 		}
@@ -45,7 +56,7 @@ func TestProfileColumnStats(t *testing.T) {
 
 	t.Run("warns on null-like placeholder text and surrounding whitespace", func(t *testing.T) {
 		t.Parallel()
-		got := profileColumnStats("c", "TEXT", []string{"N/A", " hi "}, []bool{false, false})
+		got := columnStats("c", "TEXT", []string{"N/A", " hi "}, []bool{false, false})
 		if !hasWarningContaining(got.Warnings, "null placeholders") {
 			t.Errorf("expected a null-placeholder warning, got %v", got.Warnings)
 		}
@@ -56,7 +67,7 @@ func TestProfileColumnStats(t *testing.T) {
 
 	t.Run("clean numeric column has no warnings", func(t *testing.T) {
 		t.Parallel()
-		got := profileColumnStats("c", "INTEGER", []string{"1", "2", "3"}, []bool{false, false, false})
+		got := columnStats("c", "INTEGER", []string{"1", "2", "3"}, []bool{false, false, false})
 		if len(got.Warnings) != 0 {
 			t.Errorf("expected no warnings, got %v", got.Warnings)
 		}

--- a/shell/profile_test.go
+++ b/shell/profile_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,5 +172,85 @@ func TestRunProfile_TextFormat(t *testing.T) {
 	})
 	if !strings.Contains(out, "table nums: 3 rows, 1 columns") {
 		t.Errorf("text output missing table header line:\n%s", out)
+	}
+}
+
+// writeProfileBenchCSV writes a wide, tall CSV and returns its path.
+func writeProfileBenchCSV(tb testing.TB, rows, cols int) string {
+	tb.Helper()
+	dir := tb.TempDir()
+	path := filepath.Join(dir, "big.csv")
+
+	var sb strings.Builder
+	for c := range cols {
+		if c > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb, "c%d", c)
+	}
+	sb.WriteByte('\n')
+	for r := range rows {
+		for c := range cols {
+			if c > 0 {
+				sb.WriteByte(',')
+			}
+			fmt.Fprintf(&sb, "v%d", (r+c)%97)
+		}
+		sb.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
+		tb.Fatal(err)
+	}
+	return path
+}
+
+func TestProfileTable_StreamingMatchesFullScan(t *testing.T) {
+	csv := writeProfileBenchCSV(t, 200, 4)
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if err := shell.commands.importCommand(context.Background(), shell, []string{csv}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	entry, err := shell.profileTable(context.Background(), "big")
+	if err != nil {
+		t.Fatalf("profileTable: %v", err)
+	}
+
+	if entry.RowCount != 200 || entry.ColumnCount != 4 {
+		t.Fatalf("row/col = %d/%d, want 200/4", entry.RowCount, entry.ColumnCount)
+	}
+	// Each column draws from 97 distinct generated values, so a 200-row column
+	// sees all 97. This confirms the single-pass aggregation matches a full scan.
+	for _, c := range entry.Columns {
+		if c.DistinctCount != 97 {
+			t.Errorf("column %s distinct = %d, want 97", c.Name, c.DistinctCount)
+		}
+		if c.NumericCount != 0 {
+			t.Errorf("column %s numeric = %d, want 0 (values are v-prefixed)", c.Name, c.NumericCount)
+		}
+	}
+}
+
+func BenchmarkProfileTable(b *testing.B) {
+	csv := writeProfileBenchCSV(b, 5000, 8)
+	shell, cleanup, err := newShell(b, []string{"sqly"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+	if err := shell.commands.importCommand(context.Background(), shell, []string{csv}); err != nil {
+		b.Fatalf("import: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := shell.profileTable(context.Background(), "big"); err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`profileTable` materialized the table and then, for each column, copied every row into a fresh `values` and `nulls` slice before computing stats, so peak memory scaled with columns times rows.

This introduces a `columnProfiler` that folds one cell at a time and finalizes to a `profileColumn`, driven from a single pass over the rows. The pure `profileColumnStats` helper now shares the same accumulator, so behavior is unchanged. Only the inherent per-column distinct set remains.

(The table is still read once via the existing query API; a fully streaming row API would be a larger cross-layer change. The per-column buffer duplication that this issue calls out is removed.)

## Tests

- `TestProfileTable_StreamingMatchesFullScan` imports a wide/tall fixture and checks the single-pass aggregation produces the expected distinct/numeric counts.
- `BenchmarkProfileTable` profiles a 5000x8 table with `-benchmem` to track allocations.
- Existing `TestProfileColumnStats` continues to cover the shared accumulator.

Closes #599