### PR TITLE
fix(shell): hold raw mode across prompts to stop interactive input loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Bug Fixes
+* Interactive Input Lost Between Lines: keystrokes typed right after a result, or a script piped into the interactive shell all at once, are no longer dropped. The shell re-acquired raw mode on every prompt, so input buffered while the terminal briefly returned to cooked mode between lines could be lost and the session would hang; automated interactive runs needed retries to absorb it. The shell now keeps the terminal in raw mode for the whole session (prompt v0.0.9 WithPersistentRawMode), which also disables the terminal's own newline translation, so command output is routed through a CRLF writer while the shell is interactive to keep result tables aligned.
+
+### Testing
+* Rapid Interactive Input E2E: the Go pty smoke suite adds a scenario that writes several queries plus the exit command to the interactive shell as a single burst and asserts every result appears and the session exits cleanly, so a regression that drops buffered input surfaces as a missing marker or a hang. It also asserts raw mode is entered exactly once per session.
+
+### Dependencies
+* prompt v0.0.9: upgraded from v0.0.8 for WithPersistentRawMode.
+
 ## [v0.27.1](https://github.com/nao1215/sqly/compare/v0.27.0...v0.27.1) (2026-07-06)
 
 ### Bug Fixes

--- a/config/tty.go
+++ b/config/tty.go
@@ -12,3 +12,13 @@ import (
 func IsInputFromTTY() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
+
+// IsOutputToTTY reports whether standard output is connected to an interactive
+// terminal. The interactive shell holds the terminal in raw mode across prompts,
+// which disables the terminal's own LF-to-CRLF mapping; the shell uses this to
+// decide whether command output needs explicit CRLF translation so results stay
+// aligned. When stdout is piped or redirected it returns false and output is left
+// untouched.
+func IsOutputToTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/e2e/pty_e2e_test.go
+++ b/e2e/pty_e2e_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -275,5 +276,71 @@ func TestInteractivePTY_ExitOnCtrlD(t *testing.T) {
 	s.write("\x04") // Ctrl-D / EOF
 	if code := s.waitExit(exitTimeout); code != 0 {
 		t.Fatalf("interactive shell: Ctrl-D produced exit code %d, want 0", code)
+	}
+}
+
+// rawCount returns how many times want appears in the unstripped captured output.
+// It is used to assert on the raw terminal control bytes (the bracketed-paste
+// enable the prompt emits once when it enters raw mode) that stripANSI removes.
+func (s *ptySession) rawCount(want string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return strings.Count(s.buf.String(), want)
+}
+
+// bracketedPasteEnable is the control sequence the prompt writes each time it
+// enters raw mode. sqly holds the terminal in raw mode for the whole session
+// (prompt.WithPersistentRawMode), so it appears exactly once; if the shell
+// regressed to re-acquiring raw mode on every line it would appear once per
+// prompt, which is the toggling that lets input be dropped between lines.
+const bracketedPasteEnable = "\x1b[?2004h"
+
+// TestInteractivePTY_RapidConsecutiveLinesNotLost reproduces the interactive
+// input-loss bug (prompt issue #10): a driver that dumps several lines back to
+// back — as a pipe or pty driver does — with no delay between them must have
+// every line consumed. Before the fix the shell restored and re-acquired raw mode
+// around every command, so a line already buffered when the next prompt was
+// rendered could be dropped in the mode-switch window and the session would hang.
+//
+// All queries plus a trailing ".exit" are written as a single burst so the whole
+// script is buffered before the shell reads it, exercising the many-lines-at-once
+// path deterministically. Each query selects a distinct marker, so a lost line
+// surfaces as a missing marker or as the process failing to exit. The test also
+// asserts raw mode was entered exactly once, pinning the persistent-raw-mode
+// contract that closes the loss window.
+func TestInteractivePTY_RapidConsecutiveLinesNotLost(t *testing.T) {
+	s := startPTYSession(t, filepath.Join("testdata", "user.csv"))
+	t.Cleanup(s.close)
+
+	s.waitReady(startupTimeout)
+
+	const lines = 10
+	var burst strings.Builder
+	for i := range lines {
+		// A distinct string literal per line; "sqlymark<i>" is unlikely to collide
+		// with any other terminal text, so its presence proves the line reached the
+		// prompt's read loop rather than being dropped in a mode-switch window.
+		fmt.Fprintf(&burst, "SELECT 'sqlymark%d';\r", i)
+	}
+	burst.WriteString(".exit\r")
+
+	// One write, no inter-line pauses: the whole script arrives at once.
+	s.write(burst.String())
+
+	// Every marker must appear; a dropped line would never echo or execute.
+	for i := range lines {
+		s.waitFor(fmt.Sprintf("sqlymark%d", i), ioTimeout)
+	}
+
+	// The trailing ".exit" must still be reached, proving the session processed the
+	// entire burst without hanging on a lost line.
+	if code := s.waitExit(exitTimeout); code != 0 {
+		t.Fatalf("interactive shell: rapid burst produced exit code %d, want 0 (a lost line would hang the session)", code)
+	}
+
+	// Raw mode must have been entered once for the whole session, not per line.
+	// Per-line re-acquisition is the toggling that opens the input-loss window.
+	if got := s.rawCount(bracketedPasteEnable); got != 1 {
+		t.Fatalf("interactive shell: raw mode entered %d times across the session, want 1 (persistent raw mode)", got)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/nao1215/filesql v0.17.2
-	github.com/nao1215/prompt v0.0.8
+	github.com/nao1215/prompt v0.0.9
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/nao1215/fileparser v0.5.2 h1:IXhH5m3UJf/TMidfTcVen8CSlZ4KEFEgBz6+2o+5
 github.com/nao1215/fileparser v0.5.2/go.mod h1:Jb16QbtYfgzQ2BR+UOVNSa1WeKMP2o+xnwBYFUNAG2Y=
 github.com/nao1215/filesql v0.17.2 h1:UYRhDgtzytWVlITVXw3//wc0lVyxQb9Xe9hpfYqDX5Y=
 github.com/nao1215/filesql v0.17.2/go.mod h1:83+ne68S+HKb7f93Nl2draIM26gl9tnQp+EpsgWXgss=
-github.com/nao1215/prompt v0.0.8 h1:5Oa8AAb53IAqgTuHnZ5X/5maNgmYrIh+aPaEuUauyPs=
-github.com/nao1215/prompt v0.0.8/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
+github.com/nao1215/prompt v0.0.9 h1:Jh9gMy+xOkGuVaWoN8aat0VIZzCaMa2eknbFuQZdO3o=
+github.com/nao1215/prompt v0.0.9/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=

--- a/shell/crlf.go
+++ b/shell/crlf.go
@@ -1,0 +1,66 @@
+package shell
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/nao1215/sqly/config"
+)
+
+// crlfWriter translates a lone LF ("\n") into CRLF ("\r\n") on the way to the
+// underlying writer, leaving an existing CRLF untouched.
+//
+// The interactive shell keeps the terminal in raw mode across prompts
+// (prompt.WithPersistentRawMode) so keystrokes typed between one result and the
+// next prompt are never dropped. Raw mode disables the terminal's own output
+// post-processing (OPOST/ONLCR), so command output written with "\n" would
+// staircase down the screen instead of returning to the left margin. Wrapping the
+// shell's output writers restores the alignment without touching every print
+// site.
+type crlfWriter struct {
+	mu     sync.Mutex
+	w      io.Writer
+	lastCR bool // the previous byte written was CR, so a following LF already forms CRLF
+}
+
+// Write translates lone LFs to CRLF and forwards the result to the wrapped
+// writer. It reports len(p) consumed on success so callers see their whole input
+// accepted regardless of the extra CR bytes added downstream.
+func (c *crlfWriter) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var buf bytes.Buffer
+	buf.Grow(len(p) + bytes.Count(p, []byte{'\n'}))
+	for _, b := range p {
+		if b == '\n' && !c.lastCR {
+			buf.WriteByte('\r')
+		}
+		buf.WriteByte(b)
+		c.lastCR = b == '\r'
+	}
+	if _, err := c.w.Write(buf.Bytes()); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// installCRLFTranslation routes the shell's command output (config.Stdout and
+// config.Stderr) through crlfWriter for the duration of an interactive session
+// and returns a function that restores the original writers. It is a no-op when
+// stdout is not a terminal (piped or redirected, and in tests), because raw mode
+// only affects a real terminal; there the caller gets back an unchanged restore
+// function so batch output keeps plain "\n".
+func installCRLFTranslation() func() {
+	if !config.IsOutputToTTY() {
+		return func() {}
+	}
+	prevOut, prevErr := config.Stdout, config.Stderr
+	config.Stdout = &crlfWriter{w: prevOut}
+	config.Stderr = &crlfWriter{w: prevErr}
+	return func() {
+		config.Stdout = prevOut
+		config.Stderr = prevErr
+	}
+}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -164,6 +164,7 @@ func NewShell(
 				prompt.WithIsComplete(sqlInputComplete),
 				prompt.WithWordEscape(),
 				prompt.WithKeyMap(sqlyKeyMap()),
+				prompt.WithPersistentRawMode(),
 			)
 		},
 		stdin:          os.Stdin,
@@ -396,6 +397,11 @@ func (s *Shell) communicate(ctx context.Context) error {
 
 	// The prompt session is ready, so it is now safe to announce the shell.
 	s.printWelcomeMessage()
+
+	// Persistent raw mode disables the terminal's LF-to-CRLF mapping, so route
+	// command output through CRLF translation for the session. Restored on exit.
+	restoreOutput := installCRLFTranslation()
+	defer restoreOutput()
 
 	for {
 		input, err := s.prompt(p)


### PR DESCRIPTION
## Summary

The interactive shell re-acquired raw mode on every prompt, so input buffered while the terminal briefly returned to cooked mode between lines could be dropped and the session would hang. A pipe or pseudo-terminal driver that sends several lines at once was most affected, and automated interactive runs needed retries to absorb it. This adopts prompt v0.0.9 `WithPersistentRawMode`, which keeps the terminal in raw mode for the whole session. Refs nao1215/prompt#10.

## Changes

- `shell/shell.go`: pass `prompt.WithPersistentRawMode()` to the interactive prompt so raw mode is entered once per session, not once per line.
- `shell/crlf.go`: raw mode disables the terminal's own LF-to-CRLF mapping, so route command output (`config.Stdout`/`config.Stderr`) through a CRLF writer for the duration of an interactive session so result tables are not staircased; a new `crlfWriter` translates lone `\n` to `\r\n` and leaves existing CRLF untouched.
- `config/tty.go`: add `IsOutputToTTY` so CRLF translation is installed only when stdout is a real terminal, leaving batch and redirected output with plain `\n`.
- `e2e/pty_e2e_test.go`: add a pty smoke test that writes several queries plus `.exit` as a single burst and asserts every result appears, the session exits cleanly, and raw mode is entered exactly once per session.
- `go.mod`: upgrade `github.com/nao1215/prompt` from v0.0.8 to v0.0.9.

## Design Decisions

CRLF translation is scoped to the interactive session and gated on an output TTY rather than applied globally, so batch mode, `--sql`, and redirected output keep plain `\n`, and the existing in-process tests that swap `config.Stdout` to a buffer are unaffected. The regression test drives the shell with a single pre-buffered burst because that path is deterministic: it reproduces the pipe/pty case where the whole script is buffered before the shell reads it, and it is not subject to the separate read-readiness race described below. Raw-mode entry is asserted through the bracketed-paste-enable sequence the prompt emits once on entry, which is a deterministic signal that the terminal is held in raw mode across prompts.

## Limitations

A separate read-readiness race remains: the prompt is rendered before its read loop becomes active, so a driver that types the instant it sees a fresh prompt can still lose that line. `WithPersistentRawMode` closes the between-line mode-switch window (the pipe/burst case) but not this within-line gap, so the `--retry-failed` safety net on the atago pty specs is kept. Fully closing it needs a read-readiness marker in the prompt library, which is out of scope here.

https://claude.ai/code/session_017gnwF9zFW6RHjDmfzqKZ2G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interactive shell input loss between prompts, improving reliability in long-running sessions.
  * Improved terminal output handling so line endings display correctly in interactive terminals.

* **Tests**
  * Added an end-to-end interactive test that rapidly sends multiple commands to catch missed input or hangs.

* **Dependencies**
  * Updated a prompt-related dependency to support the improved interactive shell behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->