### PR TITLE
feat(shell): guide accidental "sqly help"/"sqly version" to the right flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### New Features
+* Flag-Driven Subcommand Hint: `sqly help` and `sqly version` (and case variants) now print a short hint pointing at `--help`/`--version` and exit non-zero, instead of a confusing "path does not exist" import error. A real file or directory named `help`/`version` still imports. The help text and docs also note that sqly has no subcommands.
 * Sheet-Name Completion: `.import WORKBOOK.xlsx --sheet` (and the joined `--sheet=` form) now tab-completes the workbook's sheet names. Names with spaces or non-ASCII characters are completed in a quoted or backslash-escaped form that stays a single argument, and sheet completion does not fall back to file-path suggestions.
 * Path Completion for More Helpers: tab completion now completes filesystem paths for `.cd`, `.ls`, `.dump`, and `.save`, not only `.import`. `.cd` and `.save` offer directories only, `.ls` offers files and directories, and `.dump` completes the destination path after the table-name argument.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ sqly --sql "SELECT * FROM data" data.csv.gz
 sqly --sql "SELECT user_name, position FROM user JOIN identifier ON user.identifier = identifier.id" testdata/user.csv testdata/identifier.csv
 ```
 
+sqly is flag-driven and has no subcommands. Use `sqly --help` and `sqly --version`, not `sqly help` or `sqly version` (those are read as input paths). Helper commands such as `.tables` and `.import` run inside the interactive shell or batch stdin mode, not as command-line arguments.
+
 ## Install
 
 ```shell

