### PR TITLE
feat: allow --sql-file to export a single result set via --output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### New Features
+* SQL File Output: `--sql-file` can now export to `--output` when the script produces exactly one result set, so a saved SQL script works in the same automation pipelines as `--sql`. Setup statements may run first, the single result is written to the file with stdout left clean, and a script that yields no result set or more than one is rejected with a clear error.
+
 ### Bug Fixes
 * Profile Blank Distinct Count: `--profile` now counts the blank string as a real distinct value, so `distinct_count` stays consistent with `blank_count` instead of dropping blanks and understating cardinality for categorical columns that mix blanks with real values.
 * Profile Padded Null Placeholders: `--profile` now matches null-like placeholders such as `NULL` and `N/A` on the trimmed value, so a padded token like `" NULL "` raises both the null-placeholder warning and the whitespace warning instead of only the whitespace one.

--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ JOIN identifier i ON s.identifier = i.id
 ORDER BY s.identifier;
 ```
 
+`--sql-file` can also export with `--output` when the script produces exactly one result set, so a saved script works in the same pipelines as `--sql`. Setup statements may run first; the single result is written to the file. A script that yields no result set or more than one is rejected.
+
+```shell
+$ sqly --sql-file report.sql --output out.csv data.csv
+```
+
 ## Inspect tables: --inspect
 
 `--inspect` imports the inputs, prints a JSON report of every table (name, source, columns, row count, sample rows), and exits without the shell. It is the non-interactive equivalent of `.tables` + `.schema` + `.describe`, useful for scripts and LLMs. Import progress goes to stderr, so stdout is JSON only. `--inspect-sample N` sets the sample size (default 5; `0` for schema only).

--- a/config/argument.go
+++ b/config/argument.go
@@ -211,7 +211,7 @@ func NewArg(args []string) (*Arg, error) {
 	stdinName := flag.String("stdin-name", "stdin", "table name for the --stdin dataset")
 	query := flag.StringP("sql", "s", "", "sql query you want to execute")
 	sqlFile := flag.StringP("sql-file", "f", "", "path to a file with SQL to execute (multiline; cannot be used with --sql)")
-	output := flag.StringP("output", "o", "", "destination path for SQL results specified in --sql option")
+	output := flag.StringP("output", "o", "", "destination path for the result of --sql or a single-result --sql-file script")
 	flag.BoolVarP(&arg.InspectFlag, "inspect", "i", false, "print a JSON report of imported tables (schema, row counts, sample rows) and exit")
 	inspectSample := flag.Int("inspect-sample", defaultInspectSample, "rows to include per table in --inspect (0 for schema only)")
 	flag.BoolVar(&arg.CompareFlag, "compare", false, "compare two imported tables (schema, row count, and keyed rows) and print a report, then exit")

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -37,7 +37,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
       --stdin-name string       table name for the --stdin dataset (default "stdin")
   -s, --sql string              sql query you want to execute
   -f, --sql-file string         path to a file with SQL to execute (multiline; cannot be used with --sql)
-  -o, --output string           destination path for SQL results specified in --sql option
+  -o, --output string           destination path for the result of --sql or a single-result --sql-file script
   -i, --inspect                 print a JSON report of imported tables (schema, row counts, sample rows) and exit
       --inspect-sample int      rows to include per table in --inspect (0 for schema only) (default 5)
       --compare                 compare two imported tables (schema, row count, and keyed rows) and print a report, then exit

--- a/doc/pages/markdown/how_to_use.md
+++ b/doc/pages/markdown/how_to_use.md
@@ -46,7 +46,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
       --stdin-name string   table name for the --stdin dataset (default "stdin")
   -s, --sql string      sql query you want to execute
   -f, --sql-file string   path to a file with SQL to execute (multiline; cannot be used with --sql)
-  -o, --output string   destination path for SQL results specified in --sql option
+  -o, --output string   destination path for the result of --sql or a single-result --sql-file script
   -i, --inspect         print a JSON report of imported tables (schema, row counts, sample rows) and exit
       --inspect-sample int  rows to include per table in --inspect (0 for schema only) (default 5)
       --cache string        opt-in import cache: reuse a SQLite snapshot of the imported tables for unchanged inputs (path to the cache file)
@@ -272,7 +272,7 @@ $ sqly --sql "SELECT * FROM user" --csv testdata/user.csv > test.csv
 
 #### For windows user
 
-The sqly can save SQL execution results to the file using the --output option. The --output option specifies the destination path for SQL results specified in the --sql option.
+The sqly can save SQL execution results to the file using the --output option. The --output option specifies the destination path for the result of --sql (or a single-result --sql-file script).
 
 ```shell
 $ sqly --sql "SELECT * FROM user" --output=test.csv testdata/user.csv 
