### PR TITLE
chore(release): prepare v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## [v0.29.0](https://github.com/nao1215/sqly/compare/v0.28.0...v0.29.0) (2026-07-29)
+
+### New Features
+* SQL Dialect Support: `--dialect` (and `.dialect` in the interactive shell) now let you write queries in MySQL, PostgreSQL, or GoogleSQL (BigQuery / Cloud Spanner) instead of SQLite; sqly translates them to SQLite before running. Loading files always uses SQLite, so only the queries you write are affected. Translation is best-effort compatibility: common incompatibilities (identifier quoting, `DATE_ADD`, `EXTRACT`, `::`/`SAFE_CAST` casts, `ILIKE`, `SPLIT_PART`, `SAFE_DIVIDE`, and more) are rewritten or backed by helper functions, constructs with no SQLite equivalent (for example `QUALIFY` or `DISTINCT ON`) fail with a clear error, and everything else is passed through. Requires filesql v0.19.0.
+
+### Testing
+* Dialect E2E: `dialect.atago.yaml` adds 20 atago scenarios covering each dialect's rewrite rules and helper functions, double-quoted-string handling, unknown-dialect and unsupported-construct errors, `.dialect` inside a shell session, "loading always stays SQLite", and complex queries (joins, aggregation with `HAVING`, CTEs, window functions, correlated subqueries, and nested translations).
+
+### Documentation
+* README: a new "Query in another SQL dialect: --dialect" section documents `--dialect` and `.dialect`, and the coverage treemap was regenerated.
+
 ## [v0.28.0](https://github.com/nao1215/sqly/compare/v0.27.4...v0.28.0) (2026-07-20)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ A SQL statement is buffered until it ends with `;`, so a multi-line or pasted qu
 
 ```shell
 $ sqly testdata/user.csv
-sqly v0.28.0
+sqly v0.29.0
 
 enter "SQL query" or "sqly command that begins with a dot".
 .help print usage, .exit exit sqly.
@@ -607,7 +607,7 @@ SELECT * FROM `customers100000` WHERE `Index` BETWEEN 1000 AND 2000 ORDER BY `In
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.28.0. Run `make bench` to reproduce on your machine.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.29.0. Run `make bench` to reproduce on your machine.
 
 ## Comparison with similar tools
 


### PR DESCRIPTION
Prepares the **v0.29.0** release.

- `CHANGELOG.md`: add the `[v0.29.0]` section — SQL dialect support (`--dialect` / `.dialect` for MySQL, PostgreSQL, GoogleSQL; queries translated to SQLite, loading stays SQLite), its 20-scenario atago E2E, and the README/coverage-treemap docs.
- `README.md`: bump the version strings to `v0.29.0` to satisfy `TestREADMEVersionMatchesChangelog`.

After merge, tagging `v0.29.0` triggers the GoReleaser workflow to publish the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL dialect support through the `--dialect` command-line option and `.dialect` interactive-shell command.
  * Added best-effort translation of supported dialect syntax to SQLite, with defined handling for unsupported constructs.

* **Documentation**
  * Updated release notes, interactive shell examples, benchmark information, and dialect usage documentation for version 0.29.0.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->