### PR TITLE
feat(shell): surface a hint when non-interactive sqly receives no statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* No Silent No-Op: a non-interactive run with no TTY and no statements (empty or comment-only stdin, and no `--sql`/`--sql-file`) now prints a hint and exits non-zero instead of exiting 0 silently, so headless wrappers and CI no longer mistake a no-op invocation for a completed query. An empty `--save`/`--save-dir` batch still leaves source files untouched.
 * Reject Empty --sql: an explicit empty `--sql ""` now fails fast with a clear validation error instead of silently running no query and exiting 0, matching the other string flags that already reject explicit empty values.
 * Leaner Keyed Compare: `--compare --compare-key` now converts each side to its keyed rows and releases the raw table before loading the other, so the two full tables are no longer held in memory at the same time.
 * Single-Pass Profiling: `--profile` now aggregates each column's statistics in a single pass over the rows instead of copying the whole table into a per-column values and nulls slice, so its memory no longer scales with columns times rows.

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -49,6 +49,12 @@ const (
 	msgExcelSheet     = "Excel sheet"
 )
 
+// errNoStatements is returned by a non-interactive run that reads stdin in batch
+// mode but executes nothing (no TTY and empty or comment-only stdin, with no
+// --sql/--sql-file). Without it the run would exit 0 silently, so a headless
+// wrapper or CI job could mistake a no-op for a completed query.
+var errNoStatements = errors.New("no TTY detected and no SQL was received on stdin; pipe a SQL query or sqly command, or pass --sql/--sql-file (run with --help for usage)")
+
 // Shell is main class of the sqly command.
 // Shell is the interface to the user and requests processing from the usecase layer.
 type Shell struct {
@@ -319,10 +325,13 @@ func (s *Shell) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		// Skip write-back when nothing ran (e.g. empty stdin), so an empty batch
-		// does not trigger --save/--save-dir side effects.
+		// A non-interactive run that executed nothing (no TTY and empty or
+		// comment-only stdin, with no --sql/--sql-file) is a silent no-op that
+		// still exits 0, so headless wrappers and CI mistake it for a completed
+		// query. Surface a hint and fail instead. Returning before write-back also
+		// keeps an empty --save/--save-dir batch from rewriting source files.
 		if !ranAny {
-			return nil
+			return errNoStatements
 		}
 		return s.finishNonInteractive(ctx)
 	}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1981,8 +1981,10 @@ func TestShellRunBatch_EmptyStdinSkipsSave(t *testing.T) {
 	defer func() { config.Stderr = backupStderr }()
 	config.Stderr = &bytes.Buffer{}
 
-	if err := shell.Run(context.Background()); err != nil {
-		t.Fatalf("empty batch Run returned error: %v", err)
+	// An empty batch now fails with the no-statements hint, but it must still
+	// return before write-back so the source file is never rewritten.
+	if err := shell.Run(context.Background()); !errors.Is(err, errNoStatements) {
+		t.Fatalf("empty batch Run error = %v, want errNoStatements", err)
 	}
 	got, err := os.ReadFile(filepath.Clean(src))
 	if err != nil {
@@ -2855,6 +2857,33 @@ func TestShellRun_SQLFileRejectsPipedStdin(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "stdin") {
 		t.Fatalf("error = %q, want it to mention stdin", err.Error())
+	}
+}
+
+func TestShellRun_NonInteractiveNoStatementsHint(t *testing.T) {
+	// Regression for #659: a non-TTY run that executes nothing (empty stdin, with
+	// no --sql/--sql-file) must surface a hint and fail instead of exiting 0
+	// silently, so a headless wrapper does not mistake the no-op for success.
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "no file arguments", args: []string{"sqly"}},
+		{name: "with a file argument", args: []string{"sqly", filepath.Join("testdata", "actor.csv")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shell, cleanup, err := newShell(t, tc.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+			shell.isTTY = func() bool { return false }
+			shell.stdin = strings.NewReader("")
+
+			if err := shell.Run(context.Background()); !errors.Is(err, errNoStatements) {
+				t.Fatalf("Run error = %v, want errNoStatements", err)
+			}
+		})
 	}
 }
 

--- a/spec/batch_failfast_spec.sh
+++ b/spec/batch_failfast_spec.sh
@@ -55,8 +55,11 @@ Describe 'sqly batch fail-fast'
   End
 
   It 'does not write back for empty stdin with --save --force'
+    # Empty stdin now fails with the no-statements hint, but it must still return
+    # before write-back so the source file is left untouched.
     When run sqly "$WORK/u.csv" --save --force
-    The status should be success
+    The status should be failure
+    The stderr should include 'no TTY detected'
     The stderr should not include 'Saved'
     The contents of file "$WORK/u.csv" should equal "$(cat testdata/user.csv)"
   End

--- a/spec/v0_25_bugs_spec.sh
+++ b/spec/v0_25_bugs_spec.sh
@@ -25,4 +25,19 @@ Describe 'sqly v0.25.0 binary regressions'
     The status should be failure
     The stderr should include '--sql requires a non-empty SQL statement'
   End
+
+  # A non-interactive run that receives no statements (no TTY, empty stdin, no
+  # --sql/--sql-file) must surface a hint and exit non-zero instead of looking
+  # successful while doing nothing.
+  It 'reports a hint when non-interactive run gets empty stdin and no file'
+    When run sh -c "printf '' | \"$SQLY_BIN\""
+    The status should be failure
+    The stderr should include 'no TTY detected'
+  End
+
+  It 'reports a hint when non-interactive run gets empty stdin with a file'
+    When run sh -c "printf '' | \"$SQLY_BIN\" \"$PROJECT_ROOT/testdata/user.csv\""
+    The status should be failure
+    The stderr should include 'no TTY detected'
+  End
 End


### PR DESCRIPTION
## Summary

When sqly ran without a TTY and received no statements, it exited `0` without printing anything. Headless wrappers, CI jobs, and editor integrations could appear successful while doing nothing:

```bash
sqly
sqly testdata/user.csv
printf '' | sqly testdata/user.csv
```

The batch (non-TTY) path now returns `errNoStatements` when nothing ran, printing a hint (`no TTY detected and no SQL was received on stdin; pipe a SQL query or sqly command, or pass --sql/--sql-file`) and exiting non-zero. It returns before write-back, so an empty `--save`/`--save-dir` batch still leaves source files untouched.

## Changes

- `shell/shell.go`: add `errNoStatements`; return it from the batch path when `ranAny` is false.
- `shell/shell_test.go`: add a regression test for the empty-stdin hint (with and without a file argument); update the empty-batch `--save` test to expect the hint while still asserting no rewrite.
- `spec/v0_25_bugs_spec.sh`: add binary-level cases for empty stdin with and without a file argument.
- `spec/batch_failfast_spec.sh`: update the empty-stdin `--save --force` case to expect the hint while still asserting the source file is untouched.

## Test

- `go test ./shell/ ./config/`
- `shellspec --shell sh` (345 examples, 0 failures)

Closes #659