### PR TITLE
fix(shell): apply prompt v0.0.11 and unskip Windows ConPTY pty E2E

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.7.0
+          version: v0.8.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the atago
       # suite runs a `go build -cover` sqly and collects covdata via

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.7.0
+          version: v0.8.0
 
       - name: Run atago end-to-end tests
         # The hermetic runner builds sqly and runs the suite in a temp-backed
@@ -45,7 +45,7 @@ jobs:
   # gives Windows real interactive-shell coverage — prompt rendering, dot-commands,
   # a live .mode switch, error recovery, and a clean EOF exit — not just the batch
   # smoke tests. Serialized so the concurrent ConPTY sessions do not starve each
-  # other, with --retry-failed for the residual readline read-readiness race.
+  # other, with --retry-failed as a safety net against CPU-starvation flakes.
   atago-windows:
     name: atago interactive shell (Windows ConPTY)
     runs-on: windows-latest
@@ -62,7 +62,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.7.0
+          version: v0.8.0
 
       - name: Build sqly
         run: go build -o sqly.exe main.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+* Interactive Input Lost on Windows: keystrokes typed right after a re-rendered prompt in the interactive shell are no longer dropped on a Windows ConPTY. The prompt library entered raw mode on os.Stdin while reading input through a different handle (CONIN$ on Windows), so on a ConPTY input delivered in the render-to-read window went to an ungoverned handle and could be lost, leaving a command typed but never executed and the session hung. prompt v0.0.10 routes raw mode through the same handle it reads from, closing the gap.
+
 ### Testing
-* Stabilize the interactive-shell pty E2E: the atago pty specs drive sqly's readline REPL over a pseudo-terminal, where the prompt is re-rendered a beat before its read loop is ready. On Unix each command now submits with a trailing CR in the same send (`"...\r"`) instead of a separate `{key: enter}` step, so the Enter is read together with the command and can no longer be dropped, and `make test-e2e` runs the pty specs in their own `--parallel 1` pass so they get uncontended CPU. On a Windows ConPTY the input delivered in the render-to-read window is dropped rather than buffered, which no test-side change fixes reliably, so the pty specs are skipped there and the behavior is tracked upstream at github.com/nao1215/prompt/issues/13; Windows binary behavior stays covered by the batch smoke tests.
+* Interactive-shell pty E2E on Windows: the atago pty specs that drive sqly's readline REPL now run on Windows ConPTY too. They were skipped there while the raw-mode handle mismatch made the ConPTY sessions drop input; prompt v0.0.10 fixes that, so the `skip: { os: windows }` guards are removed and the interactive path is verified end to end on every platform. Each command still submits with a trailing CR in the same send (`"...\r"`), and `make test-e2e` runs the pty specs in their own `--parallel 1` pass so they get uncontended CPU.
+
+### Dependencies
+* prompt v0.0.10: upgraded from v0.0.9 for the raw-mode single-handle fix (github.com/nao1215/prompt/issues/13).
 
 ## [v0.27.2](https://github.com/nao1215/sqly/compare/v0.27.1...v0.27.2) (2026-07-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## [Unreleased]
 
 ### Bug Fixes
-* Interactive Input Lost on Windows: keystrokes typed right after a re-rendered prompt in the interactive shell are no longer dropped on a Windows ConPTY. The prompt library entered raw mode on os.Stdin while reading input through a different handle (CONIN$ on Windows), so on a ConPTY input delivered in the render-to-read window went to an ungoverned handle and could be lost, leaving a command typed but never executed and the session hung. prompt v0.0.10 routes raw mode through the same handle it reads from, closing the gap.
+* Interactive Input Lost on Windows: keystrokes typed right after a re-rendered prompt in the interactive shell are no longer dropped on a Windows ConPTY. The prompt library entered raw mode on os.Stdin while reading input through a different handle (CONIN$ on Windows), so on a ConPTY input delivered in the render-to-read window went to an ungoverned handle and could be lost, leaving a command typed but never executed and the session hung. prompt v0.0.11 routes raw mode through the read handle on Windows (while keeping the proven os.Stdin path on Unix), closing the gap.
 
 ### Testing
