### PR TITLE
fix: count blank string as a distinct value in --profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Bug Fixes
+* Profile Blank Distinct Count: `--profile` now counts the blank string as a real distinct value, so `distinct_count` stays consistent with `blank_count` instead of dropping blanks and understating cardinality for categorical columns that mix blanks with real values.
+
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 
 ### New Features

--- a/shell/feature_property_test.go
+++ b/shell/feature_property_test.go
@@ -159,8 +159,10 @@ func TestCompareKeyedRows_SwapProperty(t *testing.T) {
 }
 
 // TestProfileColumnStats_PartitionProperty asserts the column counts partition
-// the values exactly: every value is counted as null, blank, or non-empty, and
-// the numeric and distinct counts never exceed the non-empty count.
+// the values exactly: every value is counted as null, blank, or non-empty. The
+// numeric count never exceeds the non-empty count, and the distinct count never
+// exceeds the non-empty count plus one for the blank string, which counts as a
+// single distinct value when present.
 func TestProfileColumnStats_PartitionProperty(t *testing.T) {
 	t.Parallel()
 	property := func(values []string, nulls []bool) bool {
@@ -179,7 +181,11 @@ func TestProfileColumnStats_PartitionProperty(t *testing.T) {
 		if pc.NullCount != nullN || pc.BlankCount != blankN {
 			return false
 		}
-		if pc.NumericCount > nonEmpty || pc.DistinctCount > nonEmpty {
+		distinctCap := nonEmpty
+		if blankN > 0 {
+			distinctCap++ // the blank string contributes one distinct value
+		}
+		if pc.NumericCount > nonEmpty || pc.DistinctCount > distinctCap {
 			return false
 		}
 		return pc.NullCount+pc.BlankCount+nonEmpty == int64(len(values))

--- a/shell/profile.go
+++ b/shell/profile.go
@@ -194,6 +194,11 @@ func (c *columnProfiler) add(v string, isNull bool) {
 	}
 	if v == "" {
 		c.blankCount++
+		// The blank string is a real distinct value. Counting it keeps
+		// distinct_count consistent with blank_count so the report does not
+		// understate cardinality for categorical columns that mix blanks with
+		// real values.
+		c.distinct[v] = struct{}{}
 		return
 	}
 	c.distinct[v] = struct{}{}

--- a/shell/profile_test.go
+++ b/shell/profile_test.go
@@ -37,12 +37,27 @@ func TestProfileColumnStats(t *testing.T) {
 		if got.BlankCount != 1 {
 			t.Errorf("blank_count = %d, want 1", got.BlankCount)
 		}
-		// Non-null, non-blank values are "1","2","2" -> distinct {1,2} = 2.
-		if got.DistinctCount != 2 {
-			t.Errorf("distinct_count = %d, want 2", got.DistinctCount)
+		// Values are "1","2","","2" (index 4 is NULL). The blank string counts as a
+		// real distinct value, so distinct {1,2,""} = 3 and the metric no longer
+		// understates cardinality for columns that mix blanks with real values.
+		if got.DistinctCount != 3 {
+			t.Errorf("distinct_count = %d, want 3", got.DistinctCount)
 		}
 		if got.NumericCount != 3 {
 			t.Errorf("numeric_count = %d, want 3", got.NumericCount)
+		}
+	})
+
+	t.Run("counts a blank string as a distinct value alongside real values", func(t *testing.T) {
+		t.Parallel()
+		// Mixing blanks with real values: ["", "A", ""] has one real value plus the
+		// blank, so distinct {"", "A"} = 2 and blank_count = 2.
+		got := columnStats("v", "TEXT", []string{"", "A", ""}, []bool{false, false, false})
+		if got.BlankCount != 2 {
+			t.Errorf("blank_count = %d, want 2", got.BlankCount)
+		}
+		if got.DistinctCount != 2 {
+			t.Errorf("distinct_count = %d, want 2", got.DistinctCount)
 		}
 	})
 

--- a/spec/profile_spec.sh
+++ b/spec/profile_spec.sh
@@ -53,4 +53,22 @@ Describe 'sqly --profile workflow'
     The status should be success
     The output should include 'table orders: 2 rows, 2 columns'
   End
+
+  It 'counts a blank string as a distinct value in JSON output'
+    # Column v mixes one blank with one real value, so distinct_count is 2 and
+    # stays consistent with blank_count instead of dropping the blank. Column id
+    # has distinct_count 1, so the asserted value is unambiguous.
+    printf 'id,v\nx,\nx,A\n' > "$WORKDIR/blank.csv"
+    When run sqly --profile "$WORKDIR/blank.csv"
+    The status should be success
+    The output should include '"blank_count": 1'
+    The output should include '"distinct_count": 2'
+  End
+
+  It 'counts a blank string as a distinct value in text output'
+    printf 'id,v\nx,\nx,A\n' > "$WORKDIR/blank.csv"
+    When run sqly --profile --profile-format text "$WORKDIR/blank.csv"
+    The status should be success
+    The output should include 'blanks=1 distinct=2'
+  End
 End


### PR DESCRIPTION
## Summary

`--profile` incremented `blank_count` for empty strings but dropped those same values from `distinct_count`, so a categorical column that mixes blanks with real values reported a cardinality one lower than reality.

This makes the blank string a single distinct value, so `distinct_count` stays consistent with `blank_count`. For the issue's example (`id,v` with rows `1,` and `2,A`) column `v` now reports `distinct_count = 2`.

## Changes

The blank branch in `columnProfiler.add` now records the empty string in the distinct set. The partition property test allows `distinct_count` to reach `non_empty + 1` when a blank is present.

## Tests

Unit: a new `columnStats` case for `["", "A", ""]` and an updated mixed-values case in `shell/profile_test.go`.
E2E: `spec/profile_spec.sh` asserts the contract in both JSON (`distinct_count: 2`) and `--profile-format text` (`blanks=1 distinct=2`).

Closes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `--profile` now treats blank strings as a distinct value, so blank counts and distinct counts stay aligned.
  * Profile results now report blanks more consistently in both JSON and text output.

* **Tests**
  * Updated and added test coverage for profiles containing blank-string values.
  * Adjusted expectations to reflect the new distinct-count behavior when blanks appear alongside real values.

* **Documentation**
  * Updated the changelog with the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->