### PR TITLE
chore(ci): bump atago to v0.15.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the atago
       # suite runs a `go build -cover` sqly and collects covdata via

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       - name: Run atago end-to-end tests
         # The hermetic runner builds sqly and runs the suite in a temp-backed
@@ -62,7 +62,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       - name: Build sqly
         run: go build -o sqly.exe main.go

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -14,7 +14,7 @@ cd "$ROOT"
 
 if ! command -v atago >/dev/null 2>&1; then
 	echo "e2e: atago is not installed. Install it from https://github.com/nao1215/atago" >&2
-	echo "e2e: e.g. 'go install github.com/nao1215/atago@v0.13.0' (CI uses nao1215/setup-atago)" >&2
+	echo "e2e: e.g. 'go install github.com/nao1215/atago@v0.15.0' (CI uses nao1215/setup-atago)" >&2
 	exit 127
 fi
 


### PR DESCRIPTION
Move the pinned atago used by this repo's workflows from v0.13.0 to v0.15.0.

Two changes in that range can turn a passing spec red:

- `changes:` now tracks symlinks, so a step that plants or retargets a link is a
  creation or a modification instead of being invisible.
- `file: exists` / `file: executable` no longer accept a directory.

Neither affects the specs in this repo (checked: no `changes:` assertion here
covers a symlink-creating step, and no `file:` assertion targets a directory).
Everything else in v0.14.0 and v0.15.0 is additive or improves failure messages.