-* Interactive-shell pty E2E on Windows: the atago pty specs that drive sqly's readline REPL now run on Windows ConPTY too. They were skipped there while the raw-mode handle mismatch made the ConPTY sessions drop input; prompt v0.0.10 fixes that, so the `skip: { os: windows }` guards are removed and the interactive path is verified end to end on every platform. Each command still submits with a trailing CR in the same send (`"...\r"`), and `make test-e2e` runs the pty specs in their own `--parallel 1` pass so they get uncontended CPU.
+* Interactive-shell pty E2E on Windows: the atago pty specs that drive sqly's readline REPL now run on Windows ConPTY too. They were skipped there while the raw-mode handle mismatch made the ConPTY sessions drop input; prompt v0.0.11 fixes that, so the `skip: { os: windows }` guards are removed and the interactive path is verified end to end on every platform. Each command still submits with a trailing CR in the same send (`"...\r"`), and `make test-e2e` runs the pty specs in their own `--parallel 1` pass so they get uncontended CPU.
 
 ### Dependencies
-* prompt v0.0.10: upgraded from v0.0.9 for the raw-mode single-handle fix (github.com/nao1215/prompt/issues/13).
+* prompt v0.0.11: upgraded from v0.0.9 for the Windows raw-mode read-handle fix (github.com/nao1215/prompt/issues/13).
 
 ## [v0.27.2](https://github.com/nao1215/sqly/compare/v0.27.1...v0.27.2) (2026-07-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 * Interactive Input Lost on Windows: keystrokes typed right after a re-rendered prompt in the interactive shell are no longer dropped on a Windows ConPTY. The prompt library entered raw mode on os.Stdin while reading input through a different handle (CONIN$ on Windows), so on a ConPTY input delivered in the render-to-read window went to an ungoverned handle and could be lost, leaving a command typed but never executed and the session hung. prompt v0.0.11 routes raw mode through the read handle on Windows (while keeping the proven os.Stdin path on Unix), closing the gap.
 
 ### Testing
-* Interactive-shell pty E2E on Windows: the atago pty specs that drive sqly's readline REPL now run on Windows ConPTY too. They were skipped there while the raw-mode handle mismatch made the ConPTY sessions drop input; prompt v0.0.11 fixes that, so the `skip: { os: windows }` guards are removed and the interactive path is verified end to end on every platform. Each command still submits with a trailing CR in the same send (`"...\r"`), and `make test-e2e` runs the pty specs in their own `--parallel 1` pass so they get uncontended CPU.
+* Interactive-shell pty E2E on Windows: the atago pty specs that drive sqly's readline REPL now run on Windows ConPTY too. They were skipped there while the raw-mode handle mismatch made the ConPTY sessions drop input; prompt v0.0.11 fixes that, so the `skip: { os: windows }` guards are removed and the interactive path is verified end to end on every platform. Each command still submits with a trailing CR in the same send (`"...\r"`), the pty runs with a wide terminal (cols: 220) so the long CI sandbox path in the prompt cannot push a command onto the ConPTY last-column pending-wrap, and `make test-e2e` runs the pty specs in their own `--parallel 1` pass so they get uncontended CPU.
 
 ### Dependencies
 * prompt v0.0.11: upgraded from v0.0.9 for the Windows raw-mode read-handle fix (github.com/nao1215/prompt/issues/13).
+* atago v0.8.0: bumped the E2E runner from v0.7.0 in the e2e and coverage workflows.
 
 ## [v0.27.2](https://github.com/nao1215/sqly/compare/v0.27.1...v0.27.2) (2026-07-07)
 

--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -5,17 +5,15 @@
 # dot-commands, live .mode switching, error recovery, and clean exit — is
 # verified end to end against the real binary.
 #
