### PR TITLE
fix: resolve --compare-key column case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Profile Blank Distinct Count: `--profile` now counts the blank string as a real distinct value, so `distinct_count` stays consistent with `blank_count` instead of dropping blanks and understating cardinality for categorical columns that mix blanks with real values.
 * Profile Padded Null Placeholders: `--profile` now matches null-like placeholders such as `NULL` and `N/A` on the trimmed value, so a padded token like `" NULL "` raises both the null-placeholder warning and the whitespace warning instead of only the whitespace one.
 * Consistent Numeric Contract: `--profile` and table-mode right alignment now share one numeric predicate, so a comma-formatted value like `"1,000"` is classified as numeric by both. Profiling previously reported `numeric_count = 0` for a column that table output right-aligned as numbers.
+* Case-Insensitive Compare Key: `--compare-key` now resolves the key column case-insensitively, so `--compare-key ID` matches a column imported as `id`, following SQLite identifier semantics instead of requiring an exact case match.
 
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 

--- a/shell/compare.go
+++ b/shell/compare.go
@@ -368,10 +368,13 @@ func diffKeyedRows(key string, leftByKey, rightByKey map[string]compareRow) *com
 	return rows
 }
 
-// indexOfColumn returns the position of name in header, or -1.
+// indexOfColumn returns the position of name in header, or -1. The match is
+// case-insensitive so --compare-key follows SQLite identifier semantics, where
+// "ID" resolves the same column as "id". SQLite forbids two columns that differ
+// only by case, so the case-insensitive match stays unambiguous.
 func indexOfColumn(header model.Header, name string) int {
 	for i, h := range header {
-		if h == name {
+		if strings.EqualFold(h, name) {
 			return i
 		}
 	}

--- a/shell/compare_test.go
+++ b/shell/compare_test.go
@@ -121,6 +121,19 @@ func TestCompareKeyedRows(t *testing.T) {
 		}
 	})
 
+	t.Run("resolves the key column case-insensitively", func(t *testing.T) {
+		t.Parallel()
+		// Header is "id" but the user passed "ID". SQLite identifier matching is
+		// case-insensitive, so the key must resolve the same column as "id".
+		rows, err := compareKeyedRows("l", "r", left, right, "ID")
+		if err != nil {
+			t.Fatalf("uppercase key should resolve column id: %v", err)
+		}
+		if len(rows.Added) != 1 || len(rows.Removed) != 1 || len(rows.Modified) != 1 {
+			t.Errorf("case-insensitive key produced a different diff: %+v", rows)
+		}
+	})
+
 	t.Run("a duplicate key value is rejected as ambiguous", func(t *testing.T) {
 		t.Parallel()
 		dup := model.NewTable("d", header, []model.Record{

--- a/spec/compare_spec.sh
+++ b/spec/compare_spec.sh
@@ -38,6 +38,16 @@ Describe 'sqly --compare workflow'
     The output should include '1 added, 1 removed, 1 modified'
   End
 
+  It 'resolves an uppercase --compare-key against a lowercase column'
+    # Header column is "id"; the uppercase spelling must resolve the same column
+    # because SQLite identifier matching is case-insensitive.
+    When run sqly --compare --compare-key ID "$WORKDIR/rev1.csv" "$WORKDIR/rev2.csv"
+    The status should be success
+    The output should include '"key": "ID"'
+    The output should include '"4"'
+    The output should include '"3"'
+  End
+
   It 'rejects a missing key column'
     When run sqly --compare --compare-key nope "$WORKDIR/rev1.csv" "$WORKDIR/rev2.csv"
     The status should be failure


### PR DESCRIPTION
## Summary

`--compare-key` required an exact case match against the imported column name, so `--compare-key ID` failed against a column imported as `id` with `compare key "ID" not found in table a`, even though SQLite identifier matching is case-insensitive.

## Changes

`indexOfColumn` now matches the key column with case folding, so `--compare-key ID` resolves the same column as `--compare-key id`. SQLite forbids two columns that differ only by case, so the match stays unambiguous.

## Tests

Unit: `shell/compare_test.go` asserts an uppercase `ID` key produces the same diff as `id`, keeping the missing-column rejection.
E2E: `spec/compare_spec.sh` asserts the uppercase key spelling succeeds and the missing-key negative control still fails.

Closes #679