### PR TITLE
chore(release): v0.27.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v0.27.2](https://github.com/nao1215/sqly/compare/v0.27.1...v0.27.2) (2026-07-07)
+
 ### Bug Fixes
 * Interactive Input Lost Between Lines: keystrokes typed right after a result, or a script piped into the interactive shell all at once, are no longer dropped. The shell re-acquired raw mode on every prompt, so input buffered while the terminal briefly returned to cooked mode between lines could be lost and the session would hang; automated interactive runs needed retries to absorb it. The shell now keeps the terminal in raw mode for the whole session (prompt v0.0.9 WithPersistentRawMode), which also disables the terminal's own newline translation, so command output is routed through a CRLF writer while the shell is interactive to keep result tables aligned.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ A SQL statement is buffered until it ends with `;`, so a multi-line or pasted qu
 
 ```shell
 $ sqly testdata/user.csv
-sqly v0.27.1
+sqly v0.27.2
 
 enter "SQL query" or "sqly command that begins with a dot".
 .help print usage, .exit exit sqly.
@@ -562,7 +562,7 @@ SELECT * FROM `customers100000` WHERE `Index` BETWEEN 1000 AND 2000 ORDER BY `In
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.27.1. Run `make bench` to reproduce on your machine.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.27.2. Run `make bench` to reproduce on your machine.
 
 ## Comparison with similar tools
 


### PR DESCRIPTION
## Summary

Release v0.27.2. This is a bug-fix release that stops interactive input from being lost between lines: the shell now holds the terminal in raw mode across prompts (prompt v0.0.9 WithPersistentRawMode) instead of re-acquiring it per line.

## Changes

- Stamp `CHANGELOG.md` with the `v0.27.2` heading (dated 2026-07-07), moving the entries from `Unreleased`.
- Bump the `sqly vX.Y.Z` references in `README.md` to v0.27.2 to match the changelog.

## Release notes

### Bug Fixes
* Interactive Input Lost Between Lines: keystrokes typed right after a result, or a script piped into the interactive shell all at once, are no longer dropped. The shell re-acquired raw mode on every prompt, so input buffered while the terminal briefly returned to cooked mode between lines could be lost and the session would hang. The shell now keeps the terminal in raw mode for the whole session, and routes command output through a CRLF writer while interactive so result tables stay aligned.

### Testing
* Rapid Interactive Input E2E: the Go pty smoke suite adds a scenario that bursts several queries plus the exit command into the interactive shell in one write and asserts every result appears, the session exits cleanly, and raw mode is entered exactly once per session.

### Dependencies
* prompt v0.0.9: upgraded from v0.0.8 for WithPersistentRawMode.

https://claude.ai/code/session_017gnwF9zFW6RHjDmfzqKZ2G