### PR TITLE
fix(shell): stop leaking the staging temp path in --stdin import errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 
 ### Bug Fixes
+* Stable --stdin Error: a failing `--stdin` import now reports the input as `stdin (--stdin FORMAT)` instead of leaking the random internal staging temp path (for example `/tmp/sqly-stdin-*/stdin.csv`), so the message reads as a stdin problem and stays the same across runs.
 * No Silent No-Op: a non-interactive run with no TTY and no statements (empty or comment-only stdin, and no `--sql`/`--sql-file`) now prints a hint and exits non-zero instead of exiting 0 silently, so headless wrappers and CI no longer mistake a no-op invocation for a completed query. An empty `--save`/`--save-dir` batch still leaves source files untouched.
 * Reject Empty --sql: an explicit empty `--sql ""` now fails fast with a clear validation error instead of silently running no query and exiting 0, matching the other string flags that already reject explicit empty values.
 * Leaner Keyed Compare: `--compare --compare-key` now converts each side to its keyed rows and releases the raw table before loading the other, so the two full tables are no longer held in memory at the same time.

--- a/shell/import.go
+++ b/shell/import.go
@@ -481,6 +481,29 @@ func (s *Shell) markDirImported(name string) {
 }
 
 // importFile loads a single file into the database, applying --sheet filtering for Excel.
