### PR TITLE
test(e2e): expand the interactive-shell pty suite and run it on Windows via ConPTY

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.5.1
+          version: v0.7.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the atago
       # suite runs a `go build -cover` sqly and collects covdata via

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -31,9 +31,48 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.5.1
+          version: v0.7.0
 
       - name: Run atago end-to-end tests
         # The hermetic runner builds sqly and runs the suite in a temp-backed
-        # HOME/config sandbox, so local and CI execution are identical.
+        # HOME/config sandbox, so local and CI execution are identical. The suite
+        # includes the interactive-shell pty specs, which run over a real pty here.
         run: make test-e2e
+
+  # The interactive shell (its readline REPL) is the one path the POSIX pty
+  # harness (e2e/pty_e2e_test.go) cannot cover on Windows, because it needs a
+  # POSIX pty. atago >= v0.7.0 drives a ConPTY on Windows, so e2e/atago/pty.atago.yaml
+  # gives Windows real interactive-shell coverage — prompt rendering, dot-commands,
+  # a live .mode switch, error recovery, and a clean EOF exit — not just the batch
+  # smoke tests. Serialized so the concurrent ConPTY sessions do not starve each
+  # other, with --retry-failed for the residual readline read-readiness race.
+  atago-windows:
+    name: atago interactive shell (Windows ConPTY)
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Install atago
+        uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
+        with:
+          version: v0.7.0
+
+      - name: Build sqly
+        run: go build -o sqly.exe main.go
+
+      - name: Run the interactive-shell pty specs
+        shell: bash
+        run: |
+          export PATH="$PWD:$PATH"
+          export HOME="$RUNNER_TEMP/sqlyhome"
+          export USERPROFILE="$HOME"
+          export SQLY_HISTORY_DB_PATH="$RUNNER_TEMP/history.db"
+          mkdir -p "$HOME"
+          atago run --ci --parallel 1 --retry-failed 3 ./e2e/atago/pty.atago.yaml

--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -1,13 +1,24 @@
-# PTY tests for sqly's interactive shell. A `run:` step feeds stdin as a
-# non-TTY batch script, which never exercises the REPL prompt, completion, or
-# the TTY-detection branch. A `pty:` step runs sqly inside a real pseudo-
-# terminal and drives it with an expect/send session, so the interactive path
-# (prompt rendering, per-command execution, live .mode switching, clean exit)
-# is verified end to end against the real binary.
+# PTY tests for sqly's interactive shell (its readline REPL). A `run:` step feeds
+# stdin as a non-TTY batch script and never exercises the prompt; a `pty:` step
+# runs sqly inside a real pseudo-terminal and drives it with an expect/send
+# session, so the interactive path — prompt rendering, per-command execution,
+# dot-commands, live .mode switching, error recovery, and clean exit — is
+# verified end to end against the real binary.
 #
-# POSIX-only: the pty step reports a clear error on Windows, so these scenarios
-# skip there. Windows keeps its coverage through the Go tests and the batch
-# specs. Run with: make test-e2e
+# These run on every OS: atago's pty runner speaks a POSIX pty on Unix and a
+# ConPTY on Windows (atago >= v0.7.0), so the interactive shell is covered on
+# Windows too, not just through the batch smoke tests. Two authoring rules keep
+# the sessions robust, including when the whole suite runs in parallel and the
+# sessions starve each other of CPU:
+#
+#   * Enter is `{key: enter}` (a raw CR, 0x0d); a bare "\n" is not the Return key
+#     a raw-mode line editor waits for, and a Windows ConPTY needs the CR.
+#   * Quit with EOF (`send: ""`, a single ^D) after the prompt returns, not by
+#     typing ".exit" — a one-byte terminal EOF cannot race the completer or the
+#     prompt's read-readiness the way a multi-character command submitted with
+#     Enter can. After a query, wait for a token that appears only in the
+#     executed result before expecting the prompt again, or the prompt echoed
+#     mid-typing would match too early.
 version: "1"
 
 suite:
