### PR TITLE
fix: share one numeric contract between --profile and table-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 * Profile Blank Distinct Count: `--profile` now counts the blank string as a real distinct value, so `distinct_count` stays consistent with `blank_count` instead of dropping blanks and understating cardinality for categorical columns that mix blanks with real values.
 * Profile Padded Null Placeholders: `--profile` now matches null-like placeholders such as `NULL` and `N/A` on the trimmed value, so a padded token like `" NULL "` raises both the null-placeholder warning and the whitespace warning instead of only the whitespace one.
+* Consistent Numeric Contract: `--profile` and table-mode right alignment now share one numeric predicate, so a comma-formatted value like `"1,000"` is classified as numeric by both. Profiling previously reported `numeric_count = 0` for a column that table output right-aligned as numbers.
 
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"strings"
 
@@ -25,21 +26,43 @@ func getColumnData(records []Record, columnIndex int) []string {
 	return columnData
 }
 
-// isAllNumeric checks if all values in a column look like numbers
+// IsNumericValue reports whether s is what a human would call a number. It
+// strips comma thousands separators ("1,000") and surrounding whitespace, then
+// requires a finite decimal. It rejects the Go-specific float spellings
+// ParseFloat also accepts but data rarely means as numbers: hexadecimal floats
+// ("0x1p4"), underscore digit separators ("1_000"), and the Infinity/NaN words.
+//
+// This is the single numeric contract shared by data profiling and table-mode
+// right alignment, so the same cell is classified the same way in both. Why
+// expose it from the model layer: presentation and profiling both depend on the
+// model, so a model-level predicate keeps the two surfaces in agreement without
+// duplicating the rules.
+func IsNumericValue(s string) bool {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, ",", "")
+	if strings.ContainsAny(s, "xXpP_") {
+		return false
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return false
+	}
+	return !math.IsInf(f, 0) && !math.IsNaN(f)
+}
+
+// isAllNumeric checks if all values in a column look like numbers, skipping
+// blank cells. It uses IsNumericValue so column alignment follows the same
+// numeric contract as data profiling.
 func isAllNumeric(values []string) bool {
 	if len(values) == 0 {
 		return false
 	}
 
 	for _, v := range values {
-		v = strings.TrimSpace(v)
-		if v == "" {
+		if strings.TrimSpace(v) == "" {
 			continue
 		}
-		// Remove commas for number parsing (e.g., "1,000" -> "1000")
-		v = strings.ReplaceAll(v, ",", "")
-		// Try to parse as float
-		if _, err := strconv.ParseFloat(v, 64); err != nil {
+		if !IsNumericValue(v) {
 			return false
 		}
 	}

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -864,6 +864,24 @@ func TestIsAllNumeric(t *testing.T) {
 	}
 }
 
+func TestIsNumericValue(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"1": true, "-2.5": true, "1e3": true, "0": true,
+		// Comma thousands separators and surrounding whitespace are stripped, so
+		// the contract matches table-mode alignment.
+		"1,000": true, "2,500.50": true, " 123 ": true,
+		"abc": false, "": false, "NaN": false, "Inf": false, "1e400": false,
+		// Go-specific float spellings are not treated as data numbers.
+		"0x1p4": false, "1_000": false,
+	}
+	for in, want := range cases {
+		if got := IsNumericValue(in); got != want {
+			t.Errorf("IsNumericValue(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
 // TestTablePrintEscaping covers the output-format bugs: CSV/TSV stdout must
 // stay valid when values contain the delimiter, quotes, or newlines; LTSV must
 // reject values it cannot represent losslessly; JSON/NDJSON must reject

--- a/shell/profile.go
+++ b/shell/profile.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/nao1215/sqly/config"
@@ -202,7 +200,7 @@ func (c *columnProfiler) add(v string, isNull bool) {
 		return
 	}
 	c.distinct[v] = struct{}{}
-	if isNumericValue(v) {
+	if model.IsNumericValue(v) {
 		c.numeric++
 	} else {
 		c.nonNumeric++
@@ -240,22 +238,6 @@ func (c *columnProfiler) result() profileColumn {
 		pc.Warnings = append(pc.Warnings, fmt.Sprintf("%d value(s) have leading or trailing whitespace", c.spacecnt))
 	}
 	return pc
-}
-
-// isNumericValue reports whether s is a finite decimal number. It rejects the
-// Go-specific float spellings ParseFloat also accepts but data rarely means as
-// numbers: hexadecimal floats ("0x1p4"), underscore digit separators
-// ("1_000"), and the Infinity/NaN words. This keeps the profile's numeric count
-// aligned with what a human would call a number.
-func isNumericValue(s string) bool {
-	if strings.ContainsAny(s, "xXpP_") {
-		return false
-	}
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return false
-	}
-	return !math.IsInf(f, 0) && !math.IsNaN(f)
 }
 
 // renderProfileText renders a human-readable summary of a profile report.

--- a/shell/profile_test.go
+++ b/shell/profile_test.go
@@ -113,6 +113,19 @@ func TestProfileColumnStats(t *testing.T) {
 			t.Errorf("expected no warnings, got %v", got.Warnings)
 		}
 	})
+
+	t.Run("counts comma-formatted numerals as numeric like table-mode does", func(t *testing.T) {
+		t.Parallel()
+		// "1,000" and "2,500" are numeric to table-mode alignment, so profiling
+		// must agree and count them as numeric instead of reporting numeric=0.
+		got := columnStats("amount", "TEXT", []string{"1,000", "2,500"}, []bool{false, false})
+		if got.NumericCount != 2 {
+			t.Errorf("numeric_count = %d, want 2", got.NumericCount)
+		}
+		if hasWarningContaining(got.Warnings, "mixed numeric") {
+			t.Errorf("comma numerals should not be a mixed-type column, got %v", got.Warnings)
+		}
+	})
 }
 
 func hasWarningContaining(warnings []string, sub string) bool {
@@ -122,21 +135,6 @@ func hasWarningContaining(warnings []string, sub string) bool {
 		}
 	}
 	return false
-}
-
-func TestIsNumericValue(t *testing.T) {
-	t.Parallel()
-	cases := map[string]bool{
-		"1": true, "-2.5": true, "1e3": true, "0": true,
-		"abc": false, "": false, "NaN": false, "Inf": false, "1e400": false, "1,000": false,
-		// Go-specific float spellings are not treated as data numbers.
-		"0x1p4": false, "1_000": false,
-	}
-	for in, want := range cases {
-		if got := isNumericValue(in); got != want {
-			t.Errorf("isNumericValue(%q) = %v, want %v", in, got, want)
-		}
-	}
 }
 
 // runProfileJSON builds a shell from args, runs it, and decodes the JSON report.

--- a/spec/profile_spec.sh
+++ b/spec/profile_spec.sh
@@ -87,4 +87,20 @@ Describe 'sqly --profile workflow'
     The output should not include 'null placeholders'
     The output should include 'leading or trailing whitespace'
   End
+
+  It 'counts comma-formatted numerals as numeric, matching table-mode'
+    printf 'amount\n"1,000"\n"2,500"\n' > "$WORKDIR/commas.csv"
+    When run sqly --profile "$WORKDIR/commas.csv"
+    The status should be success
+    The output should include '"numeric_count": 2'
+    The output should not include 'mixed numeric'
+  End
+
+  It 'right-aligns the same comma-formatted column in table-mode'
+    printf 'amount\n"1,000"\n"2,500"\n' > "$WORKDIR/commas.csv"
+    When run sqly --sql 'SELECT * FROM commas' "$WORKDIR/commas.csv"
+    The status should be success
+    # Right alignment pads the value with leading spaces inside the cell.
+    The output should include '|  1,000 |'
+  End
 End


### PR DESCRIPTION
## Summary

`--profile` used a numeric check that rejected comma thousands separators, while table-mode right alignment stripped commas first. The same column could be reported as non-numeric by profiling yet right-aligned as numeric in query output. For the issue's example, `--profile` reported `numeric_count = 0` for a column of `"1,000"`/`"2,500"` that table output right-aligned as numbers.

## Changes

`model.IsNumericValue` is now the single numeric predicate both surfaces share. It strips comma separators and surrounding whitespace, then requires a finite decimal, still rejecting hex floats, underscore separators, and Inf/NaN. `isAllNumeric` (table alignment) and the column profiler both call it, so a value like `"1,000"` is classified the same way everywhere. The duplicated `isNumericValue` in the shell package is removed.

## Tests

Unit: `domain/model/table_test.go` gains `TestIsNumericValue` (comma and whitespace cases true, Go-specific spellings false); `shell/profile_test.go` asserts a comma column reports `numeric_count = 2` with no mixed-type warning.
E2E: `spec/profile_spec.sh` asserts profile reports `numeric_count: 2` and table-mode right-aligns the same comma column.

Closes #678