### PR TITLE
fix: resolve --compare-tables names case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Profile Padded Null Placeholders: `--profile` now matches null-like placeholders such as `NULL` and `N/A` on the trimmed value, so a padded token like `" NULL "` raises both the null-placeholder warning and the whitespace warning instead of only the whitespace one.
 * Consistent Numeric Contract: `--profile` and table-mode right alignment now share one numeric predicate, so a comma-formatted value like `"1,000"` is classified as numeric by both. Profiling previously reported `numeric_count = 0` for a column that table output right-aligned as numbers.
 * Case-Insensitive Compare Key: `--compare-key` now resolves the key column case-insensitively, so `--compare-key ID` matches a column imported as `id`, following SQLite identifier semantics instead of requiring an exact case match.
+* Case-Insensitive Compare Tables: `--compare-tables` now resolves table names case-insensitively, so `--compare-tables "USER,IDENTIFIER"` matches the tables imported as `user` and `identifier`. The report shows the canonical stored names.
 
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 

--- a/shell/compare.go
+++ b/shell/compare.go
@@ -160,13 +160,15 @@ func (s *Shell) resolveCompareTables(ctx context.Context) (string, string, error
 		if left == "" || right == "" {
 			return "", "", fmt.Errorf("--compare-tables must name exactly two tables as \"left,right\", got %q", spec)
 		}
-		if !s.objectExists(ctx, left) {
+		leftName, ok := s.resolveTableNameCI(ctx, left)
+		if !ok {
 			return "", "", fmt.Errorf("compare table %q not found", left)
 		}
-		if !s.objectExists(ctx, right) {
+		rightName, ok := s.resolveTableNameCI(ctx, right)
+		if !ok {
 			return "", "", fmt.Errorf("compare table %q not found", right)
 		}
-		return left, right, nil
+		return leftName, rightName, nil
 	}
 
 	tables, err := s.usecases.metadata.TablesName(ctx)
@@ -189,6 +191,27 @@ func (s *Shell) resolveCompareTables(ctx context.Context) (string, string, error
 		return "", "", fmt.Errorf("--compare needs exactly two tables but found %d (%s); name the pair with --compare-tables \"left,right\"",
 			len(names), strings.Join(names, ", "))
 	}
+}
+
+// resolveTableNameCI resolves a user-supplied table name to the actual stored
+// name case-insensitively, so --compare-tables follows SQLite identifier
+// semantics where "USER" names the table imported as "user". It returns the
+// canonical name and true on a match, prefers the temp schema over main, and
+// returns false when no table or view matches. Returning the stored case keeps
+// the comparison report's left/right labels consistent with .tables output.
+func (s *Shell) resolveTableNameCI(ctx context.Context, name string) (string, bool) {
+	literal := "'" + strings.ReplaceAll(name, "'", "''") + "'"
+	res, err := s.usecases.query.Query(ctx,
+		"SELECT name FROM sqlite_temp_master WHERE name = "+literal+" COLLATE NOCASE AND type IN ('table', 'view') "+
+			"UNION ALL SELECT name FROM sqlite_master WHERE name = "+literal+" COLLATE NOCASE AND type IN ('table', 'view')")
+	if err != nil {
+		return "", false
+	}
+	records := res.Records()
+	if len(records) == 0 || len(records[0]) == 0 {
+		return "", false
+	}
+	return records[0][0], true
 }
 
 // buildCompareReport assembles the comparison of two existing tables.

--- a/shell/compare_test.go
+++ b/shell/compare_test.go
@@ -169,6 +169,26 @@ func TestResolveCompareTables_PreservesImportOrder(t *testing.T) {
 	}
 }
 
+func TestRunCompare_CaseInsensitiveTableNames(t *testing.T) {
+	// --compare-tables "USER,IDENTIFIER" must resolve the same pair as the
+	// lowercase spelling, following SQLite identifier semantics, and the report
+	// should show the canonical stored table names.
+	dir := t.TempDir()
+	user := filepath.Join(dir, "user.csv")
+	identifier := filepath.Join(dir, "identifier.csv")
+	if err := os.WriteFile(user, []byte("id,name\n1,Alice\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(identifier, []byte("id,name\n1,Alice\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := runCompareJSON(t, []string{"sqly", "--compare", "--compare-tables", "USER,IDENTIFIER", user, identifier})
+	if report.Left != "user" || report.Right != "identifier" {
+		t.Errorf("left,right = %q,%q, want user,identifier (uppercase names resolved to canonical case)", report.Left, report.Right)
+	}
+}
+
 func TestRunCompare_PreservesCLIInputOrder(t *testing.T) {
 	// End-to-end: passing zebra.csv before ant.csv must report zebra as the left
 	// side even though "ant" sorts first, so the left/right direction follows the

--- a/spec/compare_spec.sh
+++ b/spec/compare_spec.sh
@@ -54,6 +54,22 @@ Describe 'sqly --compare workflow'
     The stderr should include 'compare key'
   End
 
+  It 'resolves uppercase --compare-tables against lowercase table names'
+    # Tables import as "user" and "identifier"; the uppercase pair must resolve
+    # the same tables because SQLite identifier matching is case-insensitive.
+    cp "$PROJECT_ROOT/testdata/user.csv" "$WORKDIR/user.csv"
+    cp "$PROJECT_ROOT/testdata/identifier.csv" "$WORKDIR/identifier.csv"
+    When run sqly --compare --compare-format text --compare-tables "USER,IDENTIFIER" "$WORKDIR/user.csv" "$WORKDIR/identifier.csv"
+    The status should be success
+    The line 1 should equal 'compare user -> identifier'
+  End
+
+  It 'rejects a genuinely missing --compare-tables name'
+    When run sqly --compare --compare-tables "nope,rev2" "$WORKDIR/rev1.csv" "$WORKDIR/rev2.csv"
+    The status should be failure
+    The stderr should include 'compare table'
+  End
+
   It 'rejects an ambiguous single-table compare'
     When run sqly --compare "$WORKDIR/rev1.csv"
     The status should be failure


### PR DESCRIPTION
## Summary

`--compare-tables` validated table names with an exact case-sensitive lookup, so `--compare-tables "USER,IDENTIFIER"` failed with `compare table "USER" not found` against tables imported as `user` and `identifier`, even though SQLite identifier matching is case-insensitive.

## Changes

Each name is now resolved through a case-insensitive lookup (`COLLATE NOCASE`) that returns the canonical stored name, so the uppercase pair resolves the same tables and the report's left/right labels stay consistent with `.tables`.

## Tests

Integration: `shell/compare_test.go` asserts `--compare-tables "USER,IDENTIFIER"` resolves to canonical `user`/`identifier`.
E2E: `spec/compare_spec.sh` asserts the uppercase pair succeeds and a genuinely missing name still fails.

Closes #680