### PR TITLE
build(coverage): combine unit and self-hosted E2E coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,16 +7,25 @@ on:
   pull_request:
     branches: [main]
 
+# octocov needs to read/write the Actions-artifact datastore (report/diff in
+# .octocov.yml) and comment coverage on pull requests. The repo's default token
+# permissions are read-only, which makes those API calls 403, so grant the
+# needed scopes explicitly here.
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write
+
 jobs:
-  unit_test:
-    name: Unit test (linux)
+  coverage:
+    name: Coverage (unit + e2e)
 
     strategy:
       matrix:
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -26,7 +35,15 @@ jobs:
           go-version: "1"
           check-latest: true
 
-      - name: Run tests with coverage report output
-        run: go test -cover -coverpkg=./... -coverprofile=coverage.out ./...
+      - name: Install atago
+        uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
+        with:
+          version: v0.1.0
+
+      # Combines unit-test coverage with self-hosted E2E coverage (the atago
+      # suite runs a `go build -cover` sqly and collects covdata via
+      # GOCOVERDIR), then merges both into coverage.out.
+      - name: Run combined unit + E2E coverage
+        run: make coverage
 
       - uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ cover.*
 dist
 /.serena
 /work
+
+# `make coverage` scratch: raw covdata (unit + e2e) and the merged dir. The
+# final coverage.out / cover.html are the only kept artifacts.
+.coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-e2e smoke demo clean vet fmt chkfmt
+.PHONY: build test test-e2e coverage smoke demo clean vet fmt chkfmt
 
 APP         = sqly
 VERSION     = $(shell git describe --tags --abbrev=0)
@@ -22,7 +22,7 @@ build:  ## Build binary
 	env GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(GO_LDFLAGS) -o $(APP) main.go
 
 clean: ## Clean project
-	-rm -rf $(APP) cover.*
+	-rm -rf $(APP) cover.* coverage.out .coverage
 
 test: ## Start test
 	env GOOS=$(GOOS) $(GO_TEST) -cover $(GO_PKGROOT) -coverpkg=./... -coverprofile=cover.out
@@ -30,6 +30,9 @@ test: ## Start test
 
 test-e2e: ## Run atago end-to-end tests in a hermetic temp-backed sandbox (requires atago)
 	sh scripts/run_e2e.sh
