### PR TITLE
fix: scope directory cache signature to importable files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Case-Insensitive Compare Tables: `--compare-tables` now resolves table names case-insensitively, so `--compare-tables "USER,IDENTIFIER"` matches the tables imported as `user` and `identifier`. The report shows the canonical stored names.
 * Case-Insensitive Schema Lookup: `.schema` now matches the stored object name case-insensitively, so `.schema V` returns the stored `CREATE VIEW v ...` (and a constrained table's real DDL) instead of falling back to a synthesized `CREATE TABLE`, following SQLite identifier semantics.
 * Cache Artifacts Not Imported: when `--cache` points inside a directory that is also imported, sqly's own cache database and manifest sidecar are no longer treated as dataset inputs. The manifest is not imported as a stray table, and the second run is a warm cache hit instead of a cold re-import.
+* Cache Signature Scope: the directory cache signature now includes only files sqly would import, so changing an unsupported sibling file such as a `.txt` note no longer invalidates the cache. Changing a supported input still invalidates it.
 
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 

--- a/shell/cache.go
+++ b/shell/cache.go
@@ -133,7 +133,7 @@ func (s *Shell) loadOrImport(ctx context.Context, paths []string) error {
 		s.clearCache(cachePath)
 	}
 
-	sigs, sigErr := collectCacheSignatures(paths, s.isCacheArtifact)
+	sigs, sigErr := collectCacheSignatures(paths, s.isCacheArtifact, s.usecases.importer.IsSupportedFile)
 	if sigErr == nil {
 		if s.tryWarmCache(ctx, cachePath, sigs) {
 			return nil
@@ -238,9 +238,12 @@ func (s *Shell) clearCache(cachePath string) {
 // collectCacheSignatures returns the invalidation signature for every input file,
 // expanding directories recursively. Files for which skip returns true are
 // excluded, so sqly's own cache artifacts inside an imported directory do not
-// enter the signature. The result is sorted by path so the signature is
-// order-independent.
-func collectCacheSignatures(paths []string, skip func(string) bool) ([]cacheSource, error) {
+// enter the signature. Inside a directory, only files for which dirSupported
+// returns true are included, so a change to an unsupported sibling (a README, a
+// .txt note) does not invalidate the cache when the imported dataset is
+// unchanged; a directly named file is always included. The result is sorted by
+// path so the signature is order-independent.
+func collectCacheSignatures(paths []string, skip func(string) bool, dirSupported func(string) bool) ([]cacheSource, error) {
 	var sigs []cacheSource
 	add := func(p string) error {
 		if skip != nil && skip(p) {
@@ -278,6 +281,9 @@ func collectCacheSignatures(paths []string, skip func(string) bool) ([]cacheSour
 			}
 			if d.IsDir() {
 				return nil
+			}
+			if dirSupported != nil && !dirSupported(path) {
+				return nil // an unsupported sibling is not part of the cache key
 			}
 			return add(path)
 		})

--- a/shell/cache_test.go
+++ b/shell/cache_test.go
@@ -84,6 +84,49 @@ func TestCache_InsideImportedDirectory(t *testing.T) {
 	}
 }
 
+// TestCache_IgnoresUnsupportedSiblingChange verifies that only files sqly would
+// import participate in the directory cache key: mutating an unsupported sibling
+// (here a .txt note) keeps the cache warm, while mutating the imported file
+// invalidates it.
+func TestCache_IgnoresUnsupportedSiblingChange(t *testing.T) {
+	dir := t.TempDir()
+	data := filepath.Join(dir, "data.csv")
+	ignore := filepath.Join(dir, "ignore.txt")
+	cache := filepath.Join(t.TempDir(), "snap.cache") // cache lives outside the imported dir
+	if err := os.WriteFile(data, []byte("id,name\n1,Alice\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ignore, []byte("note\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cold run warms the cache.
+	runQuery(t, []string{"sqly", "--cache", cache, "--sql", "SELECT COUNT(*) AS n FROM data", dir})
+
+	// Changing only the unsupported sibling leaves the imported dataset unchanged,
+	// so the second run must still be a warm hit.
+	if err := os.WriteFile(ignore, []byte("changed note\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	warmErr := captureStderr(t, func() {
+		runQuery(t, []string{"sqly", "--cache", cache, "--sql", "SELECT COUNT(*) AS n FROM data", dir})
+	})
+	if !strings.Contains(warmErr, "cache: reused") {
+		t.Errorf("changing an unsupported sibling must not invalidate the cache, stderr = %q", warmErr)
+	}
+
+	// Control: changing the supported file must invalidate the cache.
+	if err := os.WriteFile(data, []byte("id,name\n1,Alice\n2,Bob\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	coldErr := captureStderr(t, func() {
+		runQuery(t, []string{"sqly", "--cache", cache, "--sql", "SELECT COUNT(*) AS n FROM data", dir})
+	})
+	if strings.Contains(coldErr, "cache: reused") {
+		t.Errorf("changing the supported file must invalidate the cache, stderr = %q", coldErr)
+	}
+}
+
 // TestCache_InvalidatesWhenContentChangesSameSizeAndMTime reproduces issue #592:
 // a source rewritten with different but same-length content and its original
 // mtime restored must invalidate the cache, not reuse stale data.
@@ -238,7 +281,7 @@ func TestCollectCacheSignatures_DirectoryAndChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sigs, err := collectCacheSignatures([]string{dir}, nil)
+	sigs, err := collectCacheSignatures([]string{dir}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +293,7 @@ func TestCollectCacheSignatures_DirectoryAndChange(t *testing.T) {
 		t.Errorf("signatures not sorted by path: %+v", sigs)
 	}
 
-	again, err := collectCacheSignatures([]string{dir}, nil)
+	again, err := collectCacheSignatures([]string{dir}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/spec/cache_spec.sh
+++ b/spec/cache_spec.sh
@@ -39,6 +39,22 @@ Describe 'sqly --cache import cache'
     The output should not include 'snap'
   End
 
+  It 'keeps the cache warm when only an unsupported sibling file changes'
+    # data.csv is imported; ignore.txt is not. Mutating only ignore.txt leaves
+    # the imported dataset unchanged, so the second run must still be a warm hit.
+    When run sh -c "indir=\$(mktemp -d); printf 'id,name\n1,Alice\n' > \"\$indir/data.csv\"; printf 'note\n' > \"\$indir/ignore.txt\"; '$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' \"\$indir\" >/dev/null; printf 'changed\n' > \"\$indir/ignore.txt\"; '$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' \"\$indir\"; rm -rf \"\$indir\""
+    The status should be success
+    The output should include '1'
+    The stderr should include 'cache: reused'
+  End
+
+  It 'still invalidates the cache when the supported file changes'
+    When run sh -c "indir=\$(mktemp -d); printf 'id,name\n1,Alice\n' > \"\$indir/data.csv\"; printf 'note\n' > \"\$indir/ignore.txt\"; '$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' \"\$indir\" >/dev/null; printf 'id,name\n1,Alice\n2,Bob\n' > \"\$indir/data.csv\"; '$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' \"\$indir\"; rm -rf \"\$indir\""
+    The status should be success
+    The output should include '2'
+    The stderr should not include 'cache: reused'
+  End
+
   It 'invalidates the cache when the source changes'
     When run sh -c "'$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' '$WORKDIR/data.csv' >/dev/null && printf 'id,name\n1,Alice\n2,Bob\n3,Carol\n4,Dave\n' > '$WORKDIR/data.csv' && '$SQLY_BIN' --cache '$CACHE' --sql 'SELECT COUNT(*) AS n FROM data' '$WORKDIR/data.csv'"
     The status should be success


### PR DESCRIPTION
## Summary

The directory cache signature hashed every file under the tree, so changing an unsupported sibling (a README, a `.txt` note) invalidated the cache even though the imported dataset had not changed, forcing a cold re-import.

## Changes

`collectCacheSignatures` now takes the importer's `IsSupportedFile` predicate and skips unsupported files during the directory walk, so only files sqly would import participate in the cache key. A directly named file is still always included, and changing a supported input still invalidates the cache.

## Tests

Integration: `shell/cache_test.go` warms the cache, mutates only an unsupported sibling and asserts a warm hit, then mutates the supported file as a control and asserts invalidation.
E2E: `spec/cache_spec.sh` covers both the unsupported-sibling and supported-file cases.

Closes #683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reuse for imported directories so changes to unrelated, unsupported sibling files no longer invalidate the cache.
  * Supported file changes still correctly refresh the cache, preserving accurate results.
* **Tests**
  * Added coverage for cache behavior when unsupported sibling files change versus when supported data files change.
  * Updated cache-related checks to reflect the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->