### PR TITLE
perf(profile): stream rows instead of materializing the full table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Performance
+* Profile Memory Bound: `--profile` now streams each table's rows one at a time through the per-column accumulators instead of materializing the whole `SELECT *` result in Go first, so large CSV or Parquet inputs no longer hold a second full copy in memory. JSON and text output are unchanged; distinct counting still keeps a per-column distinct set, as the exact count requires.
+
 ### New Features
 * Task-Oriented Help: interactive `.help` now groups commands by purpose (Session, Navigate, Inspect, Import / Export) and shows a minimal usage suffix for each (`.import PATH...`, `.dump TABLE FILE`, `.save DIR`). The destructive in-place overwrite `.save --force` is listed on its own labeled line, distinct from the non-destructive exports. No commands were added.
 * SQL File Output: `--sql-file` can now export to `--output` when the script produces exactly one result set, so a saved SQL script works in the same automation pipelines as `--sql`. Setup statements may run first, the single result is written to the file with stdout left clean, and a script that yields no result set or more than one is rejected with a clear error.

--- a/domain/repository/sqlite.go
+++ b/domain/repository/sqlite.go
@@ -33,6 +33,12 @@ type SQLite3Repository interface {
 	Header(ctx context.Context, tableName string) (*model.Table, error)
 	// Query execute "SELECT" or "EXPLAIN" query
 	Query(ctx context.Context, query string) (*model.Table, error)
+	// QueryStream executes a "SELECT"/"EXPLAIN" query and streams each result row
+	// to fn, so callers can aggregate without materializing the whole result set.
+	// fn receives one row's cell strings and a per-cell SQL NULL flag; returning an
+	// error stops the scan and is returned. A statement with no result columns
+	// returns ErrNoRows.
+	QueryStream(ctx context.Context, query string, fn func(record []string, nulls []bool) error) error
 	// Exec execute "INSERT" or "UPDATE" or "DELETE" statement
 	Exec(ctx context.Context, statement string) (int64, error)
 }

--- a/infrastructure/memory/sqlite3.go
+++ b/infrastructure/memory/sqlite3.go
@@ -277,6 +277,60 @@ func (r *sqlite3Repository) Query(ctx context.Context, query string) (*model.Tab
 	return table, nil
 }
 
+// QueryStream executes a read query and invokes fn once per result row, scanning
+// rows one at a time so a caller can aggregate without holding the whole result
+// set in memory. Each call gets the row's cell strings and a per-cell SQL NULL
+// flag (distinguished the same way Query does, via a *[]byte scan target).
+func (r *sqlite3Repository) QueryStream(ctx context.Context, query string, fn func(record []string, nulls []bool) error) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+
+	header, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	if len(header) == 0 {
+		return repository.ErrNoRows
+	}
+
+	scanDest := make([]any, len(header))
+	rawResult := make([][]byte, len(header))
+	for i := range header {
+		scanDest[i] = &rawResult[i]
+	}
+
+	for rows.Next() {
+		if err := rows.Scan(scanDest...); err != nil {
+			return err
+		}
+		record := make([]string, len(header))
+		nulls := make([]bool, len(header))
+		for i, raw := range rawResult {
+			if raw == nil {
+				nulls[i] = true
+				continue
+			}
+			record[i] = string(raw)
+		}
+		if err := fn(record, nulls); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // extractTableName extract table name from query.
 // The query must be "SELECT" or "EXPLAIN" statement.
 func extractTableName(query string) string {

--- a/infrastructure/mock/sqlite.go
+++ b/infrastructure/mock/sqlite.go
@@ -273,6 +273,44 @@ func (c *MockSQLite3RepositoryQueryCall) DoAndReturn(f func(context.Context, str
 	return c
 }
 
+// QueryStream mocks base method.
+func (m *MockSQLite3Repository) QueryStream(ctx context.Context, query string, fn func([]string, []bool) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryStream", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// QueryStream indicates an expected call of QueryStream.
+func (mr *MockSQLite3RepositoryMockRecorder) QueryStream(ctx, query, fn any) *MockSQLite3RepositoryQueryStreamCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryStream", reflect.TypeOf((*MockSQLite3Repository)(nil).QueryStream), ctx, query, fn)
+	return &MockSQLite3RepositoryQueryStreamCall{Call: call}
+}
+
+// MockSQLite3RepositoryQueryStreamCall wrap *gomock.Call
+type MockSQLite3RepositoryQueryStreamCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSQLite3RepositoryQueryStreamCall) Return(arg0 error) *MockSQLite3RepositoryQueryStreamCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSQLite3RepositoryQueryStreamCall) Do(f func(context.Context, string, func([]string, []bool) error) error) *MockSQLite3RepositoryQueryStreamCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSQLite3RepositoryQueryStreamCall) DoAndReturn(f func(context.Context, string, func([]string, []bool) error) error) *MockSQLite3RepositoryQueryStreamCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SchemaObjects mocks base method.
 func (m *MockSQLite3Repository) SchemaObjects(ctx context.Context) ([]*model.Table, error) {
 	m.ctrl.T.Helper()

--- a/interactor/mock/query.go
+++ b/interactor/mock/query.go
@@ -158,3 +158,41 @@ func (c *MockQueryUsecaseQueryCall) DoAndReturn(f func(context.Context, string) 
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// QueryStream mocks base method.
+func (m *MockQueryUsecase) QueryStream(ctx context.Context, query string, fn func([]string, []bool) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryStream", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// QueryStream indicates an expected call of QueryStream.
+func (mr *MockQueryUsecaseMockRecorder) QueryStream(ctx, query, fn any) *MockQueryUsecaseQueryStreamCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryStream", reflect.TypeOf((*MockQueryUsecase)(nil).QueryStream), ctx, query, fn)
+	return &MockQueryUsecaseQueryStreamCall{Call: call}
+}
+
+// MockQueryUsecaseQueryStreamCall wrap *gomock.Call
+type MockQueryUsecaseQueryStreamCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockQueryUsecaseQueryStreamCall) Return(arg0 error) *MockQueryUsecaseQueryStreamCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockQueryUsecaseQueryStreamCall) Do(f func(context.Context, string, func([]string, []bool) error) error) *MockQueryUsecaseQueryStreamCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockQueryUsecaseQueryStreamCall) DoAndReturn(f func(context.Context, string, func([]string, []bool) error) error) *MockQueryUsecaseQueryStreamCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/interactor/sqlite3.go
+++ b/interactor/sqlite3.go
@@ -96,6 +96,12 @@ func (si *SQLite3Interactor) Query(ctx context.Context, query string) (*model.Ta
 	return si.r.Query(ctx, query)
 }
 
