### PR TITLE
fix(config): reject an explicit empty --sql value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* Reject Empty --sql: an explicit empty `--sql ""` now fails fast with a clear validation error instead of silently running no query and exiting 0, matching the other string flags that already reject explicit empty values.
 * Leaner Keyed Compare: `--compare --compare-key` now converts each side to its keyed rows and releases the raw table before loading the other, so the two full tables are no longer held in memory at the same time.
 * Single-Pass Profiling: `--profile` now aggregates each column's statistics in a single pass over the rows instead of copying the whole table into a per-column values and nulls slice, so its memory no longer scales with columns times rows.
 * Single-Insert History Writes: each interactive command's history write is now a single insert that relies on SQLite AUTOINCREMENT, instead of scanning the entire history table to compute the next id. History preloading at startup still reads the table once.

--- a/config/argument.go
+++ b/config/argument.go
@@ -241,6 +241,9 @@ func NewArg(args []string) (*Arg, error) {
 	// Reject other flags given an explicit empty value for the same reason: each
 	// flag's empty string is the "flag absent" sentinel, so an explicit "" would
 	// otherwise be silently ignored.
+	if flag.Changed("sql") && *query == "" {
+		return nil, errEmptyQuery
+	}
 	if flag.Changed("output") && *output == "" {
 		return nil, errEmptyOutput
 	}

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -372,6 +372,16 @@ func TestNewArg(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit empty --sql is rejected", func(t *testing.T) {
+		_, err := NewArg([]string{"sqly", "--sql", "", "testdata/user.csv"})
+		if err == nil {
+			t.Fatal("expected an error for an explicit empty --sql, got nil")
+		}
+		if !errors.Is(err, errEmptyQuery) {
+			t.Errorf("mismatch error got=%v, want=%v", err, errEmptyQuery)
+		}
+	})
+
 	t.Run("explicit empty --output is rejected", func(t *testing.T) {
 		_, err := NewArg([]string{"sqly", "--sql", "SELECT 1 AS x", "--output", ""})
 		if err == nil {

--- a/config/errors.go
+++ b/config/errors.go
@@ -21,6 +21,7 @@ var errInvalidStdinName = errors.New("--stdin-name must be a valid table name: l
 // silently behave like the flag was never passed instead of surfacing the
 // malformed value.
 var (
+	errEmptyQuery   = errors.New("--sql requires a non-empty SQL statement")
 	errEmptyOutput  = errors.New("--output requires a non-empty destination path")
 	errEmptySQLFile = errors.New("--sql-file requires a non-empty file path")
 	errEmptySaveDir = errors.New("--save-dir requires a non-empty directory path")

--- a/spec/v0_25_bugs_spec.sh
+++ b/spec/v0_25_bugs_spec.sh
@@ -23,6 +23,6 @@ Describe 'sqly v0.25.0 binary regressions'
   It 'rejects an explicit empty --sql value'
     When run sqly --sql '' "$PROJECT_ROOT/testdata/user.csv"
     The status should be failure
-    The stderr should include '--sql'
+    The stderr should include '--sql requires a non-empty SQL statement'
   End
 End

--- a/spec/v0_25_bugs_spec.sh
+++ b/spec/v0_25_bugs_spec.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Binary-level regressions for the v0.25.0 onboarding/UX hardening work. These run
+# the built sqly the way a user does (flags, batch stdin, exit codes) so the fixes
+# are pinned at the layer the bugs were reported against.
+
+Describe 'sqly v0.25.0 binary regressions'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    WORK=$(mktemp -d)
+    export SQLY_HISTORY_DB_PATH="$WORK/history.db"
+  }
+  cleanup() {
+    rm -rf "$WORK"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  # An explicit empty --sql value must fail fast instead of silently running no
+  # query and exiting 0, matching the other string flags that reject empty values.
+  It 'rejects an explicit empty --sql value'
+    When run sqly --sql '' "$PROJECT_ROOT/testdata/user.csv"
+    The status should be failure
+    The stderr should include '--sql'
+  End
+End


### PR DESCRIPTION
## Summary

An explicit empty `--sql ""` was silently treated as if `--sql` was never provided: the command exited `0` without printing anything or running any query. That let CI jobs, wrappers, and templated commands that expand to an empty string report success while executing no SQL.

This validates `--sql` during argument parsing the same way `--output`, `--sql-file`, `--save-dir`, and `--stdin` are already validated when their flag is changed, returning a clear `--sql requires a non-empty SQL statement` error so the malformed value is visible.

## Changes

- `config/argument.go`: reject `--sql ""` when the flag is explicitly set to an empty string.
- `config/errors.go`: add `errEmptyQuery`.
- `config/argument_test.go`: add a unit test asserting the empty-`--sql` rejection.
- `spec/v0_25_bugs_spec.sh`: add a binary-level shellspec case asserting `sqly --sql '' testdata/user.csv` exits non-zero with a `--sql` hint.

## Test

- `go test ./config/`
- `shellspec --shell sh spec/v0_25_bugs_spec.sh`

Closes #660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `--sql ""` is now rejected with a clear validation error instead of being treated as a successful no-op.
  * Improved validation behavior when `--sql` is explicitly provided as an empty string.
  * Added regression coverage to ensure the command fails for empty `--sql` values and emits the expected message.

* **Chores**
  * Updated the changelog with the new bug fix entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->