### PR TITLE
perf(shell): avoid holding both tables during keyed compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* Leaner Keyed Compare: `--compare --compare-key` now converts each side to its keyed rows and releases the raw table before loading the other, so the two full tables are no longer held in memory at the same time.
 * Single-Pass Profiling: `--profile` now aggregates each column's statistics in a single pass over the rows instead of copying the whole table into a per-column values and nulls slice, so its memory no longer scales with columns times rows.
 * Single-Insert History Writes: each interactive command's history write is now a single insert that relies on SQLite AUTOINCREMENT, instead of scanning the entire history table to compute the next id. History preloading at startup still reads the table once.
 * Cached Completion Metadata: interactive SQL completion now caches table and column suggestions keyed on the current table-name set, so it no longer queries every table's header on each keystroke. A line still typing a dot-command skips schema lookups entirely, and the cache refreshes when the table set changes or after an import.

--- a/shell/compare.go
+++ b/shell/compare.go
@@ -219,21 +219,32 @@ func (s *Shell) buildCompareReport(ctx context.Context, left, right, key string)
 	}
 
 	if key != "" {
-		leftTable, err := s.selectAll(ctx, left)
+		// Convert each side to its keyed rows and release the raw table before
+		// loading the other, so the two full *model.Table results never live at the
+		// same time. Peak memory is one table plus the keyed map instead of both
+		// tables plus two index maps.
+		leftByKey, err := s.keyedRows(ctx, left, key)
 		if err != nil {
 			return compareReport{}, err
 		}
-		rightTable, err := s.selectAll(ctx, right)
+		rightByKey, err := s.keyedRows(ctx, right, key)
 		if err != nil {
 			return compareReport{}, err
 		}
-		rows, err := compareKeyedRows(left, right, leftTable, rightTable, key)
-		if err != nil {
-			return compareReport{}, err
-		}
-		report.Rows = rows
+		report.Rows = diffKeyedRows(key, leftByKey, rightByKey)
 	}
 	return report, nil
