### PR TITLE
docs: add a demo asset drift check and make demo guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Cache Signature Scope: the directory cache signature now includes only files sqly would import, so changing an unsupported sibling file such as a `.txt` note no longer invalidates the cache. Changing a supported input still invalidates it.
 
 ### Documentation
+* Demo Asset Drift Check: a `TestDemoAssetsInSync` docs-sync test now guards the README demo GIFs without rendering them. It fails when a `doc/vhs/*.tape` declares an `Output` GIF that is missing (a tape changed or added without `make demo`) or when the README embeds a GIF no tape produces. Contributor docs explain when to rerun `make demo`, and the `--sql-file --output` workflow is documented as intentionally without a GIF.
 * Install Methods: the README and installation docs now cover aqua (`aqua g -i nao1215/sqly`) and mise (`mise use aqua:nao1215/sqly`), which install sqly through the aqua standard registry.
 * Helper Command Docs: the `.dump` and `.save` reference now matches current behavior. `.dump` in table mode infers the output format from the destination extension (TSV for `out.tsv`), falling back to CSV only for an unknown extension; `.save` documents native ACH/Fedwire whole-set write-back. A docs-sync test guards these descriptions.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,18 @@ make generate
 make tools
 ```
 
+### 7. Refresh demo GIFs when you change a tape
+The README demo GIFs under `doc/img/` are rendered from `doc/vhs/*.tape`. After
+changing a tape or adding a demo, rerun `make demo` (it needs vhs, ttyd, and
+ffmpeg) and commit the regenerated GIF with the tape change:
+
+```shell
+make demo
+```
+
+CI does not render GIFs; the `TestDemoAssetsInSync` test instead fails when a tape
+and its GIF, or the README and a GIF, fall out of sync.
+
 ## Documentation
 `README.md` (English) is the source of truth for user-facing documentation. When
 you add or change a feature, also update the GitHub Pages docs under

--- a/doc/pages/markdown/build_and_test.md
+++ b/doc/pages/markdown/build_and_test.md
@@ -35,3 +35,26 @@ make tools
 $ make build
 $ make test
 ```
+
+### Demo GIFs
+
+The README and GitHub Pages embed demo GIFs under `doc/img/`, each rendered from a
+matching `doc/vhs/*.tape` by [vhs](https://github.com/charmbracelet/vhs). Rerun
+`make demo` after you change a tape, add a new demo, or change a documented
+workflow whose GIF should reflect it:
+
+```shell
+$ make demo
+```
+
+`make demo` needs vhs, ttyd, and ffmpeg, so it is not run in CI. Instead, the
+`TestDemoAssetsInSync` docs-sync test guards against drift without rendering: it
+fails when a tape declares an `Output` GIF that does not exist (a tape changed or
+added without `make demo`), or when the README embeds a GIF that no tape produces.
+Commit the regenerated GIF together with the tape change so this check stays green.
+
+Not every workflow has its own GIF. The `--sql-file --output` workflow is
+intentionally not given one: its result goes to a file rather than the terminal,
+so there is nothing visually distinct to capture beyond the existing `--sql-file`
+and `--output` demos. Add a tape only when a workflow has a meaningful on-screen
+result.

--- a/docs_sync_test.go
+++ b/docs_sync_test.go
@@ -201,3 +201,115 @@ func makeCommandTargets(cmd string) []string {
 	}
 	return targets
 }
+
+// TestDemoAssetsInSync is a docs-sync guardrail for the demo GIFs. Rendering GIFs
+// needs vhs/ttyd/ffmpeg (via `make demo`) and is too heavy for CI, so this does
+// not render them; it checks that the assets a tape declares and the README
+// references actually exist and line up. That catches the common drift the
+// project cannot otherwise see: a doc/vhs/*.tape added or changed without its GIF
+// regenerated, or a README GIF pointing at an asset no tape produces.
+func TestDemoAssetsInSync(t *testing.T) {
+	t.Parallel()
+
+	tapeGIF, err := tapeOutputGIFs("doc/vhs")
+	if err != nil {
+		t.Fatalf("scan tapes: %v", err)
+	}
+	if len(tapeGIF) == 0 {
+		t.Fatal("no tape Output directives parsed; the parser or the tapes changed")
+	}
+
+	// Every tape must declare exactly one Output GIF, and that GIF must exist. A
+	// tape that was added or whose command changed without `make demo` being rerun
+	// fails here, naming the missing asset.
+	produced := map[string]bool{}
+	for tape, gif := range tapeGIF {
+		if gif == "" {
+			t.Errorf("%s has no Output directive; a tape must declare the GIF it renders", tape)
+			continue
+		}
+		produced[gif] = true
+		if _, statErr := os.Stat(gif); statErr != nil {
+			t.Errorf("%s declares Output %q, but that GIF is missing; run `make demo` to render it", tape, gif)
+		}
+	}
+
+	// Every GIF the README embeds must exist and be produced by a tape, so a
+	// documented demo cannot point at an asset nothing regenerates.
+	refs, err := markdownGIFRefs("README.md")
+	if err != nil {
+		t.Fatalf("scan README.md: %v", err)
+	}
+	if len(refs) == 0 {
+		t.Fatal("no doc/img GIF references found in README.md; the parser or the README changed")
+	}
+	for _, ref := range refs {
+		if _, statErr := os.Stat(ref.path); statErr != nil {
+			t.Errorf("README.md:%d references %q, which does not exist", ref.line, ref.path)
+		}
+		if !produced[ref.path] {
+			t.Errorf("README.md:%d references %q, but no doc/vhs/*.tape produces it; add a tape or fix the reference", ref.line, ref.path)
+		}
+	}
+}
+
+// tapeOutputGIFs maps each doc/vhs/*.tape to the GIF path in its `Output "..."`
+// directive (empty when a tape declares none). The path is repo-relative, matching
+// how the README references it.
+func tapeOutputGIFs(dir string) (map[string]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	outputLine := regexp.MustCompile(`^Output\s+"([^"]+)"`)
+	result := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".tape") {
+			continue
+		}
+		path := dir + "/" + e.Name()
+		data, readErr := os.ReadFile(path) //nolint:gosec // path is a repo-relative tape file
+		if readErr != nil {
+			return nil, readErr
+		}
+		result[path] = "" // record the tape even if it declares no Output
+		scanner := bufio.NewScanner(strings.NewReader(string(data)))
+		for scanner.Scan() {
+			if m := outputLine.FindStringSubmatch(strings.TrimSpace(scanner.Text())); m != nil {
+				result[path] = m[1]
+				break
+			}
+		}
+		if scanErr := scanner.Err(); scanErr != nil {
+			return nil, scanErr
+		}
+	}
+	return result, nil
+}
+
+// docImageRef is a Markdown image reference and the line it appears on.
+type docImageRef struct {
+	path string
+	line int
+}
+
+// markdownGIFRefs returns the repo-relative doc/img/*.gif paths embedded in a
+// Markdown file via the image syntax ![alt](path). A leading "./" is trimmed so
+// the path matches a tape's Output directive.
+func markdownGIFRefs(path string) ([]docImageRef, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	image := regexp.MustCompile(`!\[[^\]]*\]\((\.?/?doc/img/[^)]+\.gif)\)`)
+	var refs []docImageRef
+	lineNo := 0
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		lineNo++
+		for _, m := range image.FindAllStringSubmatch(scanner.Text(), -1) {
+			refs = append(refs, docImageRef{path: strings.TrimPrefix(m[1], "./"), line: lineNo})
+		}
+	}
+	return refs, scanner.Err()
+}

--- a/docs_sync_test.go
+++ b/docs_sync_test.go
@@ -297,7 +297,7 @@ type docImageRef struct {
 // Markdown file via the image syntax ![alt](path). A leading "./" is trimmed so
 // the path matches a tape's Output directive.
 func markdownGIFRefs(path string) ([]docImageRef, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path is a repo-relative doc file, not user input
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

The docs-sync guardrails did not detect when a `doc/vhs/*.tape` changed without regenerating its GIF, or when the README embedded a GIF no tape produces. This adds a lightweight drift check (no GIF rendering in CI) plus contributor guidance, following the existing docs-sync test pattern.

## Changes

- `docs_sync_test.go`: a new `TestDemoAssetsInSync` test. It parses each tape's `Output "doc/img/X.gif"` directive and asserts the GIF exists, and asserts every README `![...](doc/img/X.gif)` is produced by a tape. It fails clearly (naming the tape and the README line) when they drift, e.g. a tape added or changed without `make demo`.
- `doc/pages/markdown/build_and_test.md`, `CONTRIBUTING.md`: explain when to rerun `make demo` (it needs vhs/ttyd/ffmpeg and is not run in CI) and that the check guards drift without rendering.
- The `--sql-file --output` workflow is documented as intentionally without its own GIF: its result goes to a file, so there is nothing visually distinct to capture beyond the existing `--sql-file` and `--output` demos.
- `CHANGELOG.md`: Documentation entry under Unreleased.

## Design Decisions

Rendering GIFs needs vhs/ttyd/ffmpeg, which is too heavy for CI, so the guardrail checks asset/reference consistency instead. A tape's `Output` directive is the canonical tape→GIF mapping, so the check reads it directly rather than guessing filename conventions (which are not uniform, e.g. `demo.tape` → `demo.gif`). The check is intentionally conservative: it flags the concrete, reliable drift signals rather than trying to infer every "documented workflow", which the contributor docs and the explicit `--sql-file --output` note cover.

Closes #701