--- a/config/argument.go
+++ b/config/argument.go
@@ -448,6 +448,10 @@ func usage(flag pflag.FlagSet) string {
 	s += "[Usage]\n"
 	s += fmt.Sprintf("  %s [OPTIONS] [FILE_PATH(S)|DIRECTORY_PATH(S)]\n", color.GreenString("sqly"))
 	s += "\n"
+	s += "  sqly is flag-driven and has no subcommands: use --help and --version,\n"
+	s += "  not \"sqly help\" or \"sqly version\". Helper commands like .tables and\n"
+	s += "  .import run inside the shell or batch stdin mode, not as arguments.\n"
+	s += "\n"
 	s += "[Example]\n"
 	s += fmt.Sprintf("  - %s\n", color.HiYellowString("run sqly shell"))
 	s += "    sqly\n"

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -3,6 +3,10 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
 [Usage]
   sqly [OPTIONS] [FILE_PATH(S)|DIRECTORY_PATH(S)]
 
+  sqly is flag-driven and has no subcommands: use --help and --version,
+  not "sqly help" or "sqly version". Helper commands like .tables and
+  .import run inside the shell or batch stdin mode, not as arguments.
+
 [Example]
   - run sqly shell
     sqly

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -4,6 +4,8 @@ If no SQL query is specified with the `--sql` option, sqly will start the sqly s
 
 Flags may appear before or after the file and directory arguments; `sqly --csv data.csv` and `sqly data.csv --csv` are equivalent. A misplaced unknown flag fails with a parse error instead of being read as a file path.
 
+sqly is flag-driven and has no subcommands. Use `sqly --help` and `sqly --version`, not `sqly help` or `sqly version`; those forms are read as input paths, and sqly will point you to the right flag. Helper commands such as `.tables` and `.import` run inside the interactive shell or batch stdin mode, not as command-line arguments.
+
 sqly allows you to change the display mode of SQL results with options. By default, the output is in table format. The output format can be changed to csv (`--csv`), tsv (`--tsv`), ltsv (`--ltsv`), markdown (`--markdown`), json (`--json`), or ndjson (`--ndjson`). Excel (`--excel`) and Parquet (`--parquet`) are export-only: they render as csv on screen and write a file only through `.dump` or `--output`. Since the output mode can be changed while the sqly shell is running, it is easy to execute `sqly sample.csv` and then change settings or execute SQL queries within the sqly shell.
 
 For automation-friendly output, `--json-typed` and `--ndjson-typed` (or `.mode json-typed` / `.mode ndjson-typed` in the shell) emit native JSON scalars instead of strings: a canonical JSON number becomes a number, `true`/`false` become booleans, and a SQL NULL becomes `null`. A large integer stays lossless and never regresses into scientific notation, while a value with a leading zero such as `007` remains a string. The default `--json`/`--ndjson` keep the legacy string contract. Pair `--inspect` with `--json-typed` to apply the same contract to the report's sample rows.
@@ -17,6 +19,10 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
 
 [Usage]
   sqly [OPTIONS] [FILE_PATH(S)|DIRECTORY_PATH(S)]
+
+  sqly is flag-driven and has no subcommands: use --help and --version,
+  not "sqly help" or "sqly version". Helper commands like .tables and
+  .import run inside the shell or batch stdin mode, not as arguments.
 
 [Example]
   - run sqly shell

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -176,6 +176,14 @@ func (s *Shell) Run(ctx context.Context) error {
 		return nil
 	}
 
+	// sqly is flag-driven and has no subcommands, so a common first try like
+	// "sqly help" or "sqly version" is otherwise parsed as an input path and fails
+	// with a confusing "path does not exist" import error. Detect that exact
+	// accidental form and point the user at the right flag instead.
+	if hint, ok := positionalSubcommandHint(s.argument.FilePaths); ok {
+		return errors.New(hint)
+	}
+
 	// --sheet only affects Excel imports; reject it up front when no input can
 	// be an Excel file so a typo is not silently ignored.
 	if err := s.validateSheetFlag(); err != nil {
@@ -440,6 +448,32 @@ func (s *Shell) disableHistory(err error) {
 // --sql, --sql-file). Batch mode (non-TTY) and those flags are non-interactive.
 func (s *Shell) startsInteractiveShell() bool {
 	return s.isTTY() && !s.argument.InspectFlag && !s.argument.CompareFlag && !s.argument.ProfileFlag && s.argument.Query == "" && s.argument.SQLFilePath == ""
+}
+
+// positionalSubcommandHint reports whether the first positional argument is the
+// accidental subcommand form "help" or "version" (the flags are --help and
+// --version) and returns a correcting hint. Why check os.Stat: a real file or
+// directory actually named "help"/"version" should still import, so the hint
+// fires only when no such path exists. The match is case-insensitive to also
+// catch "HELP"/"Version".
+func positionalSubcommandHint(paths []string) (string, bool) {
+	if len(paths) == 0 {
+		return "", false
+	}
+	first := paths[0]
+	var flag string
+	switch strings.ToLower(first) {
+	case "help":
+		flag = "--help"
+	case "version":
+		flag = "--version"
+	default:
+		return "", false
+	}
+	if _, err := os.Stat(first); err == nil {
+		return "", false // a real path with that name wins
+	}
+	return fmt.Sprintf("sqly is flag-driven and has no subcommands; use %q. Run \"sqly --help\" for usage. Helper commands like .tables and .import run inside the shell or batch stdin.", flag), true
 }
 
 // reportOnly reports whether the run is a non-interactive report mode

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2895,6 +2895,59 @@ func TestShellRun_SQLFileRejectsPipedStdin(t *testing.T) {
 	}
 }
 
+func TestPositionalSubcommandHint(t *testing.T) {
+	t.Run("help with no such file suggests --help", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		hint, ok := positionalSubcommandHint([]string{"help"})
+		if !ok {
+			t.Fatal("expected a hint for 'help', got ok=false")
+		}
+		if !strings.Contains(hint, "--help") {
+			t.Errorf("hint = %q, want it to suggest --help", hint)
+		}
+	})
+
+	t.Run("version with no such file suggests --version", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		hint, ok := positionalSubcommandHint([]string{"version"})
+		if !ok {
+			t.Fatal("expected a hint for 'version', got ok=false")
+		}
+		if !strings.Contains(hint, "--version") {
+			t.Errorf("hint = %q, want it to suggest --version", hint)
+		}
+	})
+
+	t.Run("the match is case-insensitive", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		if _, ok := positionalSubcommandHint([]string{"HELP"}); !ok {
+			t.Error("expected a hint for 'HELP'")
+		}
+	})
+
+	t.Run("a real file named help is treated as a path", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		if err := os.WriteFile("help", []byte("a\n1\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := positionalSubcommandHint([]string{"help"}); ok {
+			t.Error("a real file named 'help' should win over the subcommand hint")
+		}
+	})
+
+	t.Run("a normal file argument returns false", func(t *testing.T) {
+		if _, ok := positionalSubcommandHint([]string{"data.csv"}); ok {
+			t.Error("a normal file argument should not produce a hint")
+		}
+	})
+
+	t.Run("no arguments returns false", func(t *testing.T) {
+		if _, ok := positionalSubcommandHint(nil); ok {
+			t.Error("no arguments should not produce a hint")
+		}
+	})
+}
+
 func TestShellStdinImportErrorMessage(t *testing.T) {
 	t.Parallel()
 	const staged = "/tmp/sqly-stdin-85800075/stdin.csv"

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -3,6 +3,10 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
 [Usage]
   sqly [OPTIONS] [FILE_PATH(S)|DIRECTORY_PATH(S)]
 
+  sqly is flag-driven and has no subcommands: use --help and --version,
+  not "sqly help" or "sqly version". Helper commands like .tables and
+  .import run inside the shell or batch stdin mode, not as arguments.
+
 [Example]
   - run sqly shell
     sqly

--- a/spec/v0_25_bugs_spec.sh
+++ b/spec/v0_25_bugs_spec.sh
@@ -131,4 +131,21 @@ Describe 'sqly v0.25.0 binary regressions'
     The output should include '"tables"'
     The stderr should not include 'Successfully imported'
   End
+
+  # sqly is flag-driven; the accidental subcommand forms "sqly help" / "sqly
+  # version" must point at the right flag instead of failing as an import path.
+  It 'guides "sqly help" to --help instead of an import error'
+    When run sqly help
+    The status should be failure
+    The stderr should include '--help'
+    The stderr should include 'no subcommands'
+    The stderr should not include 'path does not exist'
+  End
+
+  It 'guides "sqly version" to --version instead of an import error'
+    When run sqly version
+    The status should be failure
+    The stderr should include '--version'
+    The stderr should not include 'path does not exist'
+  End
 End


### PR DESCRIPTION
## Summary

sqly is flag-driven and has no subcommands, but a common first try like `sqly help` or `sqly version` was parsed as an input path and failed with a confusing import error:

```text
Import failed with 1 error(s):
  - path does not exist: help
all import attempts failed
```

sqly now detects the accidental `help`/`version` positional (case-insensitive) and prints a short hint pointing at `--help`/`--version`, exiting non-zero. A real file or directory named `help`/`version` still imports. The `--help` text, README, and GitHub Pages docs also state that sqly has no subcommands and that helper commands run inside the shell or batch stdin mode.

## Changes

- `shell/shell.go`: add `positionalSubcommandHint`; emit it before import in `Run`.
- `config/argument.go`: add a flag-driven note to the `--help` usage text.
- `README.md`, `doc/pages/markdown/how_to_use.md`: document that sqly has no subcommands.
- `shell/shell_test.go`: `TestPositionalSubcommandHint` (help/version/case-insensitive/real-file-wins/normal-arg/empty).
- `spec/v0_25_bugs_spec.sh`: binary-level cases for `sqly help` and `sqly version`.
- regenerated `config/testdata/usage.golden` and `shell/testdata/golden/help.golden`.

## Test

- `go test ./...`
- `shellspec --shell sh` (357 examples, 0 failures)

Closes #664