### PR TITLE
fix: preserve numeric-looking text in parquet export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * SQL File Output: `--sql-file` can now export to `--output` when the script produces exactly one result set, so a saved SQL script works in the same automation pipelines as `--sql`. Setup statements may run first, the single result is written to the file with stdout left clean, and a script that yields no result set or more than one is rejected with a clear error.
 
 ### Bug Fixes
+* Parquet Export Text Fidelity: parquet export now stages every column as TEXT, so numeric-looking text the session holds (leading-zero codes like `007`, decimal strings like `1.00`) survives the round-trip verbatim instead of being coerced to a number by the staging column's affinity.
 * Profile Blank Distinct Count: `--profile` now counts the blank string as a real distinct value, so `distinct_count` stays consistent with `blank_count` instead of dropping blanks and understating cardinality for categorical columns that mix blanks with real values.
 * Profile Padded Null Placeholders: `--profile` now matches null-like placeholders such as `NULL` and `N/A` on the trimmed value, so a padded token like `" NULL "` raises both the null-placeholder warning and the whitespace warning instead of only the whitespace one.
 * Consistent Numeric Contract: `--profile` and table-mode right alignment now share one numeric predicate, so a comma-formatted value like `"1,000"` is classified as numeric by both. Profiling previously reported `numeric_count = 0` for a column that table output right-aligned as numbers.

--- a/infrastructure/filesql/parquet.go
+++ b/infrastructure/filesql/parquet.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	libfilesql "github.com/nao1215/filesql"
 	"github.com/nao1215/sqly/domain/model"
@@ -47,7 +48,7 @@ func DumpTableToParquet(filePath string, table *model.Table) (err error) {
 	}()
 
 	ctx := context.Background()
-	if _, err = db.ExecContext(ctx, infra.GenerateCreateTableStatement(table)); err != nil {
+	if _, err = db.ExecContext(ctx, parquetStagingCreateTable(table)); err != nil {
 		return fmt.Errorf("create staging table: %w", err)
 	}
 	// Insert in a single transaction; one implicit transaction per row is slow
@@ -83,6 +84,27 @@ func DumpTableToParquet(filePath string, table *model.Table) (err error) {
 		return fmt.Errorf("write parquet to %q: %w", filePath, err)
 	}
 	return nil
+}
+
+// parquetStagingCreateTable builds the staging CREATE TABLE for a parquet export
+// with every column typed TEXT. The shared GenerateCreateTableStatement infers an
+// INTEGER column when all values parse as numbers, which makes SQLite's column
+// affinity rewrite numeric-looking text such as a leading-zero code ("007") or a
+// decimal string ("1.00") into a number before the parquet writer sees it.
+// Staging every column as TEXT keeps the original text verbatim through the
+// round-trip; re-import still types a canonical number when the reader asks for
+// typed output.
+func parquetStagingCreateTable(t *model.Table) string {
+	var b strings.Builder
+	b.WriteString("CREATE TABLE " + infra.Quote(t.Name()) + " (")
+	for i, col := range t.Header() {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(infra.Quote(col) + " TEXT")
+	}
+	b.WriteString(");")
+	return b.String()
 }
 
 // copyFile copies src to dst. A copy (not rename) is used because the temporary

