### PR TITLE
chore: prepare v0.25.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 
 ### New Features
 * Flag-Driven Subcommand Hint: `sqly help` and `sqly version` (and case variants) now print a short hint pointing at `--help`/`--version` and exit non-zero, instead of a confusing "path does not exist" import error. A real file or directory named `help`/`version` still imports. The help text and docs also note that sqly has no subcommands.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A SQL statement is buffered until it ends with `;`, so a multi-line or pasted qu
 
 ```shell
 $ sqly testdata/user.csv
-sqly v0.24.0
+sqly v0.25.0
 
 enter "SQL query" or "sqly command that begins with a dot".
 .help print usage, .exit exit sqly.
@@ -516,7 +516,7 @@ SELECT * FROM `customers100000` WHERE `Index` BETWEEN 1000 AND 2000 ORDER BY `In
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.24.0. Run `make bench` to reproduce on your machine.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.25.0. Run `make bench` to reproduce on your machine.
 
 ## Comparison with similar tools
 


### PR DESCRIPTION
## Summary
Prepare the v0.25.0 release by promoting the current unreleased changelog entry to a dated release heading and refreshing the README version references to the new release number.

## Changes
- mark the top CHANGELOG entry as v0.25.0 with the v0.24.0...v0.25.0 compare link and release date
- refresh the interactive shell snippet and benchmark caption in the README from v0.24.0 to v0.25.0

## Design Decisions
- keep the release prep limited to the versioned docs surfaces that are expected to change for this cut
