### PR TITLE
fix: match null-like profile placeholders on the trimmed value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 * Profile Blank Distinct Count: `--profile` now counts the blank string as a real distinct value, so `distinct_count` stays consistent with `blank_count` instead of dropping blanks and understating cardinality for categorical columns that mix blanks with real values.
+* Profile Padded Null Placeholders: `--profile` now matches null-like placeholders such as `NULL` and `N/A` on the trimmed value, so a padded token like `" NULL "` raises both the null-placeholder warning and the whitespace warning instead of only the whitespace one.
 
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 

--- a/shell/profile.go
+++ b/shell/profile.go
@@ -207,7 +207,10 @@ func (c *columnProfiler) add(v string, isNull bool) {
 	} else {
 		c.nonNumeric++
 	}
-	if _, ok := nullLikeTokens[strings.ToLower(v)]; ok {
+	// Match null-like placeholders on the trimmed value so a padded token such as
+	// " NULL " is still flagged. The whitespace check below stays independent, so
+	// a padded placeholder raises both warnings.
+	if _, ok := nullLikeTokens[strings.ToLower(strings.TrimSpace(v))]; ok {
 		c.nullLike++
 	}
 	if v != strings.TrimSpace(v) {

--- a/shell/profile_test.go
+++ b/shell/profile_test.go
@@ -80,6 +80,32 @@ func TestProfileColumnStats(t *testing.T) {
 		}
 	})
 
+	t.Run("flags a padded null-like placeholder and its whitespace together", func(t *testing.T) {
+		t.Parallel()
+		// " NULL " and " N/A " are null-like once trimmed, and they also carry
+		// surrounding whitespace, so both warnings must fire.
+		got := columnStats("c", "TEXT", []string{" NULL ", " N/A "}, []bool{false, false})
+		if !hasWarningContaining(got.Warnings, "null placeholders") {
+			t.Errorf("expected a null-placeholder warning, got %v", got.Warnings)
+		}
+		if !hasWarningContaining(got.Warnings, "whitespace") {
+			t.Errorf("expected a whitespace warning, got %v", got.Warnings)
+		}
+	})
+
+	t.Run("padded ordinary value warns only about whitespace", func(t *testing.T) {
+		t.Parallel()
+		// " hello " is padded but not null-like, so only the whitespace warning
+		// fires; trimming must not turn ordinary values into null placeholders.
+		got := columnStats("c", "TEXT", []string{" hello "}, []bool{false})
+		if hasWarningContaining(got.Warnings, "null placeholders") {
+			t.Errorf("did not expect a null-placeholder warning, got %v", got.Warnings)
+		}
+		if !hasWarningContaining(got.Warnings, "whitespace") {
+			t.Errorf("expected a whitespace warning, got %v", got.Warnings)
+		}
+	})
+
 	t.Run("clean numeric column has no warnings", func(t *testing.T) {
 		t.Parallel()
 		got := columnStats("c", "INTEGER", []string{"1", "2", "3"}, []bool{false, false, false})

--- a/spec/profile_spec.sh
+++ b/spec/profile_spec.sh
@@ -71,4 +71,20 @@ Describe 'sqly --profile workflow'
     The status should be success
     The output should include 'blanks=1 distinct=2'
   End
+
+  It 'flags a padded null-like placeholder and its whitespace together'
+    printf 'v\n" NULL "\n' > "$WORKDIR/nullspace.csv"
+    When run sqly --profile "$WORKDIR/nullspace.csv"
+    The status should be success
+    The output should include 'null placeholders'
+    The output should include 'leading or trailing whitespace'
+  End
+
+  It 'warns only about whitespace for a padded ordinary value'
+    printf 'v\n" hello "\n' > "$WORKDIR/padded.csv"
+    When run sqly --profile "$WORKDIR/padded.csv"
+    The status should be success
+    The output should not include 'null placeholders'
+    The output should include 'leading or trailing whitespace'
+  End
 End


### PR DESCRIPTION
## Summary

`--profile` matched null-like placeholders such as `NULL` and `N/A` against the raw cell, so a padded token like `" NULL "` was reported only as having surrounding whitespace and missed the null-placeholder warning.

This trims the value before matching the placeholder set. The whitespace check stays independent, so a padded placeholder now raises both warnings, while a padded ordinary value such as `" hello "` still raises only the whitespace warning.

## Tests

Unit: `shell/profile_test.go` gains a `" NULL "`/`" N/A "` case asserting both warnings, plus a `" hello "` control asserting only whitespace.
E2E: `spec/profile_spec.sh` asserts both warnings for `" NULL "` and only whitespace for `" hello "`.

Closes #677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `--profile` now correctly treats padded null-like values such as `" NULL "` and `" n/a "` as null placeholders.
  * These values now trigger both the null-placeholder warning and the whitespace warning, instead of only the whitespace warning.
  * Padded regular values continue to trigger only the whitespace warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->