--- a/infrastructure/filesql/parquet_test.go
+++ b/infrastructure/filesql/parquet_test.go
@@ -75,6 +75,69 @@ func TestDumpTableToParquet_RoundTrip(t *testing.T) {
 	if len(cols) != 2 || cols[0] != "id" || cols[1] != "name" {
 		t.Errorf("reimported columns = %v, want [id name]", cols)
 	}
+
+	// Cell fidelity: the reimported name column carries the same string values, not
+	// just the same row and column counts.
+	names := reimportStringColumn(t, out, "people", "name")
+	if len(names) != 3 || names[0] != "alice" || names[1] != "bob" || names[2] != "carol" {
+		t.Errorf("reimported names = %v, want [alice bob carol]", names)
+	}
+}
+
+// reimportStringColumn writes the parquet file back via filesql and returns the
+// named column's values as plain strings, so a test can assert exact cell
+// fidelity after a round-trip.
+func reimportStringColumn(t *testing.T, parquetPath, tableName, column string) []string {
+	t.Helper()
+	db, err := libfilesql.OpenContext(context.Background(), parquetPath)
+	if err != nil {
+		t.Fatalf("reimport parquet: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	rows, err := db.QueryContext(context.Background(), "SELECT "+column+" FROM "+tableName)
+	if err != nil {
+		t.Fatalf("select %s: %v", column, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan %s: %v", column, err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// TestDumpTableToParquet_PreservesNumericLookingText locks issue #687: numeric
+// looking text such as leading-zero codes ("007") and decimal strings ("1.00")
+// must survive a parquet round-trip verbatim instead of being coerced to a
+// number by the staging column's affinity.
+func TestDumpTableToParquet_PreservesNumericLookingText(t *testing.T) {
+	t.Parallel()
+
+	table := model.NewTable("codes", model.Header{"code", "amount"}, []model.Record{
+		{"007", "1.00"},
+		{"010", "2.50"},
+	})
+	out := filepath.Join(t.TempDir(), "codes.parquet")
+
+	if err := DumpTableToParquet(out, table); err != nil {
+		t.Fatalf("DumpTableToParquet: %v", err)
+	}
+
+	codes := reimportStringColumn(t, out, "codes", "code")
+	if len(codes) != 2 || codes[0] != "007" || codes[1] != "010" {
+		t.Errorf("code column = %v, want [007 010] (leading zeros preserved)", codes)
+	}
+	amounts := reimportStringColumn(t, out, "codes", "amount")
+	if len(amounts) != 2 || amounts[0] != "1.00" || amounts[1] != "2.50" {
+		t.Errorf("amount column = %v, want [1.00 2.50] (decimal text preserved)", amounts)
+	}
 }
 
 // TestDumpTableToParquet_EmptyResult covers the empty-result behavior: Parquet

--- a/spec/parquet_export_spec.sh
+++ b/spec/parquet_export_spec.sh
@@ -55,6 +55,22 @@ Describe 'sqly parquet export'
     End
   End
 
+  Describe 'numeric-looking text fidelity'
+    # The export staging no longer types a column as INTEGER from its payload, so
+    # numeric-looking text the session holds (here SQL string literals) survives
+    # the parquet round-trip verbatim instead of being coerced to a number.
+    It 'preserves leading-zero codes through a parquet round-trip'
+      out_dir=$(mktemp -d)
+      export out_dir
+      # Export the string literals to parquet, then re-import and read them back.
+      When run sh -c "'$SQLY_BIN' --parquet --output '$out_dir/codes.parquet' --sql \"SELECT '007' AS code, '00042' AS acct\" >/dev/null 2>&1; '$SQLY_BIN' --csv --sql 'SELECT code, acct FROM codes' '$out_dir/codes.parquet'"
+      The status should be success
+      The output should include '007'
+      The output should include '00042'
+      rm -rf "$out_dir"
+    End
+  End
+
   Describe 'empty result'
     It 'reports a clear error when exporting an empty result'
       out_dir=$(mktemp -d)


### PR DESCRIPTION
## Summary

Parquet export staged the table through a `CREATE TABLE` that inferred an `INTEGER` column whenever every value parsed as a number. SQLite's column affinity then rewrote numeric-looking text such as a leading-zero code (`007`) or a decimal string (`1.00`) into a number before the parquet writer saw it, so the exported file lost the original text form.

This stages every column as `TEXT` for the parquet export, so the strings the session holds are written verbatim. A canonical number is still typed on re-import when the reader asks for typed output.

## Scope note

The issue's CSV reproduction also loses leading zeros at filesql's CSV import step (a column of `007`/`010` is typed `INTEGER` on import, before any export). That import-time coercion is a separate filesql concern. This change fixes the export staging, which was the stated root cause: text the session actually holds (a `TEXT` column, a JSON value, a SQL string literal) now survives the export round-trip.

## Tests

Unit: `parquet_test.go` asserts `007`/`010`/`1.00`/`2.50` read back as exact strings after a round-trip, and the existing round-trip test now asserts cell values.
E2E: `spec/parquet_export_spec.sh` exports leading-zero codes and reads them back unchanged.

Closes #687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parquet export now preserves text values that look numeric, including leading zeros and decimal-like strings, so they round-trip without being changed.
  * Improved export/import fidelity checks to confirm exact string values are retained.
* **Tests**
  * Added coverage for numeric-looking text round-trips in Parquet export.
  * Expanded existing round-trip validation to verify cell-level string accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->