-# These run on Unix (POSIX pty). They are skipped on Windows (ConPTY): the prompt
-# is re-rendered a beat before its read loop is ready, and on a ConPTY the input
-# delivered in that window is dropped rather than buffered, so a command is typed
-# but never executed and the session hangs. That is a terminal-backend race in the
-# prompt library, tracked upstream at github.com/nao1215/prompt/issues/13; it
-# cannot be fixed reliably from the test side (combining the command and its CR
-# into one send, serializing, and retrying all reduce but do not remove it). The
-# skip is removed once prompt#13 is fixed. Windows binary behavior stays covered by
-# the batch smoke tests. Two authoring rules keep the Unix sessions robust,
-# including when the whole suite runs in parallel and the sessions starve each
-# other of CPU:
+# These run on Unix (POSIX pty) and Windows (ConPTY). They were once skipped on
+# Windows: the prompt entered raw mode on os.Stdin while go-tty read from a
+# different handle (CONIN$), so on a ConPTY input delivered right after a
+# re-rendered prompt went to an ungoverned handle and could be dropped, leaving a
+# command typed but never executed and the session hung. prompt v0.0.10 routes raw
+# mode through go-tty's own handle (github.com/nao1215/prompt/issues/13), so the
+# read path and raw mode share one handle and the skip is gone. Two authoring
+# rules keep the sessions robust, including when the whole suite runs in parallel
+# and the sessions starve each other of CPU:
 #
 #   * Submit a command with a trailing CR in the same send (`"...\r"`), not a
 #     separate `{key: enter}` step. The prompt is re-rendered a beat before its
@@ -37,7 +35,6 @@ suite:
 
 scenarios:
   - name: an interactive query prints its result table
-    skip: { os: windows } # ConPTY read-readiness race (prompt#13); see file header
     steps:
       - fixture: &people
           file: people.csv
@@ -65,7 +62,6 @@ scenarios:
               - "+--" # the box-drawn result table sqly renders to the terminal
 
   - name: the prompt reflects a live .mode switch
-    skip: { os: windows } # ConPTY read-readiness race (prompt#13); see file header
     steps:
       - fixture: *people
       - pty:
@@ -80,7 +76,6 @@ scenarios:
           exit_code: 0
 
   - name: .tables lists the imported table
-    skip: { os: windows } # ConPTY read-readiness race (prompt#13); see file header
     steps:
       - fixture: *people
       - pty:
@@ -98,7 +93,6 @@ scenarios:
             contains: "people"
 
   - name: .schema shows the imported columns
-    skip: { os: windows } # ConPTY read-readiness race (prompt#13); see file header
     steps:
       - fixture: *people
       - pty:
@@ -118,7 +112,6 @@ scenarios:
               - "city"
 
   - name: a computed aggregate round-trips through the shell
-    skip: { os: windows } # ConPTY read-readiness race (prompt#13); see file header
     steps:
       - fixture: *people
       - pty:
@@ -138,7 +131,6 @@ scenarios:
             contains: "ROWS=3"
 
   - name: two queries run in one interactive session
-    skip: { os: windows } # ConPTY read-readiness race (prompt#13); see file header
     steps:
       - fixture: *people
       - pty:
@@ -161,7 +153,6 @@ scenarios:
               - "Carol"
 
   - name: an invalid query reports an error and the shell recovers to the prompt
-    skip: { os: windows } # ConPTY read-readiness race (prompt#13); see file header
     steps:
       - fixture: *people
       - pty:
@@ -181,7 +172,6 @@ scenarios:
             contains: "no such table"
 
   - name: EOF at the prompt exits the shell cleanly
-    skip: { os: windows } # ConPTY read-readiness race (prompt#13); see file header
     steps:
       - fixture: *people
       - pty:

--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -9,11 +9,11 @@
 # Windows: the prompt entered raw mode on os.Stdin while go-tty read from a
 # different handle (CONIN$), so on a ConPTY input delivered right after a
 # re-rendered prompt went to an ungoverned handle and could be dropped, leaving a
