### PR TITLE
ci: bump atago to v0.13.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.11.0
+          version: v0.13.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the atago
       # suite runs a `go build -cover` sqly and collects covdata via

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.11.0
+          version: v0.13.0
 
       - name: Run atago end-to-end tests
         # The hermetic runner builds sqly and runs the suite in a temp-backed
@@ -62,7 +62,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.11.0
+          version: v0.13.0
 
       - name: Build sqly
         run: go build -o sqly.exe main.go

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -14,7 +14,7 @@ cd "$ROOT"
 
 if ! command -v atago >/dev/null 2>&1; then
 	echo "e2e: atago is not installed. Install it from https://github.com/nao1215/atago" >&2
-	echo "e2e: e.g. 'go install github.com/nao1215/atago@v0.11.0' (CI uses nao1215/setup-atago)" >&2
+	echo "e2e: e.g. 'go install github.com/nao1215/atago@v0.13.0' (CI uses nao1215/setup-atago)" >&2
 	exit 127
 fi
 


### PR DESCRIPTION
## Summary

Moves the atago E2E jobs to v0.13.0, the current release, and updates the install hint the local E2E runner prints so it matches what CI uses.

## Changes

- `.github/workflows/coverage.yml`, `.github/workflows/e2e_test.yml`: bump the `nao1215/setup-atago` version input to `v0.13.0` (three occurrences).
- `scripts/run_e2e.sh`: the "atago is not installed" hint suggested `go install github.com/nao1215/atago@v0.11.0`, which would have installed a different version than CI runs. It now names v0.13.0.

## Design Decisions

v0.13.0 changes two contracts that can turn a previously green spec red, so this is worth noting rather than treating as a routine bump. A command killed by its timeout now fails the step unless an assert reads its result, and the spec loader rejects explicit YAML tags. The specs here author no YAML tags, and `e2e/atago/pty.atago.yaml` is the only spec setting a timeout — each of those steps is followed by an assert on `exit_code`, so the timeout change does not reach them. CI is the check that confirms it.