+// stdinImportErrorMessage renders an import failure for the staged --stdin
+// dataset with the random temp staging path replaced by a stable
+// "stdin (--stdin FORMAT)" reference. ok is false when displayPath is not the
+// staged stdin file, so a normal file import keeps its real path and error
+// wrapping. The candidate paths (the cleaned path and the path actually handed
+// to filesql, plus their temp directories) are all scrubbed because filesql
+// embeds the path it streamed inside its own error text.
+func (s *Shell) stdinImportErrorMessage(displayPath string, err error, candidates ...string) (string, bool) {
+	if s.stdinStagedPath == "" || displayPath != s.stdinStagedPath {
+		return "", false
+	}
+	label := fmt.Sprintf("stdin (--stdin %s)", s.argument.StdinFormat)
+	msg := fmt.Sprintf("failed to import file %s: %v", label, err)
+	for _, p := range append(candidates, displayPath) {
+		if p == "" {
+			continue
+		}
+		msg = strings.ReplaceAll(msg, p, label)
+		msg = strings.ReplaceAll(msg, filepath.Dir(p), label)
+	}
+	return msg, true
+}
+
 func (s *Shell) importFile(ctx context.Context, cleanPath, displayPath, sheetName string) error {
 	// loadPath is the path actually handed to filesql. It differs from cleanPath
 	// only for an extensionless pseudo-file (e.g. /dev/stdin, /proc/self/fd/0),
@@ -504,6 +527,12 @@ func (s *Shell) importFile(ctx context.Context, cleanPath, displayPath, sheetNam
 	existingTables := tableNameSet(before)
 
 	if err := s.usecases.importer.LoadFiles(ctx, loadPath); err != nil {
+		// A failed --stdin import would otherwise leak the random staging temp
+		// path (in both this wrapper and the path filesql embeds in its own
+		// error). Map it back to a stable "stdin (--stdin FORMAT)" reference.
+		if msg, ok := s.stdinImportErrorMessage(displayPath, err, cleanPath, loadPath); ok {
+			return errors.New(msg)
+		}
 		return fmt.Errorf("failed to import file %s: %w", displayPath, err)
 	}
 

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -74,6 +74,11 @@ type Shell struct {
 	// disabled for the session if the history DB cannot be created or written,
 	// so automation does not fail on a read-only config location.
 	historyEnabled bool
+	// stdinStagedPath is the temporary staging file a --stdin dataset is written
+	// to before import. It is recorded so import error reporting can map that
+	// random path (and the temp dir filesql embeds in its own error) back to a
+	// stable "stdin" reference, instead of leaking the implementation detail.
+	stdinStagedPath string
 	// tableSources maps an imported table name to the source path it came from.
 	// It is populated on every import and used by the --inspect report and by
 	// write-back (.save) to map a table back to its source file.
@@ -448,6 +453,7 @@ func (s *Shell) init(ctx context.Context) error {
 
 	paths := s.argument.FilePaths
 	stdinAbsPath := ""
+	stagedStdinPath := ""
 	// When --stdin is set, stage piped stdin as a dataset file and import it
 	// alongside the file/directory arguments so it can be queried and joined.
 	if s.argument.StdinFormat != "" {
@@ -461,6 +467,7 @@ func (s *Shell) init(ctx context.Context) error {
 			return err
 		}
 		defer cleanup()
+		stagedStdinPath = stdinPath
 		if abs, err := filepath.Abs(stdinPath); err == nil {
 			stdinAbsPath = abs
 		} else {
@@ -472,6 +479,10 @@ func (s *Shell) init(ctx context.Context) error {
 	if len(paths) == 0 {
 		return nil
 	}
+	// Record the staged path so import error reporting can map it (and the random
+	// temp dir filesql embeds in its own error) back to a stable "stdin"
+	// reference instead of leaking the implementation-detail path.
+	s.stdinStagedPath = stagedStdinPath
 	importErr := s.loadOrImport(ctx, paths)
 	// Re-point any stdin-derived table's source from the ephemeral temp path to
 	// a stable "stdin" marker, so --inspect does not leak the temp path

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2860,6 +2860,35 @@ func TestShellRun_SQLFileRejectsPipedStdin(t *testing.T) {
 	}
 }
 
+func TestShellStdinImportErrorMessage(t *testing.T) {
+	t.Parallel()
+	const staged = "/tmp/sqly-stdin-85800075/stdin.csv"
+	s := &Shell{argument: &config.Arg{StdinFormat: "csv"}, stdinStagedPath: staged}
+
+	t.Run("non-stdin path keeps its real path and reports ok=false", func(t *testing.T) {
+		t.Parallel()
+		msg, ok := s.stdinImportErrorMessage("data.csv", errors.New("boom"), "data.csv")
+		if ok {
+			t.Fatalf("ok = true for a non-stdin path, want false (msg=%q)", msg)
+		}
+	})
+
+	t.Run("maps the staged temp path and the path filesql embeds to stdin", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New("filesql: parsing failed: failed to stream file " + staged + ": filesql: empty data source: file is empty")
+		msg, ok := s.stdinImportErrorMessage(staged, inner, staged, staged)
+		if !ok {
+			t.Fatal("ok = false for the staged stdin path, want true")
+		}
+		if strings.Contains(msg, "sqly-stdin-") {
+			t.Errorf("message still leaks the temp path: %q", msg)
+		}
+		if !strings.Contains(msg, "stdin (--stdin csv)") {
+			t.Errorf("message does not mention stdin: %q", msg)
+		}
+	})
+}
+
 func TestShellRun_NonInteractiveNoStatementsHint(t *testing.T) {
 	// Regression for #659: a non-TTY run that executes nothing (empty stdin, with
 	// no --sql/--sql-file) must surface a hint and fail instead of exiting 0

--- a/spec/v0_25_bugs_spec.sh
+++ b/spec/v0_25_bugs_spec.sh
@@ -40,4 +40,13 @@ Describe 'sqly v0.25.0 binary regressions'
     The status should be failure
     The stderr should include 'no TTY detected'
   End
+
+  # A failing --stdin import must describe the input as stdin, not leak the random
+  # internal staging temp path (which is noisy and changes every run).
+  It 'reports a stable stdin reference instead of the staging temp path'
+    When run sh -c "printf '' | \"$SQLY_BIN\" --stdin csv --sql 'SELECT COUNT(*) FROM stdin'"
+    The status should be failure
+    The stderr should include 'stdin'
+    The stderr should not include 'sqly-stdin-'
+  End
 End


### PR DESCRIPTION
## Summary

A failing `--stdin` import exposed the internal temporary staging path instead of describing the failing input as `stdin`:

```bash
printf '' | sqly --stdin csv --sql 'SELECT COUNT(*) FROM stdin'
# failed to import file /tmp/sqly-stdin-85800075/stdin.csv: filesql: parsing failed:
#   failed to stream file /tmp/sqly-stdin-85800075/stdin.csv: filesql: empty data source: file is empty
```

The path appeared twice: once in sqly's own wrapper and once inside the error filesql renders for the path it streamed. New users could misread it as a filesystem/path problem, and the random temp suffix made logs noisy and unpredictable.

`importFile` now maps the staged stdin file (and the temp directory filesql embeds) back to a stable `stdin (--stdin FORMAT)` reference. Non-stdin imports keep their real path and error wrapping unchanged.

## Changes

- `shell/shell.go`: record the staged stdin path on the shell (`stdinStagedPath`).
- `shell/import.go`: add `stdinImportErrorMessage`, used by `importFile` to scrub the staging path from a `--stdin` import failure.
- `shell/shell_test.go`: unit-test the scrub (stdin path mapped, non-stdin path untouched).
- `spec/v0_25_bugs_spec.sh`: binary-level case asserting stderr mentions `stdin` and not `sqly-stdin-`.

## Test

- `go test ./shell/`
- `shellspec --shell sh spec/v0_25_bugs_spec.sh spec/stdin_dataset_spec.sh`

Closes #663