-# command typed but never executed and the session hung. prompt v0.0.10 routes raw
-# mode through go-tty's own handle (github.com/nao1215/prompt/issues/13), so the
-# read path and raw mode share one handle and the skip is gone. Two authoring
-# rules keep the sessions robust, including when the whole suite runs in parallel
-# and the sessions starve each other of CPU:
+# command typed but never executed and the session hung. prompt v0.0.11 routes raw
+# mode through go-tty's own handle on Windows (github.com/nao1215/prompt/issues/13),
+# so the read path and raw mode share one handle and the skip is gone. Three
+# authoring rules keep the sessions robust, including when the whole suite runs in
+# parallel and the sessions starve each other of CPU:
 #
 #   * Submit a command with a trailing CR in the same send (`"...\r"`), not a
 #     separate `{key: enter}` step. The prompt is re-rendered a beat before its
@@ -28,6 +28,13 @@
 #     Enter can. After a query, wait for a token that appears only in the
 #     executed result before expecting the prompt again, or the prompt echoed
 #     mid-typing would match too early.
+#   * Give the pty a wide terminal (cols: 220). The prompt embeds the working
+#     directory, and under CI the temp sandbox path is long, so prefix plus command
+#     can land a character exactly on the last column. ConPTY defers the wrap at the
+#     final column (pending-wrap), which the line editor's redraw math mishandles,
+#     so a command whose length hits the width boundary can fail to execute. A wide
+#     terminal keeps every prompt-plus-command on one row regardless of the sandbox
+#     path length.
 version: "1"
 
 suite:
@@ -45,8 +52,8 @@ scenarios:
             Carol,41,Kyoto
       - pty:
           command: sqly people.csv
-          rows: 24
-          cols: 80
+          rows: 30
+          cols: 220
           timeout: 30s
           session:
             - expect: '\(table\)\$' # the prompt ends with "(<mode>)$ "; table is default
@@ -66,6 +73,8 @@ scenarios:
       - fixture: *people
       - pty:
           command: sqly people.csv
+          rows: 30
+          cols: 220
           timeout: 30s
           session:
             - expect: '\(table\)\$'
@@ -80,6 +89,8 @@ scenarios:
       - fixture: *people
       - pty:
           command: sqly people.csv
+          rows: 30
+          cols: 220
           timeout: 30s
           session:
             - expect: '\(table\)\$'
@@ -97,6 +108,8 @@ scenarios:
       - fixture: *people
       - pty:
           command: sqly people.csv
+          rows: 30
+          cols: 220
           timeout: 30s
           session:
             - expect: '\(table\)\$'
@@ -116,6 +129,8 @@ scenarios:
       - fixture: *people
       - pty:
           command: sqly people.csv
+          rows: 30
+          cols: 220
           timeout: 30s
           session:
             - expect: '\(table\)\$'
@@ -135,6 +150,8 @@ scenarios:
       - fixture: *people
       - pty:
           command: sqly people.csv
+          rows: 30
+          cols: 220
           timeout: 30s
           session:
             - expect: '\(table\)\$'
@@ -157,6 +174,8 @@ scenarios:
       - fixture: *people
       - pty:
           command: sqly people.csv
+          rows: 30
+          cols: 220
           timeout: 30s
           session:
             - expect: '\(table\)\$'
@@ -176,6 +195,8 @@ scenarios:
       - fixture: *people
       - pty:
           command: sqly people.csv
+          rows: 30
+          cols: 220
           timeout: 30s
           session:
             - expect: '\(table\)\$'

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/nao1215/filesql v0.17.2
-	github.com/nao1215/prompt v0.0.9
+	github.com/nao1215/prompt v0.0.10
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sergi/go-diff v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/nao1215/filesql v0.17.2
-	github.com/nao1215/prompt v0.0.10
+	github.com/nao1215/prompt v0.0.11
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/nao1215/fileparser v0.5.2 h1:IXhH5m3UJf/TMidfTcVen8CSlZ4KEFEgBz6+2o+5
 github.com/nao1215/fileparser v0.5.2/go.mod h1:Jb16QbtYfgzQ2BR+UOVNSa1WeKMP2o+xnwBYFUNAG2Y=
 github.com/nao1215/filesql v0.17.2 h1:UYRhDgtzytWVlITVXw3//wc0lVyxQb9Xe9hpfYqDX5Y=
 github.com/nao1215/filesql v0.17.2/go.mod h1:83+ne68S+HKb7f93Nl2draIM26gl9tnQp+EpsgWXgss=
