### PR TITLE
fix: match .schema stored object name case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Consistent Numeric Contract: `--profile` and table-mode right alignment now share one numeric predicate, so a comma-formatted value like `"1,000"` is classified as numeric by both. Profiling previously reported `numeric_count = 0` for a column that table output right-aligned as numbers.
 * Case-Insensitive Compare Key: `--compare-key` now resolves the key column case-insensitively, so `--compare-key ID` matches a column imported as `id`, following SQLite identifier semantics instead of requiring an exact case match.
 * Case-Insensitive Compare Tables: `--compare-tables` now resolves table names case-insensitively, so `--compare-tables "USER,IDENTIFIER"` matches the tables imported as `user` and `identifier`. The report shows the canonical stored names.
+* Case-Insensitive Schema Lookup: `.schema` now matches the stored object name case-insensitively, so `.schema V` returns the stored `CREATE VIEW v ...` (and a constrained table's real DDL) instead of falling back to a synthesized `CREATE TABLE`, following SQLite identifier semantics.
 
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 

--- a/shell/schema.go
+++ b/shell/schema.go
@@ -109,8 +109,12 @@ func (s *Shell) storedCreateSQL(ctx context.Context, schema, object string) (sql
 	// String literal: escape single quotes to query the master tables safely.
 	literal := "'" + strings.ReplaceAll(object, "'", "''") + "'"
 	for _, src := range sources {
+		// Match the name case-insensitively (COLLATE NOCASE) so the stored DDL
+		// still wins when the user spells the object in a different case, for
+		// example ".schema V" for a view created as "v". SQLite forbids two
+		// objects whose names differ only by case, so the match is unambiguous.
 		res, err := s.usecases.query.Query(ctx,
-			"SELECT sql FROM "+src.table+" WHERE name = "+literal+" AND type IN ('table', 'view') AND sql IS NOT NULL")
+			"SELECT sql FROM "+src.table+" WHERE name = "+literal+" COLLATE NOCASE AND type IN ('table', 'view') AND sql IS NOT NULL")
 		if err != nil {
 			return "", false, err
 		}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2476,6 +2476,45 @@ func TestShellExec_SchemaAndDescribe(t *testing.T) {
 		}
 	})
 
+	t.Run(".schema V returns the stored CREATE VIEW for view v, case-insensitively", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+
+		if _, err := getExecStdOutput(t, shell.exec, "CREATE VIEW v AS SELECT 1 AS x"); err != nil {
+			t.Fatalf("create view: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".schema V")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := string(got)
+		if !strings.Contains(out, "CREATE VIEW") {
+			t.Fatalf(".schema V should return the stored CREATE VIEW, got: %q", out)
+		}
+		if strings.Contains(out, "CREATE TABLE") {
+			t.Fatalf(".schema V fell back to a synthesized CREATE TABLE: %q", out)
+		}
+	})
+
+	t.Run(".schema CT returns the stored DDL with constraints for table ct, case-insensitively", func(t *testing.T) {
+		shell, cleanup := newImportedShell(t)
+		defer cleanup()
+
+		if _, err := getExecStdOutput(t, shell.exec, "CREATE TABLE ct (id INTEGER PRIMARY KEY, code TEXT UNIQUE)"); err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+		got, err := getExecStdOutput(t, shell.exec, ".schema CT")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := string(got)
+		// The synthesized fallback cannot reconstruct a UNIQUE constraint, so its
+		// presence proves the stored DDL was returned rather than a reconstruction.
+		if !strings.Contains(out, "UNIQUE") {
+			t.Fatalf(".schema CT lost the stored UNIQUE constraint, got: %q", out)
+		}
+	})
+
 	t.Run(".describe sample lists columns in definition order with types", func(t *testing.T) {
 		shell, cleanup := newImportedShell(t)
 		defer cleanup()

--- a/spec/schema_spec.sh
+++ b/spec/schema_spec.sh
@@ -41,6 +41,29 @@ Describe 'sqly schema inspection'
       The stderr should include 'Change output mode'
     End
 
+    It 'returns the stored CREATE VIEW for a differently cased view name'
+      # The view is created as "v"; ".schema V" must still return the stored
+      # CREATE VIEW instead of synthesizing a CREATE TABLE.
+      Data
+        #|CREATE VIEW v AS SELECT 1 AS x;
+        #|.schema V
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'CREATE VIEW'
+      The output should not include 'CREATE TABLE'
+    End
+
+    It 'resolves a table name case-insensitively'
+      Data
+        #|.schema USER
+      End
+      When run sqly testdata/user.csv
+      The status should be success
+      The output should include 'CREATE TABLE'
+      The output should include 'user_name'
+    End
+
     It 'errors on a missing table'
       Data
         #|.schema no_such_table


### PR DESCRIPTION
## Summary

`.schema` prefers the SQL stored in `sqlite_master`, but the lookup was exact-case. Asking for an object in a different case (`.schema V` for a view created as `v`) missed the stored DDL and fell back to a synthesized `CREATE TABLE`, losing the `CREATE VIEW` form and any `UNIQUE`/`CHECK` constraints the reconstruction cannot rebuild.

## Changes

`storedCreateSQL` now matches the object name with `COLLATE NOCASE`, so the stored definition still wins regardless of case, for tables, views, and temp objects. SQLite forbids two objects whose names differ only by case, so the match stays unambiguous.

## Tests

Unit: `shell/shell_test.go` asserts `.schema V` returns `CREATE VIEW` (not a synthesized `CREATE TABLE`) and `.schema CT` keeps a stored `UNIQUE` constraint.
E2E: `spec/schema_spec.sh` asserts `.schema V` prints `CREATE VIEW` in a batch run and a table resolves case-insensitively.

Closes #681