### PR TITLE
docs: align .save and .dump helper docs with current behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Cache Artifacts Not Imported: when `--cache` points inside a directory that is also imported, sqly's own cache database and manifest sidecar are no longer treated as dataset inputs. The manifest is not imported as a stray table, and the second run is a warm cache hit instead of a cold re-import.
 * Cache Signature Scope: the directory cache signature now includes only files sqly would import, so changing an unsupported sibling file such as a `.txt` note no longer invalidates the cache. Changing a supported input still invalidates it.
 
+### Documentation
+* Helper Command Docs: the `.dump` and `.save` reference now matches current behavior. `.dump` in table mode infers the output format from the destination extension (TSV for `out.tsv`), falling back to CSV only for an unknown extension; `.save` documents native ACH/Fedwire whole-set write-back. A docs-sync test guards these descriptions.
+
 ## [v0.25.0](https://github.com/nao1215/sqly/compare/v0.24.0...v0.25.0) (2026-06-28)
 
 ### New Features

--- a/doc/pages/markdown/sqly_helper_command.md
+++ b/doc/pages/markdown/sqly_helper_command.md
@@ -50,10 +50,15 @@ sqly:~/github/github.com/nao1215/sqly(table)$ .dump
 [Usage]
   .dump TABLE_NAME FILE_PATH
 [Note]
-  Output will be in the format specified in .mode.
-  table mode is not available in .dump. If mode is table, .dump output CSV file.
+  The format comes from .mode. When .mode is table, it is inferred from the
+  file extension (for example .tsv, .parquet), falling back to CSV (written to
+  the path as given) only when the extension is unknown.
+  Compression is inferred from the path (.gz, .xz, .zst, .z, .snappy, .s2, .lz4).
+  A .mode that disagrees with the extension is rejected instead of normalizing.
   ACH/Fedwire tables can be dumped to csv/tsv/xlsx, but not back to .ach/.fed format.
 ```
+
+For example, `.dump user out.tsv` in `table` mode writes a TSV file.
 
 ### exit command
 
@@ -135,6 +140,27 @@ sqly:~/github/github.com/nao1215/sqly(table)$ .mode
 sqly:~/github/github.com/nao1215/sqly(table)$ .pwd
 /home/nao
 ```
+
+### save command
+
+Write the current tables back to files. `.save DIRECTORY` writes each table into
+that directory and leaves the original sources untouched; `.save --force`
+overwrites each table's source file in place.
+
+```shell
+sqly:~/data(table)$ .save
+[Usage]
+  .save DIRECTORY   write each table into DIRECTORY (originals untouched)
+  .save --force     overwrite each table's source file in place
+[Note]
+  csv/tsv/ltsv/parquet sources are written; compression is preserved.
+  A whole ACH or Fedwire set is reconstructed back into a single .ach/.fed
+  file when all of that source's tables are still present.
+```
+
+An ACH or Fedwire file imports as a multi-table set. `.save` rewrites the whole
+set back to its native `.ach`/`.fed` file only when all of that source's tables
+are present; a partial set is rejected before any file is written.
 
 ### tables command
 

--- a/docs_sync_test.go
+++ b/docs_sync_test.go
@@ -44,6 +44,69 @@ func TestDocsMakeCommandsExist(t *testing.T) {
 	}
 }
 