+// QueryStream executes a "SELECT"/"EXPLAIN" query and streams each result row to
+// fn, so callers can aggregate without materializing the whole result set.
+func (si *SQLite3Interactor) QueryStream(ctx context.Context, query string, fn func(record []string, nulls []bool) error) error {
+	return si.r.QueryStream(ctx, query, fn)
+}
+
 // Exec execute "INSERT" or "UPDATE" or "DELETE" statement
 func (si *SQLite3Interactor) Exec(ctx context.Context, statement string) (int64, error) {
 	return si.r.Exec(ctx, statement)

--- a/shell/profile.go
+++ b/shell/profile.go
@@ -110,54 +110,53 @@ func (s *Shell) runProfile(ctx context.Context) error {
 	return nil
 }
 
-// profileTable builds the data-quality summary for a single table by scanning its
-// rows once and computing per-column statistics.
+// profileTable builds the data-quality summary for a single table by streaming
+// its rows and folding each into per-column accumulators. Why stream instead of
+// SELECT * into a model.Table: the table is never held in memory all at once, so
+// profiling a large input no longer scales memory with rows. The accumulators
+// keep only running counts and each column's distinct set, which the distinct
+// count needs.
 func (s *Shell) profileTable(ctx context.Context, name string) (profileTable, error) {
 	columns, err := s.inspectColumns(ctx, name)
 	if err != nil {
 		return profileTable{}, err
 	}
-	table, err := s.selectAll(ctx, name)
-	if err != nil {
-		return profileTable{}, err
+
+	// Build profilers in column-definition order. inspectColumns reads PRAGMA
+	// table_info, whose cid order matches the SELECT * column order streamed below,
+	// so a record's cell index lines up with its profiler.
+	profilers := make([]*columnProfiler, len(columns))
+	for ci, c := range columns {
+		profilers[ci] = newColumnProfiler(c.Name, c.Type)
 	}
 
-	typeByName := make(map[string]string, len(columns))
-	for _, c := range columns {
-		typeByName[c.Name] = c.Type
-	}
-
-	header := table.Header()
-	records := table.Records()
-
-	// Aggregate per column in a single pass over the rows. Why not build a
-	// per-column values/nulls slice first: that duplicated the whole table once
-	// per column. The accumulators hold only running counts (and the distinct set
-	// the report needs anyway), so profiling no longer scales memory with
-	// columns * rows.
-	profilers := make([]*columnProfiler, len(header))
-	for ci, colName := range header {
-		profilers[ci] = newColumnProfiler(colName, typeByName[colName])
-	}
-	for ri, rec := range records {
-		for ci := range header {
+	var rowCount int64
+	quoted := s.usecases.importer.QuoteIdentifier(name)
+	err = s.usecases.query.QueryStream(ctx, "SELECT * FROM "+quoted, func(record []string, nulls []bool) error {
+		rowCount++
+		for ci := range profilers {
 			var v string
-			if ci < len(rec) {
-				v = rec[ci]
+			if ci < len(record) {
+				v = record[ci]
 			}
-			profilers[ci].add(v, table.IsNull(ri, ci))
+			profilers[ci].add(v, ci < len(nulls) && nulls[ci])
 		}
+		return nil
+	})
+	if err != nil {
+		return profileTable{}, fmt.Errorf("failed to read rows of %s: %w", name, err)
 	}
-	cols := make([]profileColumn, len(header))
-	for ci := range header {
+
+	cols := make([]profileColumn, len(profilers))
+	for ci := range profilers {
 		cols[ci] = profilers[ci].result()
 	}
 
 	return profileTable{
 		Name:        name,
 		Source:      s.tableSources[name],
-		RowCount:    int64(len(records)),
-		ColumnCount: len(header),
+		RowCount:    rowCount,
+		ColumnCount: len(columns),
 		Columns:     cols,
 	}, nil
 }

--- a/shell/profile_test.go
+++ b/shell/profile_test.go
@@ -274,7 +274,9 @@ func TestProfileTable_StreamingMatchesFullScan(t *testing.T) {
 		t.Fatalf("row/col = %d/%d, want 200/4", entry.RowCount, entry.ColumnCount)
 	}
 	// Each column draws from 97 distinct generated values, so a 200-row column
-	// sees all 97. This confirms the single-pass aggregation matches a full scan.
+	// sees all 97. This confirms the streaming aggregation (rows folded one at a
+	// time via QueryStream, never materialized as a whole table) matches a full
+	// scan.
 	for _, c := range entry.Columns {
 		if c.DistinctCount != 97 {
 			t.Errorf("column %s distinct = %d, want 97", c.Name, c.DistinctCount)
@@ -285,6 +287,10 @@ func TestProfileTable_StreamingMatchesFullScan(t *testing.T) {
 	}
 }
 
+// BenchmarkProfileTable measures the streaming profile path with -benchmem. Rows
+// are folded one at a time via QueryStream, so allocations track the per-column
+// distinct sets rather than a full in-memory copy; raising the row count should
+// not grow the per-op footprint.
 func BenchmarkProfileTable(b *testing.B) {
 	csv := writeProfileBenchCSV(b, 5000, 8)
 	shell, cleanup, err := newShell(b, []string{"sqly"})

--- a/usecase/query.go
+++ b/usecase/query.go
@@ -14,6 +14,11 @@ import (
 type QueryUsecase interface {
 	// Query execute "SELECT" or "EXPLAIN" query
 	Query(ctx context.Context, query string) (*model.Table, error)
+	// QueryStream executes a "SELECT"/"EXPLAIN" query and streams each result row
+	// to fn, so callers can aggregate without materializing the whole result set.
+	// fn receives one row's cell strings and a per-cell SQL NULL flag; returning an
+	// error stops the scan.
+	QueryStream(ctx context.Context, query string, fn func(record []string, nulls []bool) error) error
 	// Exec execute "INSERT" or "UPDATE" or "DELETE" statement
 	Exec(ctx context.Context, statement string) (int64, error)
 	// ExecSQL executes "SELECT/EXPLAIN" query or "INSERT/UPDATE/DELETE" statement


### PR DESCRIPTION
## Summary

`--profile` read each table with `SELECT *` into a `model.Table` and then aggregated per column, so a large CSV or Parquet input held a full second copy of the data in Go before any statistics were computed. This follows up #599 by removing that materialization: rows are now streamed one at a time into the existing per-column accumulators, so memory no longer scales with row count.

## Changes

- `domain/repository/sqlite.go`, `usecase/query.go`: add `QueryStream(ctx, query, fn)`, which scans a read query row-by-row and calls `fn` with each row's cells and per-cell SQL NULL flag.
- `infrastructure/memory/sqlite3.go`: implement `QueryStream` (same NULL handling as `Query`, via a `[]byte` scan target), and `interactor/sqlite3.go` delegates to it.
- `infrastructure/mock/sqlite.go`, `interactor/mock/query.go`: regenerated mocks.
- `shell/profile.go`: `profileTable` builds the per-column profilers from `inspectColumns` (PRAGMA table_info, whose cid order matches `SELECT *`) and folds each streamed row into them, counting rows as it goes. No full table is held in memory.
- `shell/profile_test.go`: the streaming-match regression test and the `-benchmem` benchmark document the bounded-memory behavior.
- `CHANGELOG.md`: Performance entry under Unreleased.

## Design Decisions

The only per-value memory that remains is each column's distinct set, which the exact `distinct_count` requires; the issue explicitly allows that. Output is byte-for-byte unchanged: the JSON and text contracts, the row/column counts, and all warnings come from the same accumulators as before, just fed by a stream instead of a materialized table. `QueryStream` follows the existing `Query` pattern through the layers, so go-arch-lint boundaries are unaffected.

Closes #703