### PR TITLE
feat(shell): make interactive .help task-oriented and self-contained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### New Features
+* Task-Oriented Help: interactive `.help` now groups commands by purpose (Session, Navigate, Inspect, Import / Export) and shows a minimal usage suffix for each (`.import PATH...`, `.dump TABLE FILE`, `.save DIR`). The destructive in-place overwrite `.save --force` is listed on its own labeled line, distinct from the non-destructive exports. No commands were added.
 * SQL File Output: `--sql-file` can now export to `--output` when the script produces exactly one result set, so a saved SQL script works in the same automation pipelines as `--sql`. Setup statements may run first, the single result is written to the file with stdout left clean, and a script that yields no result set or more than one is rejected with a clear error.
 
 ### Bug Fixes

--- a/shell/help.go
+++ b/shell/help.go
@@ -8,14 +8,66 @@ import (
 	"github.com/nao1215/sqly/config"
 )
 
-// helpCommand print all sqly command and their description.
+// helpLine is one helper command's usage and what it does, as shown by .help.
+// usage carries the minimal argument shape (e.g. ".import PATH...") so the syntax
+// of path-taking and destructive commands is visible without leaving the shell.
+type helpLine struct {
+	usage string
+	desc  string
+}
+
+// helpGroup is a titled set of help lines, grouping commands by purpose so .help
+// reads as a task list rather than a flat alphabetical dump.
+type helpGroup struct {
+	title string
+	lines []helpLine
+}
+
+// helpGroups returns the grouped .help layout. The destructive in-place overwrite
+// is listed on its own line so it is visually distinct from the non-destructive
+// exports (.dump and .save DIR).
+func helpGroups() []helpGroup {
+	return []helpGroup{
+		{"Session", []helpLine{
+			{helpCommand, "show this help"},
+			{modeCommand + " MODE", "change output mode (table, csv, tsv, ltsv, json, ndjson, markdown, ...)"},
+			{clearCommand, "clear the terminal screen"},
+			{exitCommand, "exit sqly"},
+		}},
+		{"Navigate", []helpLine{
+			{cdCommand + " [DIR]", "change the working directory (no arg: home)"},
+			{pwdCommand, "print the working directory"},
+			{lsCommand + " [DIR]", "list directory contents"},
+		}},
+		{"Inspect", []helpLine{
+			{tablesCommand, "list imported tables"},
+			{schemaCommand + " TABLE", "print a table's CREATE statement"},
+			{describeCommand + " TABLE", "print a table's columns"},
+			{headerCommand + " TABLE", "print a table's header row"},
+		}},
+		{"Import / Export", []helpLine{
+			{importCommand + " PATH...", "load files or directories into the session"},
+			{dumpCommand + " TABLE FILE", "export a table to a file (format follows .mode; default csv)"},
+			{saveCommand + " DIR", "write changed tables into DIR (sources untouched)"},
+			{saveCommand + " --force", "overwrite each table's source file in place (destructive)"},
+		}},
+	}
+}
+
+// helpCommand prints the helper commands grouped by purpose, with a minimal usage
+// suffix for each so common tasks and risky operations are discoverable in-shell.
 func (c CommandList) helpCommand(_ context.Context, _ *Shell, argv []string) error {
 	if len(argv) > 0 {
 		return fmt.Errorf(".help takes no arguments, got %d", len(argv))
 	}
-	for _, cmdName := range c.sortCommandNameKey() {
-		fmt.Fprintf(config.Stdout, "%20s: %s\n",
-			color.CyanString(cmdName), c[cmdName].description)
+	fmt.Fprintln(config.Stdout, "sqly helper commands (run inside the shell; SQL needs no leading dot):")
+	for _, g := range helpGroups() {
+		fmt.Fprintf(config.Stdout, "\n%s\n", g.title)
+		for _, ln := range g.lines {
+			// Pad before coloring so the column stays aligned when color is disabled
+			// (tests, pipes); the trailing spaces sit inside the colored span.
+			fmt.Fprintf(config.Stdout, "  %s %s\n", color.CyanString("%-18s", ln.usage), ln.desc)
+		}
 	}
 	return nil
 }

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -403,6 +403,47 @@ func TestShellExec(t *testing.T) {
 		g.Assert(t, "help_command", got)
 	})
 