+// TestHelperCommandDocsMatchBehavior is a docs-sync guardrail for the
+// helper-command reference: the .save and .dump descriptions must match the
+// shell's current behavior. The .dump format in table mode is inferred from the
+// destination extension (not always CSV), and .save can reconstruct a whole
+// ACH/Fedwire set back to its native file. A stale description here misleads
+// users about what these commands write.
+func TestHelperCommandDocsMatchBehavior(t *testing.T) {
+	t.Parallel()
+
+	const path = "doc/pages/markdown/sqly_helper_command.md"
+	dump, err := docSection(path, "dump command")
+	if err != nil {
+		t.Fatalf("read .dump section: %v", err)
+	}
+	if strings.Contains(dump, "If mode is table, .dump output CSV file") {
+		t.Errorf(".dump docs still claim table mode always writes CSV; it infers the format from the destination extension")
+	}
+	if !strings.Contains(dump, "extension") {
+		t.Errorf(".dump docs should describe extension-driven format inference in table mode")
+	}
+
+	save, err := docSection(path, "save command")
+	if err != nil {
+		t.Fatalf("read .save section: %v", err)
+	}
+	if !strings.Contains(save, "ACH") || !strings.Contains(save, "Fedwire") {
+		t.Errorf(".save docs should mention ACH/Fedwire whole-set write-back")
+	}
+}
+
+// docSection returns the body of the Markdown section introduced by the heading
+// "### <title>", up to the next "### " heading or end of file. It lets a
+// docs-sync test assert on one command's description without matching text from
+// a neighboring section.
+func docSection(path, title string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	heading := "### " + title
+	var b strings.Builder
+	inSection := false
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "### ") {
+			if inSection {
+				break // reached the next section
+			}
+			inSection = strings.TrimSpace(line) == heading
+			continue
+		}
+		if inSection {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	if !inSection && b.Len() == 0 {
+		return "", os.ErrNotExist
+	}
+	return b.String(), scanner.Err()
+}
+
 // makefileTargets returns the set of target names declared in the Makefile (a
 // line of the form "name:" at column 0). Pattern rules and variables are ignored.
 func makefileTargets(path string) (map[string]bool, error) {

--- a/shell/save.go
+++ b/shell/save.go
@@ -28,7 +28,9 @@ func (c CommandList) saveCommand(ctx context.Context, s *Shell, argv []string) e
 			"  .save DIRECTORY   write each table into DIRECTORY (originals untouched)\n" +
 			"  .save --force     overwrite each table's source file in place\n" +
 			"[Note]\n" +
-			"  Only csv/tsv/ltsv/parquet sources are written; compression is preserved")
+			"  csv/tsv/ltsv/parquet sources are written; compression is preserved.\n" +
+			"  A whole ACH/Fedwire set is reconstructed back into a single .ach/.fed file\n" +
+			"  when all of that source's tables are still present")
 	}
 	// Reject an empty destination so `.save ""` is not treated as an in-place
 	// save, which would bypass the --force safeguard.

--- a/spec/helpers_spec.sh
+++ b/spec/helpers_spec.sh
@@ -113,4 +113,18 @@ Describe 'sqly shell helper commands'
       The stderr should include 'ndjson'
     End
   End
+
+  Describe '.dump'
+    It 'infers TSV from the .tsv extension in table mode, not CSV'
+      # In table mode .dump picks the format from the destination extension, so
+      # ".dump user out.tsv" writes a tab-separated file rather than falling back
+      # to CSV. The header line must be tab-separated, not comma-separated.
+      When run sh -c "out=\$(mktemp -d)/out.tsv; printf '.dump user %s\n' \"\$out\" | '$SQLY_BIN' '$PROJECT_ROOT/testdata/user.csv' >/dev/null; head -n1 \"\$out\""
+      The status should be success
+      The output should include "$(printf 'user_name\tidentifier')"
+      The output should not include 'user_name,identifier'
+      # The dump progress line confirms the inferred format on stderr.
+      The stderr should include 'mode=tsv'
+    End
+  End
 End


### PR DESCRIPTION
## Summary

The helper-command reference described stale behavior in two places:

- `.dump` in table mode was documented as always writing CSV, but it infers the output format from the destination extension and only falls back to CSV for an unknown extension.
- `.save` was documented as writing only csv/tsv/ltsv/parquet sources, but it also reconstructs a whole ACH/Fedwire set back to its native `.ach`/`.fed` file.

## Changes

Updated the `.dump` and `.save` sections of the helper-command docs and the `.save` in-shell help note to match current behavior. Added a docs-sync guard test that fails if either description regresses, an e2e asserting `.dump user out.tsv` writes TSV (not CSV) in table mode, and a docs example for ACH/Fedwire `.save` write-back. The write-back contract is already exercised by the ACH/Fedwire round-trip Go tests.

Closes #684