### PR TITLE
docs(readme): add Arch Linux install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ go install github.com/nao1215/sqly@latest
 brew install nao1215/tap/sqly
 ```
 
+Arch Linux users can install the [AUR package](https://aur.archlinux.org/packages/sqly-bin):
+
+```shell
+yay -S sqly-bin
+```
+
+Without an AUR helper:
+
+```shell
+git clone https://aur.archlinux.org/sqly-bin.git
+cd sqly-bin
+makepkg -si
+```
+
 sqly is in the [aqua](https://aquaproj.github.io/) standard registry:
 
 ```shell


### PR DESCRIPTION
## Summary
Add Arch Linux installation instructions to the README using the sqly-bin AUR package.
This documents both the AUR helper flow and the manual makepkg flow.

## Changes
- add a README install example for `yay -S sqly-bin`
- add manual AUR installation steps with `git clone` and `makepkg -si`

## Design Decisions
- keep the new section in the existing Install block next to other package manager examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Arch Linux install section to the README with step-by-step setup instructions.
  * Included guidance for installing via an AUR helper, plus a manual installation fallback when one isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->