### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v0.27.0](https://github.com/nao1215/sqly/compare/v0.26.0...v0.27.0) (2026-07-04)
 
 ### New Features
 * Import Mode for Ragged Rows: the new `--import-mode` flag and `.import-mode` shell command choose how a CSV/TSV row whose field count differs from the header is imported. `stop` (default) aborts the import and reports the mismatch, `skip` drops the ragged rows and imports the rest, and `fill` keeps every row by padding short rows with empty values and truncating long rows to the header width. The shell command changes the policy for later `.import` runs in the same session.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ A SQL statement is buffered until it ends with `;`, so a multi-line or pasted qu
 
 ```shell
 $ sqly testdata/user.csv
-sqly v0.26.0
+sqly v0.27.0
 
 enter "SQL query" or "sqly command that begins with a dot".
 .help print usage, .exit exit sqly.
@@ -562,7 +562,7 @@ SELECT * FROM `customers100000` WHERE `Index` BETWEEN 1000 AND 2000 ORDER BY `In
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.26.0. Run `make bench` to reproduce on your machine.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.27.0. Run `make bench` to reproduce on your machine.
 
 ## Comparison with similar tools
 


### PR DESCRIPTION
Release v0.27.0.

Adds `--import-mode` and the `.import-mode` shell command (stop/skip/fill) to control how a ragged CSV/TSV row is imported, and fixes the silent data loss where a field-count mismatch produced an empty table (via filesql v0.17.0). See the CHANGELOG for details.

Merging this finalizes the CHANGELOG; the v0.27.0 tag is pushed after merge and the release workflow publishes from the tag.