@@ -15,8 +26,6 @@ suite:
 
 scenarios:
   - name: an interactive query prints its result table
-    skip:
-      os: windows
     steps:
       - fixture: &people
           file: people.csv
@@ -27,35 +36,148 @@ scenarios:
             Carol,41,Kyoto
       - pty:
           command: sqly people.csv
-          timeout: 20s
+          rows: 24
+          cols: 80
+          timeout: 30s
           session:
-            # The prompt ends with "(<mode>)$ "; table is the default mode.
-            - expect: '\(table\)\$'
-            - send: "SELECT name FROM people WHERE age = 25;\n"
-            # Bob is the only 25-year-old, so it appears in the result table but
-            # not in the echoed query text.
-            - expect: "Bob"
-            - expect: '\(table\)\$'
-            - send: ".exit\n"
+            - expect: '\(table\)\$' # the prompt ends with "(<mode>)$ "; table is default
+            - send: "SELECT name FROM people WHERE age = 25;"
+            - send: { key: enter }
+            - expect: "Bob" # Bob is the only 25-year-old; a result token, not echoed text
+            - expect: '\(table\)\$' # the prompt returned, editor idle again
+            - send: "" # EOF (^D) quits cleanly
       - assert:
           exit_code: 0
           stdout:
-            contains: "Bob"
+            contains:
+              - "Bob"
+              - "+--" # the box-drawn result table sqly renders to the terminal
 
   - name: the prompt reflects a live .mode switch
-    skip:
-      os: windows
     steps:
       - fixture: *people
       - pty:
           command: sqly people.csv
-          timeout: 20s
+          timeout: 30s
           session:
             - expect: '\(table\)\$'
-            - send: ".mode csv\n"
-            # The mode-change status goes to stderr, which the pty transcript
-            # merges in, and the next prompt now reports the csv mode.
-            - expect: '\(csv\)\$'
-            - send: ".exit\n"
+            - send: ".mode csv"
+            - send: { key: enter }
+            - expect: '\(csv\)\$' # the mode change is live: the next prompt says csv
+            - send: ""
+      - assert:
+          exit_code: 0
+
+  - name: .tables lists the imported table
+    steps:
+      - fixture: *people
+      - pty:
+          command: sqly people.csv
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: ".tables"
+            - send: { key: enter }
+            - expect: "people" # the imported CSV became the "people" table
+            - expect: '\(table\)\$'
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "people"
+
+  - name: .schema shows the imported columns
+    steps:
+      - fixture: *people
+      - pty:
+          command: sqly people.csv
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: ".schema people" # .schema requires a table name
+            - send: { key: enter }
+            - expect: "city" # a column from the CREATE TABLE DDL, post-execution
+            - expect: '\(table\)\$'
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "CREATE TABLE"
+              - "city"
+
+  - name: a computed aggregate round-trips through the shell
+    steps:
+      - fixture: *people
+      - pty:
+          command: sqly people.csv
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            # A distinctive, self-labeling result so the wait cannot match stray
+            # output — the count of the three imported rows.
+            - send: "SELECT 'ROWS=' || COUNT(*) AS r FROM people;"
+            - send: { key: enter }
+            - expect: "ROWS=3"
+            - expect: '\(table\)\$'
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "ROWS=3"
+
+  - name: two queries run in one interactive session
+    steps:
+      - fixture: *people
+      - pty:
+          command: sqly people.csv
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: "SELECT name FROM people WHERE city = 'Tokyo';"
+            - send: { key: enter }
+            - expect: "Alice"
+            - expect: '\(table\)\$'
+            - send: "SELECT name FROM people WHERE city = 'Kyoto';"
+            - send: { key: enter }
+            - expect: "Carol"
+            - expect: '\(table\)\$'
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "Alice"
+              - "Carol"
+
+  - name: an invalid query reports an error and the shell recovers to the prompt
+    steps:
+      - fixture: *people
+      - pty:
+          command: sqly people.csv
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: "SELECT * FROM no_such_table;"
+            - send: { key: enter }
+            - expect: "no such table" # the query error is reported, not swallowed
+            - expect: '\(table\)\$' # the shell recovered to a working prompt (it did
+              # not exit on the error) — the clean EOF exit below confirms it is
+              # still reading input.
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "no such table"
+
+  - name: EOF at the prompt exits the shell cleanly
+    steps:
+      - fixture: *people
+      - pty:
+          command: sqly people.csv
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: "" # EOF (^D) at an empty prompt exits with status 0
       - assert:
           exit_code: 0

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -72,4 +72,10 @@ export PATH
 # No `exec`: it would replace the shell and skip the EXIT trap, leaking the
 # sandbox. As the last command under `set -e`, atago's exit status is the
 # script's exit status either way.