@@ -288,3 +288,11 @@ $ sqly --sql "SELECT * FROM user" --output result.ndjson.gz testdata/user.csv
 ```
 
 Text and JSON formats (csv, tsv, ltsv, json, ndjson, markdown) support the compression wrappers `.gz`, `.xz`, `.zst`, `.z`, `.snappy`, `.s2`, and `.lz4`. An explicit mode flag that disagrees with the path extension is rejected instead of writing a surprising format. Bzip2 output and compression on Parquet or Excel are rejected with a clear error.
+
+### Export a --sql-file script result with --output
+
+`--output` also works with `--sql-file` when the script produces exactly one result set. Setup statements (DDL/DML) may run first; the single result set is written to the output file and stdout stays clean. A script that produces no result set, or more than one, is rejected with a clear error.
+
+```shell
+$ sqly --sql-file report.sql --output out.csv data.csv
+```

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -996,8 +996,14 @@ func (s *Shell) exec(ctx context.Context, request string) error {
 // Rowset results are captured rather than printed, so a successful run leaves
 // stdout clean and writes only to the output file.
 func (s *Shell) runSQLFileToOutput(ctx context.Context, script string) error {
+	// Start from a clean slate and clear on the way out, so a reused Shell never
+	// counts rowsets captured by an earlier run.
+	s.capturedRowsets = nil
 	s.collectingOutput = true
-	defer func() { s.collectingOutput = false }()
+	defer func() {
+		s.collectingOutput = false
+		s.capturedRowsets = nil
+	}()
 
 	if _, err := s.runBatchReader(ctx, strings.NewReader(script)); err != nil {
 		return err

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -107,6 +107,15 @@ type Shell struct {
 	// to stdout only after write-back succeeds, so a run that fails during
 	// write-back leaves stdout free of success counts.
 	pendingAffected []string
+	// collectingOutput routes rowset results into capturedRowsets instead of
+	// printing them, so --sql-file combined with --output can export the single
+	// result set the script produces. No-rowset statements stay silent in this
+	// mode, keeping stdout clean for the exported-data run.
+	collectingOutput bool
+	// capturedRowsets holds the rowset results produced while collectingOutput is
+	// set. The one-result-set contract is enforced after the script finishes: zero
+	// or more than one captured rowset is an error.
+	capturedRowsets []*model.Table
 	// completionTableKey fingerprints the table-name set the cached table/column
 	// completion suggestions were built from. completionTableCols holds those
 	// suggestions. Together they let interactive completion reuse table and column
@@ -206,11 +215,11 @@ func (s *Shell) Run(ctx context.Context) error {
 		return err
 	}
 
-	// --output is only honored by the --sql path (a single result written to one
-	// file). Without --sql (no query, batch stdin, --sql-file, or interactive)
-	// the flag was silently ignored, so reject it instead of looking successful.
-	if s.argument.Output.FilePath != "" && s.argument.Query == "" {
-		return errors.New("--output requires --sql")
+	// --output is honored by --sql (a single result) and --sql-file (the script's
+	// one result set). Without either (batch stdin or interactive) the flag was
+	// silently ignored, so reject it instead of looking successful.
+	if s.argument.Output.FilePath != "" && s.argument.Query == "" && s.argument.SQLFilePath == "" {
+		return errors.New("--output requires --sql or --sql-file")
 	}
 
 	// Reject an --output destination that is an existing directory before import,
@@ -310,6 +319,11 @@ func (s *Shell) Run(ctx context.Context) error {
 	if s.argument.SQLFilePath != "" {
 		if err := s.preflightSave(ctx, sqlScript); err != nil {
 			return err
+		}
+		// With --output, export the script's single result set to the file instead
+		// of printing each statement's result, mirroring how --sql exports.
+		if s.argument.Output.FilePath != "" {
+			return s.runSQLFileToOutput(ctx, sqlScript)
 		}
 		ranAny, err := s.runBatchReader(ctx, strings.NewReader(sqlScript))
 		if err != nil {
@@ -975,6 +989,33 @@ func (s *Shell) exec(ctx context.Context, request string) error {
 	return nil
 }
 
+// runSQLFileToOutput runs a --sql-file script and exports its single result set
+// to --output. The script may run any number of setup statements (DDL/DML), but
+// exactly one must produce a result set: zero or more than one is rejected with a
+// clear error, matching the one-file/one-result contract of --sql --output.
+// Rowset results are captured rather than printed, so a successful run leaves
+// stdout clean and writes only to the output file.
+func (s *Shell) runSQLFileToOutput(ctx context.Context, script string) error {
+	s.collectingOutput = true
+	defer func() { s.collectingOutput = false }()
+
+	if _, err := s.runBatchReader(ctx, strings.NewReader(script)); err != nil {
+		return err
+	}
+
+	switch len(s.capturedRowsets) {
+	case 0:
+		return errors.New("--output requires the --sql-file script to produce one result set, but it produced none; add a statement that returns rows (for example a SELECT)")
+	case 1:
+		if err := s.outputToFile(s.capturedRowsets[0]); err != nil {
+			return err
+		}
+		return s.finishNonInteractive(ctx)
+	default:
+		return fmt.Errorf("--output supports a single result set, but the --sql-file script produced %d; reduce it to one SELECT or run without --output", len(s.capturedRowsets))
+	}
+}
+
 // execSQL execute SQL query.
 func (s *Shell) execSQL(ctx context.Context, req string) error {
 	req = strings.TrimRight(req, ";")
@@ -995,6 +1036,13 @@ func (s *Shell) execSQL(ctx context.Context, req string) error {
 		}
 	}
 	if table == nil {
+		// While collecting a --sql-file script's output, a no-rowset statement
+		// (DDL, DML, PRAGMA) is a legitimate setup step. Stay silent so stdout
+		// holds nothing but the exported data; the one-result-set contract is
+		// checked after the whole script runs.
+		if s.collectingOutput {
+			return nil
+		}
 		// --output is only meaningful for a statement that produces a rowset. An
 		// INSERT/UPDATE/DELETE without RETURNING produces only an affected-row
 		// count, so reject --output instead of silently ignoring it.
@@ -1017,6 +1065,13 @@ func (s *Shell) execSQL(ctx context.Context, req string) error {
 	// typed mode (--json-typed/--ndjson-typed or .mode json-typed/ndjson-typed).
 	// The flag is ignored by every non-JSON format.
 	table.SetJSONTyped(s.state.mode.jsonTyped)
+
+	// While collecting a --sql-file script's output, capture each rowset instead
+	// of printing it. The script's single result set is exported after the run.
+	if s.collectingOutput {
+		s.capturedRowsets = append(s.capturedRowsets, table)
+		return nil
+	}
 
 	// use --sql option and user want to output table data to file.
 	if s.argument.NeedsOutputToFile() {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -3105,6 +3105,85 @@ func TestShellRun_SQLFileWithEmptyStdinIsAllowed(t *testing.T) {
 	}
 }
 
+func TestShellRun_SQLFileWithOutput(t *testing.T) {
+	writeScript := func(t *testing.T, dir, body string) string {
+		t.Helper()
+		p := filepath.Join(dir, "q.sql")
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Run("exports a single result set to the output file with clean stdout", func(t *testing.T) {
+		dir := t.TempDir()
+		sqlPath := writeScript(t, dir, "SELECT user_name FROM user ORDER BY identifier LIMIT 1;\n")
+		out := filepath.Join(dir, "out.csv")
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sql-file", sqlPath, "--output", out, filepath.Join("testdata", "user.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("")
+
+		stdout := captureStdout(t, func() {
+			if err := shell.Run(context.Background()); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+		})
+		if strings.TrimSpace(stdout) != "" {
+			t.Errorf("stdout should be empty for an exported run, got %q", stdout)
+		}
+		data, err := os.ReadFile(out) //nolint:gosec // test-controlled temp path
+		if err != nil {
+			t.Fatalf("read output file: %v", err)
+		}
+		if !strings.Contains(string(data), "user_name") {
+			t.Errorf("output file missing the result header: %q", data)
+		}
+	})
+
+	t.Run("rejects a script that produces no result set", func(t *testing.T) {
+		dir := t.TempDir()
+		sqlPath := writeScript(t, dir, "CREATE TEMP TABLE t AS SELECT 1 AS x;\n")
+		out := filepath.Join(dir, "out.csv")
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sql-file", sqlPath, "--output", out, filepath.Join("testdata", "user.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("")
+
+		err = shell.Run(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "result set") {
+			t.Fatalf("Run error = %v, want a no-result-set error", err)
+		}
+		if _, statErr := os.Stat(out); statErr == nil {
+			t.Errorf("output file should not be created when the script yields no result set")
+		}
+	})
+
+	t.Run("rejects a script that produces multiple result sets", func(t *testing.T) {
+		dir := t.TempDir()
+		sqlPath := writeScript(t, dir, "SELECT user_name FROM user LIMIT 1;\nSELECT identifier FROM user LIMIT 1;\n")
+		out := filepath.Join(dir, "out.csv")
+		shell, cleanup, err := newShell(t, []string{"sqly", "--sql-file", sqlPath, "--output", out, filepath.Join("testdata", "user.csv")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+		shell.isTTY = func() bool { return false }
+		shell.stdin = strings.NewReader("")
+
+		err = shell.Run(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "single result set") {
+			t.Fatalf("Run error = %v, want a single-result-set error", err)
+		}
+	})
+}
+
 func TestShellRun_StdinDatasetWithoutQueryFails(t *testing.T) {
 	// Regression for: a --stdin dataset run with no query must fail loudly
 	// instead of importing the data and discarding it.

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -37,7 +37,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
       --stdin-name string       table name for the --stdin dataset (default "stdin")
   -s, --sql string              sql query you want to execute
   -f, --sql-file string         path to a file with SQL to execute (multiline; cannot be used with --sql)
-  -o, --output string           destination path for SQL results specified in --sql option
+  -o, --output string           destination path for the result of --sql or a single-result --sql-file script
   -i, --inspect                 print a JSON report of imported tables (schema, row counts, sample rows) and exit
       --inspect-sample int      rows to include per table in --inspect (0 for schema only) (default 5)
       --compare                 compare two imported tables (schema, row count, and keyed rows) and print a report, then exit

--- a/spec/sqlfile_output_spec.sh
+++ b/spec/sqlfile_output_spec.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# --sql-file with --output (issue #685). A saved SQL script can export its single
+# result set to a file, the same way --sql can. A script that produces zero or
+# more than one result set is rejected with a clear error, and a successful
+# export keeps stdout clean (the data goes only to the file).
+
+Describe 'sqly --sql-file --output'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  setup() {
+    WORKDIR=$(mktemp -d)
+  }
+  cleanup() {
+    rm -rf "$WORKDIR"
+  }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'exports a single-SELECT script to the output file with clean stdout'
+    printf 'SELECT user_name FROM user ORDER BY identifier LIMIT 1;\n' > "$WORKDIR/q.sql"
+    When run sqly --sql-file "$WORKDIR/q.sql" --output "$WORKDIR/out.csv" testdata/user.csv
+    The status should be success
+    # The data is written to the file, not stdout.
+    The output should equal ''
+    The stderr should include 'Output sql result'
+    The path "$WORKDIR/out.csv" should be exist
+    The contents of file "$WORKDIR/out.csv" should include 'user_name'
+  End
+
+  It 'exports a single result set even when the script first runs DDL/DML'
+    printf 'CREATE TEMP TABLE picked AS SELECT user_name FROM user;\nSELECT * FROM picked ORDER BY user_name LIMIT 1;\n' > "$WORKDIR/q.sql"
+    When run sqly --sql-file "$WORKDIR/q.sql" --output "$WORKDIR/out.csv" testdata/user.csv
+    The status should be success
+    The output should equal ''
+    The stderr should include 'Output sql result'
+    The path "$WORKDIR/out.csv" should be exist
+  End
+
+  It 'rejects a script that produces no result set'
+    printf 'CREATE TEMP TABLE t AS SELECT 1 AS x;\n' > "$WORKDIR/q.sql"
+    When run sqly --sql-file "$WORKDIR/q.sql" --output "$WORKDIR/out.csv" testdata/user.csv
+    The status should be failure
+    The stderr should include 'result set'
+    The path "$WORKDIR/out.csv" should not be exist
+  End
+
+  It 'rejects a script that produces multiple result sets'
+    printf 'SELECT user_name FROM user LIMIT 1;\nSELECT identifier FROM user LIMIT 1;\n' > "$WORKDIR/q.sql"
+    When run sqly --sql-file "$WORKDIR/q.sql" --output "$WORKDIR/out.csv" testdata/user.csv
+    The status should be failure
+    The stderr should include 'single result set'
+    The path "$WORKDIR/out.csv" should not be exist
+  End
+End


### PR DESCRIPTION
## Summary

`--output` was rejected unless `--sql` was used, so a saved script run with `--sql-file` could not export its result to a file the way `--sql` can, leaving a gap for script-based automation.

`--sql-file` now accepts `--output` when the script produces exactly one result set. Setup statements (DDL/DML) may run first; their no-rowset results stay silent so stdout is clean, and the single result set is written to the output file. A script that produces no result set, or more than one, is rejected with a clear error.

## Changes

- The upfront `--output requires --sql` check now also accepts `--sql-file`.
- A new `runSQLFileToOutput` runs the script while capturing rowsets, then enforces the one-result-set contract and exports via the existing `outputToFile`.
- `--output` flag help updated; golden files regenerated.
- README, GitHub Pages how-to, and CHANGELOG document the behavior.

## Tests

Unit: `shell/shell_test.go` covers the single-result success (clean stdout, file written), the no-result-set rejection, and the multiple-result-set rejection.
E2E: `spec/sqlfile_output_spec.sh` covers a single-SELECT export, a DDL-then-SELECT export, and both failure cases.

Closes #685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `--sql-file` can now export results to `--output` when the script returns exactly one result set.
  * Scripts may include setup statements first; only the final single result set is written out.
* **Bug Fixes**
  * `--output` now rejects scripts with no result set or more than one result set, with clearer errors.
  * Exported output stays out of standard output, keeping terminal output clean.
* **Documentation**
  * Updated CLI help, README, and user guides to describe the expanded `--output` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->