### PR TITLE
docs: add aqua and mise installation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Cache Signature Scope: the directory cache signature now includes only files sqly would import, so changing an unsupported sibling file such as a `.txt` note no longer invalidates the cache. Changing a supported input still invalidates it.
 
 ### Documentation
+* Install Methods: the README and installation docs now cover aqua (`aqua g -i nao1215/sqly`) and mise (`mise use aqua:nao1215/sqly`), which install sqly through the aqua standard registry.
 * Helper Command Docs: the `.dump` and `.save` reference now matches current behavior. `.dump` in table mode infers the output format from the destination extension (TSV for `out.tsv`), falling back to CSV only for an unknown extension; `.save` documents native ACH/Fedwire whole-set write-back. A docs-sync test guards these descriptions.
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ go install github.com/nao1215/sqly@latest
 brew install nao1215/tap/sqly
 ```
 
+sqly is in the [aqua](https://aquaproj.github.io/) standard registry:
+
+```shell
+aqua g -i nao1215/sqly
+```
+
+[mise](https://mise.jdx.dev/) can install it through the same registry with the aqua backend:
+
+```shell
+mise use aqua:nao1215/sqly
+```
+
 Runs on Windows, macOS, and Linux. Requires Go 1.25 or later when building from source.
 
 ## Verifying release integrity

--- a/doc/pages/markdown/installation.md
+++ b/doc/pages/markdown/installation.md
@@ -19,6 +19,22 @@ go install github.com/nao1215/sqly@latest
 brew install nao1215/tap/sqly
 ```
 
+### Use aqua
+
+sqly is in the [aqua](https://aquaproj.github.io/) standard registry:
+
+```shell
+aqua g -i nao1215/sqly
+```
+
+### Use mise
+
+[mise](https://mise.jdx.dev/) installs it through the aqua standard registry with the aqua backend:
+
+```shell
+mise use aqua:nao1215/sqly
+```
+
 ### Use pre-built binaries
 
 The following binaries are distributed on the release page.


### PR DESCRIPTION
## Summary

sqly is in the aqua standard registry, so document installing it with aqua and with mise (via the aqua backend), alongside the existing go install and Homebrew instructions.

## Changes

- `README.md`: add `aqua g -i nao1215/sqly` and `mise use aqua:nao1215/sqly` to the Install section.
- `doc/pages/markdown/installation.md`: add "Use aqua" and "Use mise" sections mirroring the README.
- `CHANGELOG.md`: Documentation entry under Unreleased.

## Notes

Both methods resolve sqly through the aqua standard registry entry (`pkgs/nao1215/sqly`), so they track the same GitHub releases as the other install paths. Documentation only; no code or behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new installation options for sqly using Aqua and Mise.
  * Expanded the README and installation guide with updated setup commands and examples.
  * Noted the new install methods in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->