### PR TITLE
chore: release v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v0.27.1](https://github.com/nao1215/sqly/compare/v0.27.0...v0.27.1) (2026-07-06)
 
 ### Bug Fixes
 * Unicode BOM on Import: a CSV, TSV, LTSV, JSON, or JSONL file that begins with a Unicode byte-order mark now imports correctly. A UTF-8 BOM (written by Excel, Notepad, and PowerShell) used to stay attached to the first column name, so `SELECT name` failed with `no such column`, and it broke JSON/JSONL parsing outright; a UTF-16 file surfaced as a column-count mismatch. The reader now strips a UTF-8 BOM and transcodes UTF-16 (LE or BE) to UTF-8 before parsing. A non-Unicode legacy encoding without a BOM (for example Shift-JIS) still passes through as raw bytes. Requires filesql v0.17.1.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ A SQL statement is buffered until it ends with `;`, so a multi-line or pasted qu
 
 ```shell
 $ sqly testdata/user.csv
-sqly v0.27.0
+sqly v0.27.1
 
 enter "SQL query" or "sqly command that begins with a dot".
 .help print usage, .exit exit sqly.
@@ -562,7 +562,7 @@ SELECT * FROM `customers100000` WHERE `Index` BETWEEN 1000 AND 2000 ORDER BY `In
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.27.0. Run `make bench` to reproduce on your machine.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.27.1. Run `make bench` to reproduce on your machine.
 
 ## Comparison with similar tools
 

--- a/doc/img/cover-tree.svg
+++ b/doc/img/cover-tree.svg
@@ -7,64 +7,64 @@
 >
 
 <g>
-	<rect x="20.000000" y="20.000000" width="988.000000" height="600.000000" style="fill: rgb(70, 171, 89);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="20.000000" y="20.000000" width="988.000000" height="600.000000" style="fill: rgb(20, 142, 75);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
 	transform="translate(28.000000,35.600000) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">github.com/nao1215/sqly 84.9%</text>
+	data-math="N">github.com/nao1215/sqly 92.0%</text>
 		
 </g>
 
 
 <g>
-	<rect x="677.117192" y="401.552294" width="151.413175" height="210.447706" style="fill: rgb(27, 152, 80);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="610.171660" y="489.799054" width="228.358986" height="122.200946" style="fill: rgb(14, 132, 69);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(685.117192,417.152294) scale(1.000000)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">config 89.9%</text>
-		
-</g>
-
-
-<g>
-	<rect x="836.530366" y="534.668865" width="125.746314" height="77.331135" style="fill: rgb(89, 182, 95);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(844.530366,550.268865) scale(0.571595)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">di/wire_gen.go 82.1%</text>
-		
-</g>
-
-
-<g>
-	<rect x="677.117192" y="41.600000" width="322.882808" height="186.568807" style="fill: rgb(11, 128, 67);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(685.117192,57.200000) scale(1.000000)"
+	transform="translate(618.171660,505.399054) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">domain/model 95.0%</text>
+	data-math="N">config 94.2%</text>
 		
 </g>
 
 
 <g>
-	<rect x="677.117192" y="236.168807" width="322.882808" height="157.383486" style="fill: rgb(177, 222, 112);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="846.530646" y="576.504753" width="109.432257" height="35.495247" style="fill: rgb(86, 180, 94);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(685.117192,251.768807) scale(1.000000)"
+	transform="translate(854.530646,592.104753) scale(0.486626)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">di/wire_gen.go 82.5%</text>
+		
+</g>
+
+
+<g>
+	<rect x="610.171660" y="270.456382" width="228.358986" height="211.342672" style="fill: rgb(4, 115, 61);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(618.171660,286.056382) scale(1.000000)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">domain/model 97.5%</text>
+		
+</g>
+
+
+<g>
+	<rect x="846.530646" y="428.620915" width="153.469354" height="139.883838" style="fill: rgb(177, 222, 112);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(854.530646,444.220915) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">golden 67.9%</text>
 		
@@ -72,103 +72,102 @@
 
 
 <g>
-	<rect x="385.191533" y="41.600000" width="283.925658" height="570.400000" style="fill: rgb(76, 174, 91);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="610.171660" y="41.600000" width="389.828340" height="220.856382" style="fill: rgb(22, 146, 77);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(393.191533,57.200000) scale(1.000000)"
+	transform="translate(618.171660,57.200000) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">infrastructure 84.1%</text>
+	data-math="N">infrastructure 91.2%</text>
 		
 </g>
 
 
 <g>
-	<rect x="836.530366" y="401.552294" width="163.469634" height="125.116571" style="fill: rgb(19, 141, 74);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="846.530646" y="270.456382" width="153.469354" height="150.164533" style="fill: rgb(1, 109, 57);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(844.530366,417.152294) scale(0.960089)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">interactor 92.3%</text>
+	transform="translate(854.530646,286.056382) scale(0.894983)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">interactor 99.0%</text>
 		
 </g>
 
 
 <g>
-	<rect x="970.276681" y="534.668865" width="29.723319" height="77.331135" style="fill: rgb(90, 182, 95);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="963.962904" y="576.504753" width="36.037096" height="35.495247" style="fill: rgb(57, 164, 86);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(978.276681,550.268865) scale(0.109962)"
+	transform="translate(971.962904,592.104753) scale(0.160554)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">main.go 81.8%</text>
+	data-math="N">main.go 86.7%</text>
 		
 </g>
 
 
 <g>
-	<rect x="28.000000" y="41.600000" width="349.191533" height="570.400000" style="fill: rgb(66, 169, 88);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="28.000000" y="41.600000" width="574.171660" height="570.400000" style="fill: rgb(18, 140, 74);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
 	transform="translate(36.000000,57.200000) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">shell 85.4%</text>
+	data-math="N">shell 92.5%</text>
 		
 </g>
 
 
 <g>
-	<rect x="685.117192" y="423.152294" width="135.413175" height="114.195575" style="fill: rgb(5, 116, 61);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="618.171660" y="511.399054" width="165.727001" height="92.600946" style="fill: rgb(2, 111, 59);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(693.117192,438.752294) scale(0.731698)"
+	transform="translate(626.171660,526.999054) scale(0.917445)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">argument.go 97.4%</text>
+	data-math="N">argument.go 98.4%</text>
 		
 </g>
 
 
 <g>
-	<rect x="790.969773" y="545.347868" width="29.560593" height="52.592847" style="fill: rgb(102, 189, 99);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="791.898662" y="580.438919" width="21.144990" height="23.561081" style="fill: rgb(26, 152, 80);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+</g>
+
+
+<g>
+	<rect x="791.898662" y="511.399054" width="38.631985" height="61.039865" style="fill: rgb(157, 213, 105);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(798.969773,560.947868) scale(0.094171)"
+	transform="translate(799.898662,526.999054) scale(0.214318)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">config.go 80.0%</text>
+	data-math="N">db.go 71.4%</text>
 		
 </g>
 
 
 <g>
-	<rect x="685.117192" y="545.347868" width="97.852581" height="58.652132" style="fill: rgb(140, 206, 102);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="821.043652" y="580.438919" width="9.486994" height="18.300901" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(693.117192,560.947868) scale(0.775119)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">db.go 74.2%</text>
-		
 </g>
 
 
 <g>
-	<rect x="924.141869" y="156.578570" width="38.174515" height="63.590237" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="754.946203" y="432.515243" width="21.254555" height="41.283811" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(932.141869,172.178570) scale(0.144365)"
+	transform="translate(762.946203,448.115243) scale(0.034209)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">common.go 100.0%</text>
 		
@@ -176,51 +175,56 @@
 
 
 <g>
-	<rect x="924.141869" y="63.200000" width="67.858131" height="85.378570" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="754.946203" y="292.056382" width="75.584443" height="132.458861" style="fill: rgb(1, 108, 57);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(932.141869,78.800000) scale(0.337618)"
+	transform="translate(762.946203,307.656382) scale(0.413781)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">export.go 100.0%</text>
+	data-math="N">export.go 99.1%</text>
 		
 </g>
 
 
 <g>
-	<rect x="970.316383" y="156.578570" width="21.683617" height="63.590237" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="784.200758" y="458.454091" width="31.702610" height="15.344963" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+</g>
+
+
+<g>
+	<rect x="784.200758" y="432.515243" width="31.702610" height="17.938848" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+</g>
+
+
+<g>
+	<rect x="823.903369" y="432.515243" width="6.627278" height="41.283811" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+</g>
+
+
+<g>
+	<rect x="618.171660" y="292.056382" width="128.774543" height="181.742672" style="fill: rgb(7, 121, 64);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(978.316383,172.178570) scale(0.034826)"
+	transform="translate(626.171660,307.656382) scale(0.839096)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">history.go 100.0%</text>
+	data-math="N">table.go 96.4%</text>
 		
 </g>
 
 
 <g>
-	<rect x="685.117192" y="63.200000" width="231.024677" height="156.968807" style="fill: rgb(16, 135, 71);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="854.530646" y="450.220915" width="65.901543" height="110.283838" style="fill: rgb(254, 248, 177);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(693.117192,78.800000) scale(1.000000)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">table.go 93.4%</text>
-		
-</g>
-
-
-<g>
-	<rect x="685.117192" y="257.768807" width="151.967202" height="127.783486" style="fill: rgb(254, 248, 177);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(693.117192,273.368807) scale(0.745434)"
+	transform="translate(862.530646,465.820915) scale(0.273583)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">assertions.go 47.4%</text>
 		
@@ -228,18 +232,18 @@
 
 
 <g>
-	<rect x="924.226062" y="366.395596" width="67.773938" height="19.156697" style="fill: rgb(117, 196, 100);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="985.686438" y="510.648528" width="6.313562" height="49.856225" style="fill: rgb(117, 196, 100);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 </g>
 
 
 <g>
-	<rect x="845.084394" y="257.768807" width="71.141668" height="127.783486" style="fill: rgb(83, 178, 93);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="928.432190" y="450.220915" width="63.567810" height="52.427613" style="fill: rgb(83, 178, 93);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(853.084394,273.368807) scale(0.382928)"
+	transform="translate(936.432190,465.820915) scale(0.330332)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">golden.go 83.0%</text>
 		
@@ -247,116 +251,63 @@
 
 
 <g>
-	<rect x="924.226062" y="257.768807" width="67.773938" height="46.313394" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="928.432190" y="510.648528" width="49.254248" height="20.928113" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(932.226062,273.368807) scale(0.283848)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">interface.go 100.0%</text>
-		
 </g>
 
 
 <g>
-	<rect x="924.226062" y="312.082202" width="67.773938" height="46.313394" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="928.432190" y="539.576641" width="49.254248" height="20.928113" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(932.226062,327.682202) scale(0.317242)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">options.go 100.0%</text>
-		
 </g>
 
 
 <g>
-	<rect x="393.191533" y="63.200000" width="267.925658" height="299.213865" style="fill: rgb(87, 180, 94);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="618.171660" y="63.200000" width="173.006983" height="191.256382" style="fill: rgb(23, 148, 78);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(401.191533,78.800000) scale(1.000000)"
+	transform="translate(626.171660,78.800000) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">filesql 82.4%</text>
+	data-math="N">filesql 90.8%</text>
 		
 </g>
 
 
 <g>
-	<rect x="393.191533" y="370.413865" width="202.746369" height="116.528936" style="fill: rgb(89, 182, 95);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="799.178643" y="63.200000" width="94.820535" height="191.256382" style="fill: rgb(25, 152, 80);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(401.191533,386.013865) scale(0.845772)"
+	transform="translate(807.178643,78.800000) scale(0.356977)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">memory/sqlite3.go 82.0%</text>
+	data-math="N">memory/sqlite3.go 90.1%</text>
 		
 </g>
 
 
 <g>
-	<rect x="393.191533" y="494.942800" width="202.746369" height="109.057200" style="fill: rgb(83, 178, 93);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="901.999178" y="63.200000" width="90.000822" height="119.393424" style="fill: rgb(38, 156, 82);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(401.191533,510.542800) scale(1.000000)"
+	transform="translate(909.999178,78.800000) scale(0.453436)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">persistence 83.0%</text>
+	data-math="N">persistence 88.9%</text>
 		
 </g>
 
 
 <g>
-	<rect x="603.937902" y="370.413865" width="57.179289" height="233.586135" style="fill: rgb(2, 112, 59);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="901.999178" y="190.593424" width="90.000822" height="63.862957" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(611.937902,386.013865) scale(0.357459)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">sql.go 98.3%</text>
-		
-</g>
-
-
-<g>
-	<rect x="910.305981" y="423.152294" width="81.694019" height="54.109943" style="fill: rgb(93, 184, 96);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(918.305981,438.752294) scale(0.456208)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">export.go 81.5%</text>
-		
-</g>
-
-
-<g>
-	<rect x="975.084995" y="485.262236" width="16.915005" height="33.406628" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(983.084995,500.862236) scale(0.005607)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">history.go 100.0%</text>
-		
-</g>
-
-
-<g>
-	<rect x="910.305981" y="485.262236" width="56.779014" height="33.406628" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(918.305981,500.862236) scale(0.326755)"
+	transform="translate(909.999178,206.193424) scale(0.592955)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">sql.go 100.0%</text>
 		
@@ -364,57 +315,102 @@
 
 
 <g>
-	<rect x="844.530366" y="423.152294" width="57.775614" height="95.516571" style="fill: rgb(6, 118, 62);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="942.539605" y="363.661945" width="41.251767" height="48.958970" style="fill: rgb(16, 136, 71);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(852.530366,438.752294) scale(0.271977)"
+	transform="translate(950.539605,379.261945) scale(0.175359)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">sqlite3.go 97.0%</text>
+	data-math="N">export.go 93.3%</text>
 		
 </g>
 
 
 <g>
-	<rect x="208.108732" y="492.787497" width="65.417532" height="53.412501" style="fill: rgb(14, 132, 69);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="991.791372" y="363.661945" width="0.208628" height="48.958970" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+</g>
+
+
+<g>
+	<rect x="854.530646" y="292.056382" width="80.008959" height="120.564533" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(216.108732,508.387497) scale(0.367690)"
+	transform="translate(862.530646,307.656382) scale(0.512892)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">batch.go 94.1%</text>
+	data-math="N">sql.go 100.0%</text>
 		
 </g>
 
 
 <g>
-	<rect x="208.108732" y="554.199999" width="65.417532" height="49.800001" style="fill: rgb(50, 161, 84);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="942.539605" y="292.056382" width="49.460395" height="63.605563" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(216.108732,569.799999) scale(0.467969)"
+	transform="translate(950.539605,307.656382) scale(0.205027)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">sqlite3.go 100.0%</text>
+		
+</g>
+
+
+<g>
+	<rect x="441.543035" y="63.200000" width="152.628625" height="196.660185" style="fill: rgb(9, 124, 66);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(449.543035,78.800000) scale(1.000000)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">batch.go 95.7%</text>
+		
+</g>
+
+
+<g>
+	<rect x="253.279378" y="472.726707" width="123.134194" height="131.273293" style="fill: rgb(59, 165, 86);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(261.279378,488.326707) scale(0.797129)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">cd.go 87.5%</text>
+	data-math="N">cache.go 86.5%</text>
 		
 </g>
 
 
 <g>
-	<rect x="345.303110" y="578.731395" width="23.888423" height="8.634303" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="506.954245" y="519.189529" width="32.626097" height="47.106217" style="fill: rgb(75, 174, 91);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(514.954245,534.789529) scale(0.157444)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">cd.go 84.2%</text>
+		
+</g>
+
+
+<g>
+	<rect x="547.580342" y="590.084111" width="24.258506" height="13.915889" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 </g>
 
 
 <g>
-	<rect x="139.882338" y="522.590623" width="60.226394" height="81.409377" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="442.371999" y="522.600512" width="56.582247" height="37.611984" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(147.882338,538.190623) scale(0.270995)"
+	transform="translate(450.371999,538.200512) scale(0.248666)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">command.go 100.0%</text>
 		
@@ -422,44 +418,57 @@
 
 
 <g>
-	<rect x="281.526264" y="492.787497" width="41.375623" height="77.943897" style="fill: rgb(173, 220, 110);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="253.279378" y="63.200000" width="180.263657" height="196.660185" style="fill: rgb(14, 133, 70);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(289.526264,508.387497) scale(0.155488)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">describe.go 68.8%</text>
-		
-</g>
-
-
-<g>
-	<rect x="230.539784" y="333.713314" width="69.325468" height="91.467932" style="fill: rgb(7, 120, 63);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(238.539784,349.313314) scale(0.427287)"
+	transform="translate(261.279378,78.800000) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">dump.go 96.6%</text>
+	data-math="N">compare.go 93.9%</text>
 		
 </g>
 
 
 <g>
-	<rect x="345.303110" y="595.365697" width="7.944212" height="8.634303" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="506.954245" y="469.690611" width="39.608707" height="41.498918" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(514.954245,485.290611) scale(0.136624)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">describe.go 100.0%</text>
+		
+</g>
+
+
+<g>
+	<rect x="384.413573" y="551.010262" width="49.958426" height="52.989738" style="fill: rgb(26, 152, 80);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(392.413573,566.610262) scale(0.272103)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">dump.go 90.0%</text>
+		
+</g>
+
+
+<g>
+	<rect x="579.838848" y="590.895810" width="8.749609" height="13.104190" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 </g>
 
 
 <g>
-	<rect x="208.108732" y="433.181246" width="80.990948" height="51.606251" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="554.562953" y="469.690611" width="39.608707" height="41.498918" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(216.108732,448.781246) scale(0.356310)"
+	transform="translate(562.562953,485.290611) scale(0.129434)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">extension.go 100.0%</text>
 		
@@ -467,70 +476,89 @@
 
 
 <g>
-	<rect x="297.099680" y="433.181246" width="72.091853" height="51.606251" style="fill: rgb(117, 196, 100);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="442.371999" y="568.212496" width="56.582247" height="35.787504" style="fill: rgb(50, 161, 84);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(305.099680,448.781246) scale(0.389527)"
+	transform="translate(450.371999,583.812496) scale(0.281821)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">header.go 77.8%</text>
+	data-math="N">header.go 87.5%</text>
 		
 </g>
 
 
 <g>
-	<rect x="321.386793" y="578.731395" width="15.916317" height="25.268605" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="578.775381" y="519.189529" width="15.396279" height="37.326044" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 </g>
 
 
 <g>
-	<rect x="214.439250" y="63.200000" width="154.752283" height="262.513314" style="fill: rgb(86, 180, 94);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="36.000000" y="379.356522" width="209.279378" height="224.643478" style="fill: rgb(25, 151, 79);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(222.439250,78.800000) scale(0.963558)"
+	transform="translate(44.000000,394.956522) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">import.go 82.5%</text>
+	data-math="N">import.go 90.2%</text>
 		
 </g>
 
 
 <g>
-	<rect x="307.865252" y="333.713314" width="61.326282" height="91.467932" style="fill: rgb(72, 172, 90);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="506.954245" y="574.295746" width="32.626097" height="29.704254" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(315.865252,349.313314) scale(0.429226)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">ls.go 84.6%</text>
-		
-</g>
-
-
-<g>
-	<rect x="330.901887" y="492.787497" width="38.289646" height="77.943897" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(338.901887,508.387497) scale(0.165846)"
+	transform="translate(514.954245,589.895746) scale(0.086594)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">mode.go 100.0%</text>
+	data-math="N">importmode.go 100.0%</text>
 		
 </g>
 
 
 <g>
-	<rect x="36.000000" y="509.876446" width="95.882338" height="94.123554" style="fill: rgb(4, 116, 61);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="384.413573" y="377.162453" width="91.328251" height="84.528158" style="fill: rgb(12, 128, 68);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(44.000000,525.476446) scale(0.594363)"
+	transform="translate(392.413573,392.762453) scale(0.490418)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">inspect.go 94.9%</text>
+		
+</g>
+
+
+<g>
+	<rect x="442.371999" y="469.690611" width="56.582247" height="44.909901" style="fill: rgb(30, 153, 80);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(450.371999,485.290611) scale(0.384302)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">ls.go 89.7%</text>
+		
+</g>
+
+
+<g>
+	<rect x="579.838848" y="564.515573" width="14.332812" height="18.380237" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+</g>
+
+
+<g>
+	<rect x="384.413573" y="469.690611" width="49.958426" height="73.319651" style="fill: rgb(4, 116, 61);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(392.413573,485.290611) scale(0.252667)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
 	data-math="N">parse.go 97.5%</text>
 		
@@ -538,135 +566,175 @@
 
 
 <g>
-	<rect x="281.526264" y="578.731395" width="31.860529" height="25.268605" style="fill: rgb(102, 189, 99);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-</g>
-
-
-<g>
-	<rect x="36.000000" y="333.713314" width="95.882338" height="168.163131" style="fill: rgb(27, 153, 80);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="547.580342" y="519.189529" width="23.195039" height="37.326044" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(44.000000,349.313314) scale(0.554738)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">schema.go 89.9%</text>
+	transform="translate(555.580342,534.789529) scale(0.037474)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">pathexpand.go 100.0%</text>
 		
 </g>
 
 
 <g>
-	<rect x="36.000000" y="63.200000" width="170.439250" height="262.513314" style="fill: rgb(111, 193, 100);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="502.994709" y="267.860185" width="91.176951" height="101.302268" style="fill: rgb(9, 124, 66);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(510.994709,283.460185) scale(0.489433)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">profile.go 95.7%</text>
+		
+</g>
+
+
+<g>
+	<rect x="547.580342" y="564.515573" width="24.258506" height="17.568538" style="fill: rgb(64, 168, 88);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+</g>
+
+
+<g>
+	<rect x="253.279378" y="267.860185" width="123.134194" height="196.866522" style="fill: rgb(36, 156, 82);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(261.279378,283.460185) scale(0.858447)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">save.go 89.0%</text>
+		
+</g>
+
+
+<g>
+	<rect x="384.413573" y="267.860185" width="110.581137" height="101.302268" style="fill: rgb(5, 117, 62);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(392.413573,283.460185) scale(0.656813)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">schema.go 97.3%</text>
+		
+</g>
+
+
+<g>
+	<rect x="36.000000" y="63.200000" width="209.279378" height="308.156522" style="fill: rgb(20, 143, 75);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
 	transform="translate(44.000000,78.800000) scale(1.000000)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">shell.go 78.6%</text>
+	data-math="N">shell.go 91.9%</text>
 		
 </g>
 
 
 <g>
-	<rect x="139.882338" y="333.713314" width="82.657445" height="91.467932" style="fill: rgb(67, 170, 89);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="543.593461" y="377.162453" width="50.578199" height="84.528158" style="fill: rgb(16, 135, 71);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(147.882338,349.313314) scale(0.495963)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">state.go 85.3%</text>
-		
-</g>
-
-
-<g>
-	<rect x="139.882338" y="433.181246" width="60.226394" height="81.409377" style="fill: rgb(85, 180, 94);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(147.882338,448.781246) scale(0.307128)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">tables.go 82.6%</text>
-		
-</g>
-
-
-<g>
-	<rect x="361.247322" y="595.365697" width="7.944212" height="8.634303" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-</g>
-
-
-<g>
-	<rect x="401.191533" y="84.800000" width="251.925658" height="232.655982" style="fill: rgb(72, 172, 90);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(409.191533,100.400000) scale(1.000000)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">adapter.go 84.6%</text>
-		
-</g>
-
-
-<g>
-	<rect x="401.191533" y="325.455982" width="251.925658" height="28.957883" style="fill: rgb(180, 223, 114);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-</g>
-
-
-<g>
-	<rect x="571.076664" y="516.542800" width="16.861239" height="57.592900" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-<text 
-	data-notex="1" 
-	text-anchor="start"
-	transform="translate(579.076664,532.142800) scale(0.004722)"
+	transform="translate(551.593461,392.762453) scale(0.257278)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">delimited.go 100.0%</text>
+	data-math="N">state.go 93.5%</text>
 		
 </g>
 
 
 <g>
-	<rect x="502.708258" y="516.542800" width="60.368406" height="42.354145" style="fill: rgb(143, 207, 103);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="483.741823" y="377.162453" width="51.851638" height="84.528158" style="fill: rgb(15, 134, 71);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(510.708258,532.142800) scale(0.330122)"
-	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">excel.go 73.7%</text>
+	transform="translate(491.741823,392.762453) scale(0.248970)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">tables.go 93.6%</text>
 		
 </g>
 
 
 <g>
-	<rect x="571.076664" y="582.135700" width="16.861239" height="13.864300" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
-	
-</g>
-
-
-<g>
-	<rect x="401.191533" y="516.542800" width="93.516724" height="79.457200" style="fill: rgb(118, 196, 100);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="626.171660" y="84.800000" width="157.006983" height="120.999083" style="fill: rgb(20, 143, 75);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 <text 
 	data-notex="1" 
 	text-anchor="start"
-	transform="translate(409.191533,532.142800) scale(0.504666)"
+	transform="translate(634.171660,100.400000) scale(0.918014)"
 	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
-	data-math="N">history.go 77.6%</text>
+	data-math="N">adapter.go 91.8%</text>
 		
 </g>
 
 
 <g>
-	<rect x="502.708258" y="566.896946" width="60.368406" height="29.103054" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	<rect x="760.621795" y="213.799083" width="22.556849" height="32.657299" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(768.621795,229.399083) scale(0.032524)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(255, 255, 255); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">compression.go 100.0%</text>
+		
+</g>
+
+
+<g>
+	<rect x="626.171660" y="213.799083" width="126.450134" height="32.657299" style="fill: rgb(70, 171, 89);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(634.171660,229.399083) scale(0.719076)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">parquet.go 84.8%</text>
+		
+</g>
+
+
+<g>
+	<rect x="952.835428" y="163.342956" width="24.043741" height="11.250468" style="fill: rgb(0, 104, 55);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+</g>
+
+
+<g>
+	<rect x="909.999178" y="126.592062" width="34.836250" height="48.001363" style="fill: rgb(41, 157, 82);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(917.999178,142.192062) scale(0.140151)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">excel.go 88.6%</text>
+		
+</g>
+
+
+<g>
+	<rect x="909.999178" y="84.800000" width="74.000822" height="33.792062" style="fill: rgb(46, 159, 83);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
+	
+<text 
+	data-notex="1" 
+	text-anchor="start"
+	transform="translate(917.999178,100.400000) scale(0.377610)"
+	style="font-family: Open Sans, verdana, arial, sans-serif !important; font-size: 12px; fill: rgb(0, 0, 0); fill-opacity: 1.00; white-space: pre;" 
+	data-math="N">history.go 88.0%</text>
+		
+</g>
+
+
+<g>
+	<rect x="952.835428" y="126.592062" width="31.164572" height="28.750894" style="fill: rgb(64, 168, 88);opacity:1;fill-opacity:1.00;stroke:rgb(128,128,128);stroke-width:1px;stroke-opacity:1.00;" />
 	
 </g>
 


### PR DESCRIPTION
Release v0.27.1.

This release fixes three import/export data-integrity bugs and substantially expands the atago end-to-end suite.

Bug fixes:
- A leading Unicode BOM (UTF-8 or UTF-16) no longer corrupts CSV/TSV/LTSV/JSON/JSONL imports (requires filesql v0.17.1).
- A zero-padded numeric code such as `02134` keeps its leading zeros instead of importing as `2134` (requires filesql v0.17.2).
- Excel export adapts a table name to Excel's worksheet-name rules, so a long or punctuated name no longer fails the `.xlsx` write.

Testing: new atago suites cover Unicode BOM handling, zero-padded codes, Excel sheet-name limits, join semantics, shell navigate/inspect error paths, compression round-trips across every writable codec, in-place write-back for TSV/LTSV/Parquet, and non-CSV formats under compression.

Merging this finalizes the CHANGELOG; the v0.27.1 tag is pushed after merge and the release workflow publishes from the tag.