-github.com/nao1215/prompt v0.0.10 h1:WCiZEeP2MkcV/WPOG80llW3HOgSwfs5p0KF6hgXpqfA=
-github.com/nao1215/prompt v0.0.10/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
+github.com/nao1215/prompt v0.0.11 h1:K2PAlrBMkhpbnKHOh2SHD5WZQpL7JU3cUjjwH8OFhTY=
+github.com/nao1215/prompt v0.0.11/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/nao1215/fileparser v0.5.2 h1:IXhH5m3UJf/TMidfTcVen8CSlZ4KEFEgBz6+2o+5
 github.com/nao1215/fileparser v0.5.2/go.mod h1:Jb16QbtYfgzQ2BR+UOVNSa1WeKMP2o+xnwBYFUNAG2Y=
 github.com/nao1215/filesql v0.17.2 h1:UYRhDgtzytWVlITVXw3//wc0lVyxQb9Xe9hpfYqDX5Y=
 github.com/nao1215/filesql v0.17.2/go.mod h1:83+ne68S+HKb7f93Nl2draIM26gl9tnQp+EpsgWXgss=
-github.com/nao1215/prompt v0.0.9 h1:Jh9gMy+xOkGuVaWoN8aat0VIZzCaMa2eknbFuQZdO3o=
-github.com/nao1215/prompt v0.0.9/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
+github.com/nao1215/prompt v0.0.10 h1:WCiZEeP2MkcV/WPOG80llW3HOgSwfs5p0KF6hgXpqfA=
+github.com/nao1215/prompt v0.0.10/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=


### PR DESCRIPTION
## Summary

Upgrade the prompt dependency to v0.0.11, which fixes raw mode being applied to the wrong terminal handle on Windows without regressing macOS, and re-enable the interactive-shell pty E2E on Windows ConPTY that was skipped while that bug was unfixed. The Windows ConPTY job now exercises the real interactive path end to end, which is the actual verification that prompt#13 is fixed.

## Changes

- go.mod / go.sum: upgrade github.com/nao1215/prompt from v0.0.9 to v0.0.11.
- e2e/atago/pty.atago.yaml: remove the `skip: { os: windows }` guard from all eight pty scenarios and rewrite the file header to describe the fixed raw-mode handling instead of the skip rationale.
- CHANGELOG.md: add Unreleased Bug Fixes, Testing, and Dependencies entries for the prompt v0.0.11 upgrade and the un-skip.

## Design Decisions

The prompt library previously entered raw mode with golang.org/x/term.MakeRaw on os.Stdin but read input through go-tty's own handle (CONIN$ on Windows), so on a ConPTY the two were different handles and input delivered right after a re-rendered prompt could be dropped. prompt v0.0.11 routes raw mode through go-tty's own handle on Windows while keeping the proven os.Stdin path on Unix, so the ConPTY sessions no longer lose input and the platform skip is no longer needed. The pty specs keep their `--parallel 1` retry pass and the trailing-CR send format as general robustness against CPU starvation under parallel load; those are independent of the handle fix.

## Limitations

Local verification runs on Unix (POSIX pty), where all eight pty scenarios pass with no skips. The Windows ConPTY and macOS behavior are verified by this PR's CI matrix.

https://claude.ai/code/session_017gnwF9zFW6RHjDmfzqKZ2G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropped interactive-shell keystrokes after prompt re-renders in Windows ConPTY sessions.
* **Testing**
  * Expanded interactive PTY end-to-end coverage to run on Windows (removed Windows-only skips).
  * Updated interactive PTY terminal dimensions and execution constraints to improve reliability.
* **Chores**
  * Upgraded tooling/version used by coverage and E2E workflows.
  * Updated prompt dependency to include Windows raw-mode input fixes.
* **Documentation**
  * Updated the changelog and PTY test documentation to reflect the new Windows behavior and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->