### PR TITLE
test(e2e): run ShellSpec through a hermetic temp-backed sandbox

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -33,8 +33,7 @@ jobs:
           curl -fsSL https://git.io/shellspec | sh -s 0.28.1 --yes
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Build sqly
-        run: make build
-
       - name: Run shellspec end-to-end tests
-        run: shellspec --shell sh
+        # The hermetic runner builds sqly and runs the suite in a temp-backed
+        # HOME/config sandbox, so local and CI execution are identical.
+        run: make test-e2e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
 * Clean Ctrl-D Exit: pressing Ctrl-D (EOF) in the interactive shell now exits cleanly like `.exit` instead of printing a raw `EOF` line. Both EOF spellings the prompt library reports (Ctrl-D on an empty line and a closed input stream) are treated as a normal termination.
 * Symlink-Resolved System-Path Guard: import path validation now rejects a symlink whose canonical target is a blocked system location (such as a link to `/etc/hosts`), not only a directly typed system path. It also normalizes the macOS `/private` prefix, while standard Unix pseudo-files (`/dev/stdin`, `/proc/self/fd/*`) keep importing.
 
+### Documentation
+* Hermetic E2E Harness: the ShellSpec suite now runs through `scripts/run_e2e.sh`, which builds the binary and runs the suite in a throwaway temp-backed HOME and config sandbox, so it never reads or writes the developer's real config directory and local and CI runs are identical. `make test-e2e` and the CI job invoke the suite only through this wrapper.
+
 ### Dependencies
 * Prompt: upgrade `github.com/nao1215/prompt` to v0.0.8 for the `ActionClearScreen` key action that backs the Ctrl+L clear-screen binding.
 * Prompt: upgrade `github.com/nao1215/prompt` to v0.0.7 for the `WithIsComplete` multiline submit predicate and the `WithWordEscape` option that lets completion treat backslash-escaped whitespace as part of a word.

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ test: ## Start test
 	env GOOS=$(GOOS) $(GO_TEST) -cover $(GO_PKGROOT) -coverpkg=./... -coverprofile=cover.out
 	$(GO_TOOL) cover -html=cover.out -o cover.html
 
-test-e2e: build ## Run shellspec end-to-end tests against the built binary
-	shellspec --shell sh
+test-e2e: ## Run shellspec end-to-end tests in a hermetic temp-backed sandbox
+	sh scripts/run_e2e.sh
 
 demo: build ## Render README demo GIFs from doc/vhs/*.tape (requires vhs, ttyd, ffmpeg)
 	for tape in doc/vhs/*.tape; do vhs "$$tape"; done

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Hermetic ShellSpec runner for sqly. It builds the binary and runs the E2E
+# suite inside a throwaway temp-backed HOME and config sandbox, so the suite
+# never reads or writes the developer's real config directory and local and CI
+# runs are identical. Any extra arguments are forwarded to shellspec (for
+# example a single spec file).
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Build the binary the specs exercise. spec_helper.sh resolves it at $ROOT/sqly.
+make build
+
+# Create an isolated sandbox and remove it on exit, so no run leaves state behind.
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT INT TERM
+
+mkdir -p "$SANDBOX/home" "$SANDBOX/config" "$SANDBOX/data" "$SANDBOX/cache"
+
+# Point HOME and every XDG base directory at the sandbox so config, history, and
+# cache files land there instead of in the developer's real home. USERPROFILE
+# covers Windows-style home resolution if the suite ever runs there.
+HOME="$SANDBOX/home"
+export HOME
+export USERPROFILE="$SANDBOX/home"
+export XDG_CONFIG_HOME="$SANDBOX/config"
+export XDG_DATA_HOME="$SANDBOX/data"
+export XDG_CACHE_HOME="$SANDBOX/cache"
+
+# Route sqly's command history to the sandbox explicitly, so specs that do not
+# set their own SQLY_HISTORY_DB_PATH still never touch the real history DB.
+export SQLY_HISTORY_DB_PATH="$SANDBOX/history.db"
+
+# Expose the sandbox root so the hermeticity spec can assert that HOME and the
+# history DB live inside it.
+export SQLY_E2E_SANDBOX="$SANDBOX"
+
+exec shellspec --shell sh "$@"

--- a/spec/hermetic_spec.sh
+++ b/spec/hermetic_spec.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Proves the E2E suite runs in the isolated sandbox prepared by
+# scripts/run_e2e.sh, so it never depends on the developer's real config
+# directory. When the suite is run directly (not through the wrapper),
+# SQLY_E2E_SANDBOX is unset and these checks skip instead of failing.
+
+Describe 'hermetic E2E environment'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  It 'runs with HOME inside the sandbox'
+    Skip if 'not run through scripts/run_e2e.sh' test -z "${SQLY_E2E_SANDBOX:-}"
+    When run sh -c 'case "$HOME" in "$SQLY_E2E_SANDBOX"*) exit 0 ;; *) exit 1 ;; esac'
+    The status should be success
+  End
+
+  It 'routes the history DB into the sandbox'
+    Skip if 'not run through scripts/run_e2e.sh' test -z "${SQLY_E2E_SANDBOX:-}"
+    When run sh -c 'case "$SQLY_HISTORY_DB_PATH" in "$SQLY_E2E_SANDBOX"*) exit 0 ;; *) exit 1 ;; esac'
+    The status should be success
+  End
+
+  It 'still runs sqly normally inside the sandbox'
+    When run sqly --sql 'SELECT 1 AS one' "$PROJECT_ROOT/testdata/user.csv"
+    The status should be success
+    The output should include 'one'
+  End
+End


### PR DESCRIPTION
## Summary

The ShellSpec suite ran the built binary directly, so it could be influenced by host state (the developer's real HOME, config, history, and cache directories), making local and CI runs less reproducible.

This adds `scripts/run_e2e.sh`, which builds sqly and runs the suite inside a throwaway temp-backed HOME and XDG sandbox, with sqly's history DB routed there explicitly, and removes it on exit. `make test-e2e` and the E2E CI job now invoke the suite only through this wrapper, so local and CI execution are identical.

## Changes

- `scripts/run_e2e.sh`: hermetic runner (build + sandboxed HOME/XDG/history + cleanup), forwards extra args to shellspec.
- `Makefile`: `test-e2e` now calls the wrapper.
- `.github/workflows/e2e_test.yml`: run the suite via `make test-e2e` instead of building and calling shellspec directly.
- `spec/hermetic_spec.sh`: asserts HOME and the history DB live inside the sandbox (skips when run without the wrapper), and that sqly still runs normally there.

## Test

- `make test-e2e` (360 examples, 0 failures)
- `shellspec --shell sh spec/hermetic_spec.sh` without the wrapper skips the sandbox assertions instead of failing.

Closes #657