### PR TITLE
chore(ci): bump atago to v0.17.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the atago
       # suite runs a `go build -cover` sqly and collects covdata via

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       - name: Run atago end-to-end tests
         # The hermetic runner builds sqly and runs the suite in a temp-backed
@@ -62,7 +62,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       - name: Build sqly
         run: go build -o sqly.exe main.go

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -14,7 +14,7 @@ cd "$ROOT"
 
 if ! command -v atago >/dev/null 2>&1; then
 	echo "e2e: atago is not installed. Install it from https://github.com/nao1215/atago" >&2
-	echo "e2e: e.g. 'go install github.com/nao1215/atago@v0.16.0' (CI uses nao1215/setup-atago)" >&2
+	echo "e2e: e.g. 'go install github.com/nao1215/atago@v0.17.0' (CI uses nao1215/setup-atago)" >&2
 	exit 127
 fi
 


### PR DESCRIPTION
Pins the E2E suites to [atago v0.17.0](https://github.com/nao1215/atago/releases/tag/v0.17.0).

That release adds a Scoop bucket for Windows installs and carries two failure-message fixes: an assertion whose observed value was empty now renders `(empty)` instead of omitting the `Actual:` section, and a run step whose output capture was cut short now names the exit code the process reached instead of reporting `failed to execute`.

No spec changes are needed — neither fix alters an assertion's verdict, only how a failure reads.

`scripts/run_e2e.sh` names the same version in its install hint, so it moves too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated testing to use Atago v0.17.0.
  - Updated the end-to-end test setup instructions to recommend installing Atago v0.17.0 instead of v0.16.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->