-atago run --ci "$@" "$ROOT/e2e/atago"
+#
+# --retry-failed absorbs the inherently racy interactive-shell specs
+# (e2e/atago/pty.atago.yaml drives sqly's readline REPL over a pty; the prompt is
+# re-rendered a beat before its read loop is ready, so a fast keystroke can be
+# lost under parallel load). A recovered scenario is reported as flaky, never
+# hidden, and a real regression still fails after the retries.
+atago run --ci --retry-failed 3 "$@" "$ROOT/e2e/atago"


### PR DESCRIPTION
## Summary

atago v0.7.0 drives a Windows ConPTY for its `pty:` step, so the interactive-shell E2E in `e2e/atago/pty.atago.yaml` can now run on Windows too — the one path the POSIX pty harness (`e2e/pty_e2e_test.go`) cannot cover because it needs a POSIX pty. This expands that suite from two scenarios to eight and adds a Windows CI leg, so the readline REPL gets real interactive coverage on every OS instead of only the batch smoke tests on Windows.

## Changes

- `e2e/atago/pty.atago.yaml`: grow from two scenarios to eight and drop the `skip: {os: windows}` gates. New coverage: a query result table (with the box-drawn output), a live `.mode` switch, `.tables`, `.schema TABLE`, a computed aggregate round trip, two queries in one session, a query error that is reported while the shell recovers to a working prompt, and a clean EOF exit. Two authoring rules keep the sessions robust across platforms: Enter is `{key: enter}` (a raw CR, which a raw-mode line editor and a ConPTY both need — a bare `\n` is not the Return key), and each session quits with EOF (`send: ""`, a single Ctrl-D) after the prompt returns rather than typing `.exit`, since a one-byte terminal EOF cannot race the completer or the prompt's read-readiness the way a multi-character command can.
- `.github/workflows/e2e_test.yml`: bump atago to v0.7.0 and add an `atago-windows` job that builds sqly, then runs the pty specs over a ConPTY (`--parallel 1` so the concurrent sessions do not starve each other, `--retry-failed 3` for the residual readline read-readiness race).
- `.github/workflows/coverage.yml`: bump atago to v0.7.0 to match.
- `scripts/run_e2e.sh`: run the suite with `--retry-failed 3`, since the interactive-shell specs are inherently racy when the whole suite runs in parallel. A recovered scenario is reported as flaky, never hidden, and a real regression still fails after the retries.

## Notes

The interactive REPL over a pty is inherently racy: the prompt is re-rendered a beat before its read loop is ready, and there is no output signal to expect on for read-readiness, so a fast keystroke can occasionally be lost under parallel load. `--retry-failed` absorbs that without hiding real failures. The error-recovery scenario asserts the shell reports a query error and then accepts a clean EOF exit, which proves it recovered to a working prompt without piling on a second fragile query round trip.

Only the pty specs are enabled on Windows here. The rest of `e2e/atago` is `sqly --sql` batch coverage that already runs on Linux and macOS; extending the whole suite to Windows is a separate, larger step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end coverage for the interactive shell, including more reliable prompt handling, query execution, error recovery, and clean exit behavior.
  * Added Windows coverage for interactive shell testing to help catch platform-specific issues.
* **Tests**
  * Expanded interactive test scenarios and increased retry handling for flaky end-to-end runs.
  * Updated CI workflows to use a newer testing tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->