### PR TITLE
fix: never import sqly cache artifacts from an imported directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Case-Insensitive Compare Key: `--compare-key` now resolves the key column case-insensitively, so `--compare-key ID` matches a column imported as `id`, following SQLite identifier semantics instead of requiring an exact case match.
 * Case-Insensitive Compare Tables: `--compare-tables` now resolves table names case-insensitively, so `--compare-tables "USER,IDENTIFIER"` matches the tables imported as `user` and `identifier`. The report shows the canonical stored names.
 * Case-Insensitive Schema Lookup: `.schema` now matches the stored object name case-insensitively, so `.schema V` returns the stored `CREATE VIEW v ...` (and a constrained table's real DDL) instead of falling back to a synthesized `CREATE TABLE`, following SQLite identifier semantics.
+* Cache Artifacts Not Imported: when `--cache` points inside a directory that is also imported, sqly's own cache database and manifest sidecar are no longer treated as dataset inputs. The manifest is not imported as a stray table, and the second run is a warm cache hit instead of a cold re-import.
 
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 

--- a/shell/cache.go
+++ b/shell/cache.go
@@ -47,6 +47,32 @@ func cacheManifestPath(cachePath string) string {
 	return cachePath + ".manifest.json"
 }
 
+// isCacheArtifact reports whether path is one of sqly's own cache files (the
+// cache database or its manifest sidecar). When --cache points inside a directory
+// that is also imported, these files must never be treated as dataset inputs:
+// importing the manifest would create a stray table, and counting either file in
+// the cache signature would invalidate the cache on every run. Paths are compared
+// after resolving to absolute form so a relative input still matches.
+func (s *Shell) isCacheArtifact(path string) bool {
+	if s.argument.CachePath == "" {
+		return false
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	for _, artifact := range []string{s.argument.CachePath, cacheManifestPath(s.argument.CachePath)} {
+		artifactAbs, err := filepath.Abs(artifact)
+		if err != nil {
+			artifactAbs = artifact
+		}
+		if abs == artifactAbs {
+			return true
+		}
+	}
+	return false
+}
+
 // cacheEnabled reports whether this run should use the import cache. Caching is
 // opt-in (--cache), needs file inputs, and is skipped for a --stdin dataset
 // (ephemeral, no stable signature) and for ACH/Fedwire inputs (their write-back
@@ -107,7 +133,7 @@ func (s *Shell) loadOrImport(ctx context.Context, paths []string) error {
 		s.clearCache(cachePath)
 	}
 
-	sigs, sigErr := collectCacheSignatures(paths)
+	sigs, sigErr := collectCacheSignatures(paths, s.isCacheArtifact)
 	if sigErr == nil {
 		if s.tryWarmCache(ctx, cachePath, sigs) {
 			return nil
@@ -210,11 +236,16 @@ func (s *Shell) clearCache(cachePath string) {
 }
 
 // collectCacheSignatures returns the invalidation signature for every input file,
-// expanding directories recursively. The result is sorted by path so the
-// signature is order-independent.
-func collectCacheSignatures(paths []string) ([]cacheSource, error) {
+// expanding directories recursively. Files for which skip returns true are
+// excluded, so sqly's own cache artifacts inside an imported directory do not
+// enter the signature. The result is sorted by path so the signature is
+// order-independent.
+func collectCacheSignatures(paths []string, skip func(string) bool) ([]cacheSource, error) {
 	var sigs []cacheSource
 	add := func(p string) error {
+		if skip != nil && skip(p) {
+			return nil
+		}
 		abs, err := filepath.Abs(p)
 		if err != nil {
 			abs = p

--- a/shell/cache_test.go
+++ b/shell/cache_test.go
@@ -54,6 +54,36 @@ func TestCache_WarmHitReusesSnapshot(t *testing.T) {
 	}
 }
 
+// TestCache_InsideImportedDirectory verifies that when the cache path lives
+// inside the directory being imported, sqly's own cache artifacts (the database
+// and its manifest sidecar) are not treated as dataset inputs: the second run is
+// still a warm hit and no manifest-derived table appears.
+func TestCache_InsideImportedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "data.csv")
+	cache := filepath.Join(dir, "snap.cache") // cache sidecar lands inside the imported dir
+	if err := os.WriteFile(src, []byte("id,name\n1,Alice\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cold run imports the directory and writes the cache and manifest inside it.
+	runQuery(t, []string{"sqly", "--cache", cache, "--sql", "SELECT COUNT(*) AS n FROM data", dir})
+
+	// The second run over the same directory must reuse the cache, and the cache
+	// manifest must not have been imported as an extra table.
+	var tables string
+	warmErr := captureStderr(t, func() {
+		tables = runQuery(t, []string{"sqly", "--cache", cache, "--sql",
+			"SELECT group_concat(name, ',') AS t FROM sqlite_master WHERE type='table' ORDER BY name", dir})
+	})
+	if !strings.Contains(warmErr, "cache: reused") {
+		t.Errorf("second run should reuse the cache, stderr = %q", warmErr)
+	}
+	if strings.Contains(tables, "manifest") || strings.Contains(tables, "snap") {
+		t.Errorf("cache artifact was imported as a table: %q", tables)
+	}
+}
+
 // TestCache_InvalidatesWhenContentChangesSameSizeAndMTime reproduces issue #592:
 // a source rewritten with different but same-length content and its original
 // mtime restored must invalidate the cache, not reuse stale data.
@@ -208,7 +238,7 @@ func TestCollectCacheSignatures_DirectoryAndChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sigs, err := collectCacheSignatures([]string{dir})
+	sigs, err := collectCacheSignatures([]string{dir}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +250,7 @@ func TestCollectCacheSignatures_DirectoryAndChange(t *testing.T) {
 		t.Errorf("signatures not sorted by path: %+v", sigs)
 	}
 
-	again, err := collectCacheSignatures([]string{dir})
+	again, err := collectCacheSignatures([]string{dir}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/shell/import.go
+++ b/shell/import.go
@@ -394,7 +394,10 @@ func (s *Shell) supportedFilesInDir(dir string) ([]string, error) {
 		if d.IsDir() {
 			return nil
 		}
-		if s.usecases.importer.IsSupportedFile(path) {
+		// Skip sqly's own cache artifacts so a --cache file that lives inside the
+		// imported directory is never loaded as a dataset (for example its manifest
+		// JSON becoming a stray table).
+		if s.usecases.importer.IsSupportedFile(path) && !s.isCacheArtifact(path) {
 			files = append(files, path)
 		}
 		return nil

--- a/spec/cache_spec.sh
+++ b/spec/cache_spec.sh
@@ -27,6 +27,18 @@ Describe 'sqly --cache import cache'
     The stderr should include 'cache: reused'
   End
 
+  It 'reuses the cache when it lives inside the imported directory and ignores its manifest'
+    # The cache database and manifest sidecar land inside the directory that is
+    # imported. They must not be loaded as datasets, so the second run is a warm
+    # hit and no manifest-derived table appears.
+    When run sh -c "'$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' '$WORKDIR' >/dev/null && '$SQLY_BIN' --cache '$CACHE' --sql \"SELECT group_concat(name, ',') AS t FROM sqlite_master WHERE type='table'\" '$WORKDIR'"
+    The status should be success
+    The stderr should include 'cache: reused'
+    The output should include 'data'
+    The output should not include 'manifest'
+    The output should not include 'snap'
+  End
+
   It 'invalidates the cache when the source changes'
     When run sh -c "'$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' '$WORKDIR/data.csv' >/dev/null && printf 'id,name\n1,Alice\n2,Bob\n3,Carol\n4,Dave\n' > '$WORKDIR/data.csv' && '$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' '$WORKDIR/data.csv'"
     The status should be success


### PR DESCRIPTION
## Summary

When `--cache PATH` pointed inside a directory that was also imported, the generated `*.manifest.json` sidecar was a plain JSON file, so the next run loaded it as a dataset and created a stray table. Both the cache database and its manifest also entered the directory cache signature, so the second run never matched and cold-imported every time.

## Changes

A new `isCacheArtifact` helper identifies sqly's own cache database and manifest sidecar (compared as absolute paths). Directory import enumeration (`supportedFilesInDir`) and cache-signature collection (`collectCacheSignatures`) both skip those files. The manifest is no longer imported, and a cache that lives inside the imported directory now produces a warm hit on the second run.

## Tests

Integration: `shell/cache_test.go` asserts the second run reuses the cache and no manifest-derived table appears.
E2E: `spec/cache_spec.sh` asserts `cache: reused` on the warm run with the cache inside the imported directory and no manifest table.

Closes #682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache reuse when the cache location is inside an imported directory, so reruns now use the warm cache instead of re-importing.
  * Prevented cache metadata files from appearing as extra tables in imports and query results.
  * Improved directory imports to ignore sqly’s own cache artifacts, reducing unexpected dataset entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->