+
+coverage: ## Combine unit + self-hosted E2E coverage into coverage.out / cover.html (uses a `go build -cover` sqly; scratch under .coverage/)
+	sh scripts/coverage.sh
 
 demo: build ## Render README demo GIFs from doc/vhs/*.tape (requires vhs, ttyd, ffmpeg)
 	for tape in doc/vhs/*.tape; do vhs "$$tape"; done

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Combine unit-test coverage with self-hosted E2E coverage into a single
+# coverage.out. Unit tests report line coverage, but they never exercise the
+# real sqly binary the way an end user does; the atago E2E specs do. Go 1.20+
+# lets us instrument a built binary (`go build -cover`) and collect its runtime
+# coverage via GOCOVERDIR, so we can merge "what the tests cover" with "what a
+# real run covers" and get one honest number.
+#
+# This is intentionally a separate, heavier target: `make test` / `make
+# test-e2e` stay fast and unchanged. Everything lands under .coverage/
+# (gitignored) except the final coverage.out / cover.html, which are the same
+# artifacts `make test` already produces so octocov and local tooling need no
+# changes.
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+cov="${ROOT}/.coverage"
+
+rm -rf "${cov}"
+mkdir -p "${cov}/unit" "${cov}/e2e" "${cov}/merged"
+
+# 1. Unit-test coverage as raw covdata (GOCOVERDIR form) so it can be merged
+#    with the E2E covdata below. -covermode=atomic must match the binary build.
+echo ">> unit coverage -> ${cov}/unit"
+go test -count=1 -cover -covermode=atomic -coverpkg=./... ./... \
+	-args -test.gocoverdir="${cov}/unit"
+
+# 2. Self-hosted E2E via a coverage-instrumented sqly. run_e2e.sh builds sqly
+#    with `go build -cover` when COVER is set and puts it first on PATH; atago
+#    forwards GOCOVERDIR to the sqly child processes, so each writes its own
+#    covdata into ${cov}/e2e.
+echo ">> e2e coverage -> ${cov}/e2e"
+COVER=1 GOCOVERDIR="${cov}/e2e" sh "${ROOT}/scripts/run_e2e.sh"
+
+# 3. Merge the raw covdata and render the combined text profile + reports.
+echo ">> merging unit + e2e covdata -> coverage.out"
+go tool covdata merge -i="${cov}/unit,${cov}/e2e" -o="${cov}/merged"
+go tool covdata textfmt -i="${cov}/merged" -o="${ROOT}/coverage.out"
+
+go tool cover -func=coverage.out | tail -n 1
+go tool cover -html=coverage.out -o cover.html
+echo ">> wrote coverage.out and cover.html (unit + e2e combined)"

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -19,7 +19,22 @@ if ! command -v atago >/dev/null 2>&1; then
 fi
 
 # Build the binary the specs exercise; it is exposed on PATH below.
-make build
+#
+# When COVER is set (by scripts/coverage.sh) the binary is built with Go's
+# coverage instrumentation instead of the plain `make build`. atago passes the
+# environment through to the spec commands, so the sqly child processes inherit
+# GOCOVERDIR and write their runtime covdata there. The default (unset COVER)
+# path stays byte-for-byte identical, keeping `make test-e2e` fast.
+if [ -n "${COVER:-}" ]; then
+	: "${GOCOVERDIR:?COVER set but GOCOVERDIR is empty; export GOCOVERDIR to collect e2e coverage}"
+	VERSION="$(git describe --tags --abbrev=0 2>/dev/null || echo dev)"
+	env GO111MODULE=on CGO_ENABLED=0 \
+		go build -cover -covermode=atomic -coverpkg=./... \
+		-ldflags "-X github.com/nao1215/sqly/config.Version=${VERSION}" \
+		-o sqly main.go
+else
+	make build
+fi
 
 # Create an isolated sandbox and remove it on exit, so no run leaves state behind.
 SANDBOX="$(mktemp -d)"

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -27,7 +27,10 @@ fi
 # path stays byte-for-byte identical, keeping `make test-e2e` fast.
 if [ -n "${COVER:-}" ]; then
 	: "${GOCOVERDIR:?COVER set but GOCOVERDIR is empty; export GOCOVERDIR to collect e2e coverage}"
-	VERSION="$(git describe --tags --abbrev=0 2>/dev/null || echo dev)"
+	# Mirror the Makefile's VERSION exactly (empty when no tags are reachable, e.g.
+	# on a shallow CI checkout) so `sqly --version` resolves the same way the plain
+	# `make build` binary does: an empty ldflag falls back to "(devel)".
+	VERSION="$(git describe --tags --abbrev=0 2>/dev/null || true)"
 	env GO111MODULE=on CGO_ENABLED=0 \
 		go build -cover -covermode=atomic -coverpkg=./... \
 		-ldflags "-X github.com/nao1215/sqly/config.Version=${VERSION}" \


### PR DESCRIPTION
## What

Make sqly's reported coverage number combine **unit-test coverage** with
**self-hosted E2E coverage** (the atago suite runs the real built `sqly`
binary, exercising code paths unit tests never reach).

- Unit-only: **81.8%**
- Combined (unit + E2E): **83.0%**

## How

- `scripts/run_e2e.sh` gains a `COVER` switch: when set, it builds sqly with
  `go build -cover -covermode=atomic -coverpkg=./...` instead of `make build`,
  keeping the default `make test-e2e` path byte-for-byte unchanged. atago
  forwards `GOCOVERDIR` to the sqly child processes, so each writes runtime
  covdata.
- New `scripts/coverage.sh` (run via `make coverage`): collects unit coverage
  as raw covdata, runs the E2E suite through the instrumented binary, then
  `go tool covdata merge` + `textfmt` into `coverage.out` (+ `cover.html`).
- `.github/workflows/coverage.yml` now installs atago (via
  `nao1215/setup-atago`) and runs `make coverage`, feeding the combined
  `coverage.out` to octocov (same auto-detected path as before).
- `.coverage/` scratch dir gitignored and cleaned by `make clean`.

`make test`, `make test-e2e`, the separate `unit_test.yml` and `e2e_test.yml`
workflows, and the README octocov badge are all unchanged.

## Verified locally

- `make coverage` passes: 404/404 E2E scenarios pass, combined total 83.0%,
  **zero** `GOCOVERDIR not set` warnings, 427 E2E covdata files collected.
- `make test-e2e` (default path) unchanged and green.
- Diff scoped to Makefile, scripts, .gitignore, coverage.yml only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a combined coverage flow that includes both unit and end-to-end test coverage, with an HTML report and merged coverage output.
  * Updated CI coverage reporting so results can be posted and artifacts accessed correctly.

* **Bug Fixes**
  * Improved coverage generation reliability by using a dedicated working directory and cleaner cleanup behavior.

* **Chores**
  * Ignored temporary coverage scratch files in version control.
  * Increased the coverage job timeout slightly to better fit the expanded test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->