+	t.Run(".help is grouped, shows usage, and flags destructive save", func(t *testing.T) {
+		shell, cleanup, err := newShell(t, []string{"sqly"})
+		if err != nil {
+			t.Error(err)
+		}
+		defer cleanup()
+
+		got, err := getExecStdOutput(t, shell.exec, ".help")
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := string(got)
+
+		// Task-oriented groups, not a single flat list.
+		for _, group := range []string{"Session", "Navigate", "Inspect", "Import / Export"} {
+			if !strings.Contains(out, group) {
+				t.Errorf(".help output is missing the %q group:\n%s", group, out)
+			}
+		}
+		// Usage suffixes for path/argument-taking commands.
+		for _, usage := range []string{".import PATH", ".dump TABLE", ".save DIR", ".mode MODE"} {
+			if !strings.Contains(out, usage) {
+				t.Errorf(".help output is missing usage %q:\n%s", usage, out)
+			}
+		}
+		// Destructive overwrite is visually distinct and labeled.
+		if !strings.Contains(out, ".save --force") || !strings.Contains(out, "destructive") {
+			t.Errorf(".help output should flag .save --force as destructive:\n%s", out)
+		}
+		// Every command still appears, so .help stays a complete reference.
+		for _, name := range shell.commands.sortCommandNameKey() {
+			if !strings.Contains(out, name) {
+				t.Errorf(".help output is missing command %q:\n%s", name, out)
+			}
+		}
+		// Stays compact: comfortably within one screen.
+		if lines := strings.Count(out, "\n"); lines > 28 {
+			t.Errorf(".help output is too long (%d lines); keep it within one screen", lines)
+		}
+	})
+
 	t.Run("execute .import csv", func(t *testing.T) {
 		shell, cleanup, err := newShell(t, []string{"sqly"})
 		if err != nil {

--- a/shell/testdata/golden/help_command.golden
+++ b/shell/testdata/golden/help_command.golden
@@ -1,14 +1,24 @@
-                 .cd: change directory
-              .clear: clear terminal screen
-           .describe: print column information of a table
-               .dump: dump db table to file in a format according to output mode (default: csv)
-               .exit: exit sqly
-             .header: print table header
-               .help: print help message
-             .import: import file(s) and/or directory(ies)
-                 .ls: print directory contents
-               .mode: change output mode
-                .pwd: print current working directory
-               .save: write tables back to files: .save DIR (to a directory) or .save --force (overwrite sources)
-             .schema: print CREATE TABLE statement of a table
-             .tables: print tables
+sqly helper commands (run inside the shell; SQL needs no leading dot):
+
+Session
+  .help              show this help
+  .mode MODE         change output mode (table, csv, tsv, ltsv, json, ndjson, markdown, ...)
+  .clear             clear the terminal screen
+  .exit              exit sqly
+
+Navigate
+  .cd [DIR]          change the working directory (no arg: home)
+  .pwd               print the working directory
+  .ls [DIR]          list directory contents
+
+Inspect
+  .tables            list imported tables
+  .schema TABLE      print a table's CREATE statement
+  .describe TABLE    print a table's columns
+  .header TABLE      print a table's header row
+
+Import / Export
+  .import PATH...    load files or directories into the session
+  .dump TABLE FILE   export a table to a file (format follows .mode; default csv)
+  .save DIR          write changed tables into DIR (sources untouched)
+  .save --force      overwrite each table's source file in place (destructive)

--- a/spec/helpers_spec.sh
+++ b/spec/helpers_spec.sh
@@ -8,6 +8,22 @@
 Describe 'sqly shell helper commands'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
 
+  Describe '.help'
+    It 'groups commands, shows usage, and flags destructive save'
+      Data
+        #|.help
+      End
+      When run sqly
+      The status should be success
+      The output should include 'Import / Export'
+      The output should include '.import PATH'
+      The output should include '.dump TABLE FILE'
+      The output should include '.save DIR'
+      The output should include '.save --force'
+      The output should include 'destructive'
+    End
+  End
+
   Describe '.cd and .pwd'
     It 'changes directory with a relative path and reports it'
       Data


### PR DESCRIPTION
## Summary

Interactive `.help` was a flat alphabetical list of one-line descriptions, so users still had to guess the syntax of common commands or leave the shell to check the docs. This change makes `.help` task-oriented and self-contained while keeping it within one screen. No commands were added.

## Changes

- `shell/help.go`: `.help` now groups commands by purpose (Session, Navigate, Inspect, Import / Export) and prints a minimal usage suffix for each (for example `.import PATH...`, `.dump TABLE FILE`, `.save DIR`, `.mode MODE`). The destructive in-place overwrite `.save --force` is listed on its own line and labeled `(destructive)`, distinct from the non-destructive `.dump` and `.save DIR` exports. The grouped layout is data-driven via `helpGroups`.
- `shell/testdata/golden/help_command.golden`: updated to the grouped output.
- `shell/shell_test.go`: a golden test (existing) plus a new assertion test checking the groups, usage suffixes, the destructive label, completeness (every command present), and a one-screen length bound.
- `spec/helpers_spec.sh`: an E2E assertion running the binary and checking the grouped help.
- `CHANGELOG.md`: New Features entry under Unreleased.

## Design Decisions

The grouping and usage strings live in a small `helpGroups` table in `help.go` rather than on the `command` struct, so the per-command `description` field stays intact for command completion (which uses it). Usage suffixes are padded before colorizing so the column stays aligned when color is stripped (tests, pipes). The output keeps every command, so `.help` remains a complete reference, just organized by task with visible syntax.

Closes #702