+}
+
+// keyedRows loads a table and indexes its rows by the key column, returning a
+// keyed map and releasing the raw table. Keeping only the keyed map lets the
+// caller load the two sides one at a time instead of holding both full tables.
+func (s *Shell) keyedRows(ctx context.Context, name, key string) (map[string]compareRow, error) {
+	table, err := s.selectAll(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return keyedRowsFromTable(table, key, name)
 }
 
 // selectAll returns every row of a table for row-level comparison.
@@ -292,57 +303,28 @@ func compareSchemas(left, right []inspectColumn) compareSchema {
 // differing value). The key column must exist in both tables and be unique on
 // each side, otherwise the comparison is ambiguous and an error is returned.
 func compareKeyedRows(leftName, rightName string, left, right *model.Table, key string) (*compareRows, error) {
-	leftIdx := indexOfColumn(left.Header(), key)
-	if leftIdx < 0 {
-		return nil, fmt.Errorf("compare key %q not found in table %s", key, leftName)
-	}
-	rightIdx := indexOfColumn(right.Header(), key)
-	if rightIdx < 0 {
-		return nil, fmt.Errorf("compare key %q not found in table %s", key, rightName)
-	}
-
-	leftByKey, err := indexRowsByKey(left, leftIdx, leftName, key)
+	leftByKey, err := keyedRowsFromTable(left, key, leftName)
 	if err != nil {
 		return nil, err
 	}
-	rightByKey, err := indexRowsByKey(right, rightIdx, rightName, key)
+	rightByKey, err := keyedRowsFromTable(right, key, rightName)
 	if err != nil {
 		return nil, err
 	}
-
-	rows := &compareRows{
-		Key:      key,
-		Added:    []compareRow{},
-		Removed:  []compareRow{},
-		Modified: []compareModifiedRow{},
-	}
-
-	for _, k := range sortedKeys(leftByKey) {
-		lrow := rowMap(left, leftByKey[k])
-		rIdx, ok := rightByKey[k]
-		if !ok {
-			rows.Removed = append(rows.Removed, lrow)
-			continue
-		}
-		rrow := rowMap(right, rIdx)
-		if !rowMapsEqual(lrow, rrow) {
-			rows.Modified = append(rows.Modified, compareModifiedRow{Key: k, Left: lrow, Right: rrow})
-		}
-	}
-	for _, k := range sortedKeys(rightByKey) {
-		if _, ok := leftByKey[k]; !ok {
-			rows.Added = append(rows.Added, rowMap(right, rightByKey[k]))
-		}
-	}
-	return rows, nil
+	return diffKeyedRows(key, leftByKey, rightByKey), nil
 }
 
-// indexRowsByKey maps each row's key-column value to its row index, rejecting a
-// duplicate key (which would make the keyed comparison ambiguous). A SQL NULL key
-// is keyed under the empty string, matching how a NULL key renders.
-func indexRowsByKey(t *model.Table, keyIdx int, name, key string) (map[string]int, error) {
+// keyedRowsFromTable indexes a table's rows by the key column's value, rejecting
+// a duplicate key (which would make the keyed comparison ambiguous). A SQL NULL
+// key is keyed under the empty string, matching how a NULL key renders. Each row
+// is materialized into a compareRow so the source table can be released.
+func keyedRowsFromTable(t *model.Table, key, name string) (map[string]compareRow, error) {
+	keyIdx := indexOfColumn(t.Header(), key)
+	if keyIdx < 0 {
+		return nil, fmt.Errorf("compare key %q not found in table %s", key, name)
+	}
 	records := t.Records()
-	out := make(map[string]int, len(records))
+	out := make(map[string]compareRow, len(records))
 	for i, rec := range records {
 		if keyIdx >= len(rec) {
 			continue
@@ -351,9 +333,39 @@ func indexRowsByKey(t *model.Table, keyIdx int, name, key string) (map[string]in
 		if _, dup := out[k]; dup {
 			return nil, fmt.Errorf("compare key %q is not unique in table %s (value %q appears more than once)", key, name, k)
 		}
-		out[k] = i
+		out[k] = rowMap(t, i)
 	}
 	return out, nil
+}
+
+// diffKeyedRows builds the keyed row diff from two already-indexed sides. Removed
+// and modified rows follow the left side's sorted keys, added rows the right
+// side's, so the report is deterministic.
+func diffKeyedRows(key string, leftByKey, rightByKey map[string]compareRow) *compareRows {
+	rows := &compareRows{
+		Key:      key,
+		Added:    []compareRow{},
+		Removed:  []compareRow{},
+		Modified: []compareModifiedRow{},
+	}
+
+	for _, k := range sortedKeys(leftByKey) {
+		lrow := leftByKey[k]
+		rrow, ok := rightByKey[k]
+		if !ok {
+			rows.Removed = append(rows.Removed, lrow)
+			continue
+		}
+		if !rowMapsEqual(lrow, rrow) {
+			rows.Modified = append(rows.Modified, compareModifiedRow{Key: k, Left: lrow, Right: rrow})
+		}
+	}
+	for _, k := range sortedKeys(rightByKey) {
+		if _, ok := leftByKey[k]; !ok {
+			rows.Added = append(rows.Added, rightByKey[k])
+		}
+	}
+	return rows
 }
 
 // indexOfColumn returns the position of name in header, or -1.
@@ -409,8 +421,8 @@ func rowMapsEqual(a, b compareRow) bool {
 	return true
 }
 
-// sortedKeys returns the keys of a row index in deterministic order.
-func sortedKeys(m map[string]int) []string {
+// sortedKeys returns the keys of a string-keyed map in deterministic order.
+func sortedKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/shell/compare_test.go
+++ b/shell/compare_test.go
@@ -3,8 +3,10 @@ package shell
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nao1215/sqly/config"
@@ -288,4 +290,89 @@ func TestRunCompare_Errors(t *testing.T) {
 			t.Error("expected an error for a missing named table")
 		}
 	})
+}
+
+// writeKeyedCompareBenchCSVs writes two large keyed CSVs that differ by a few
+// added, removed, and modified rows, returning their paths.
+func writeKeyedCompareBenchCSVs(tb testing.TB, rows int) (string, string) {
+	tb.Helper()
+	dir := tb.TempDir()
+	left := filepath.Join(dir, "kleft.csv")
+	right := filepath.Join(dir, "kright.csv")
+
+	var lb, rb strings.Builder
+	lb.WriteString("id,name,score\n")
+	rb.WriteString("id,name,score\n")
+	for i := range rows {
+		fmt.Fprintf(&lb, "%d,name%d,%d\n", i, i, i%100)
+		// Shift the score on every 10th row (modified) and drop the last row on
+		// the right while adding one fresh id, so the diff has work to do.
+		score := i % 100
+		if i%10 == 0 {
+			score++
+		}
+		if i != rows-1 {
+			fmt.Fprintf(&rb, "%d,name%d,%d\n", i, i, score)
+		}
+	}
+	fmt.Fprintf(&rb, "%d,fresh,1\n", rows+1)
+
+	if err := os.WriteFile(left, []byte(lb.String()), 0o600); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(right, []byte(rb.String()), 0o600); err != nil {
+		tb.Fatal(err)
+	}
+	return left, right
+}
+
+func TestBuildCompareReport_KeyedDiff(t *testing.T) {
+	left, right := writeKeyedCompareBenchCSVs(t, 50)
+	shell, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if err := shell.commands.importCommand(context.Background(), shell, []string{left, right}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	report, err := shell.buildCompareReport(context.Background(), "kleft", "kright", "id")
+	if err != nil {
+		t.Fatalf("buildCompareReport: %v", err)
+	}
+	if report.Rows == nil {
+		t.Fatal("expected keyed rows section")
+	}
+	// Right drops the last row (1 removed), adds one fresh id (1 added), and
+	// shifts the score on ids 0,10,20,30,40 (5 modified).
+	if len(report.Rows.Removed) != 1 {
+		t.Errorf("removed = %d, want 1", len(report.Rows.Removed))
+	}
+	if len(report.Rows.Added) != 1 {
+		t.Errorf("added = %d, want 1", len(report.Rows.Added))
+	}
+	if len(report.Rows.Modified) != 5 {
+		t.Errorf("modified = %d, want 5", len(report.Rows.Modified))
+	}
+}
+
+func BenchmarkBuildCompareReportKeyed(b *testing.B) {
+	left, right := writeKeyedCompareBenchCSVs(b, 5000)
+	shell, cleanup, err := newShell(b, []string{"sqly"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+	if err := shell.commands.importCommand(context.Background(), shell, []string{left, right}); err != nil {
+		b.Fatalf("import: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := shell.buildCompareReport(context.Background(), "kleft", "kright", "id"); err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

`--compare --compare-key` loaded both full tables with `SELECT *` and kept them, plus two index maps, alive at once while building the keyed diff.

Each side is now converted to its keyed rows (`keyedRows`) and the raw table is released before the other side is loaded; the two keyed maps are then diffed (`diffKeyedRows`). The two full `*model.Table` results never live at the same time. `compareKeyedRows` is kept as a thin wrapper over the shared helpers so the existing table-level tests still apply.

(A fully streaming row API would require a new query-layer iterator; this change removes the simultaneous full-table materialization that the issue calls out.)

## Tests

- `TestBuildCompareReport_KeyedDiff` drives the production keyed path on imported fixtures and checks added/removed/modified counts.
- `BenchmarkBuildCompareReportKeyed` compares two 5000-row keyed tables with `-benchmem`.
- The existing `TestCompareKeyedRows` (and its property tests) continue to cover the diff semantics.

Closes #600