### PR TITLE
fix(shell): show a continuation prompt while a statement is buffered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Bug Fixes
+* Buffered Statement Looked Like A Hung Shell: the interactive shell now shows `   ...> ` while it is collecting the rest of a statement. A query typed without a trailing `;` is buffered until it is complete, but the cursor simply dropped to a bare line with nothing in front of it, so there was no way to tell the shell was waiting for more input rather than stuck; the recovery (press Enter on a blank line) was documented but invisible at the moment it was needed. A dot-command is always complete and still runs on the first Enter. Requires prompt v0.0.12.
+
 * Non-Latin File Names Lost Their Table Name: a file named in Japanese, Chinese, Korean, Cyrillic, or accented Latin now keeps its name as the table name. Table names were sanitized against the ASCII letter range, so every other letter was deleted: `売上.csv` and `Данные.csv` both became `sheet`, `café.csv` became `caf`, and an Excel sheet named `Café` became `data_Caf`. Two such files in one run therefore collided on the same fallback name and the second failed to import, so the run exited 1 with one of the inputs missing. Table names are always emitted double-quoted, so the restriction bought nothing. Punctuation, symbols, and quotes are still removed, a name starting with a digit still gets a `sheet_` prefix, and a name left with nothing still falls back to `sheet`. Requires filesql v0.22.0.
 
 * Unfetchable URL Reported As A Missing File: an input written as a URL sqly cannot download now names the scheme instead of claiming the path does not exist. `sqly --sql ... s3://bucket/data.csv` (and `file://`, `ftp://`, `gs://`, and the rest) fell through to the local-path branch and failed with "path does not exist", which reads as a typo in the URL rather than a scheme sqly was never going to fetch. It now says only http and https are downloaded, names the scheme it found, and points at passing a local path. A local file name that merely contains a colon, and a Windows drive path, are still treated as paths.
@@ -20,6 +22,7 @@
 * Dialect E2E: 58 atago scenarios in `e2e/atago/dialect_cross.atago.yaml`, `dialect_mysql.atago.yaml`, `dialect_postgresql.atago.yaml`, and `dialect_googlesql.atago.yaml` pin the semantics above from the CLI, each with a description of what SQLite would have done instead. `dialect.atago.yaml` adds 12 more covering chained `::` casts, `E''` and dollar-quoted strings, json operators, `~*`, `LATERAL` rejection, backtick names containing a space, `#` comments and raw strings, negative `DATE_DIFF`, `SELECT * EXCEPT` and `ARRAY<>` rejection, dialect name aliases, and a batch script stopped by a translate error.
 * Known Limitations: `e2e/atago/known_bugs/` records dialect behavior sqly cannot reproduce as executable specs that are expected to fail, run by `scripts/run_known_bugs.sh` and kept out of CI.
 * Non-Latin Table Names: `e2e/atago/unicode_table_names.atago.yaml` adds 9 scenarios covering a Japanese, Cyrillic, and accented-Latin file name queried by its own name, two Japanese-named files joined in one run (the collision that used to drop an input), the name reported by `--inspect` and `.tables`, write-back to a Japanese-named source, a non-Latin Excel sheet name, and the characters that must still be dropped or fall back.
+* Continuation Prompt: `pty.atago.yaml` adds two pty scenarios driving the real REPL, one asserting that an incomplete statement shows the continuation marker and then runs both lines as one statement, and one asserting that a dot-command never opens a continuation.
 * Unfetchable URL Schemes: `http_import.atago.yaml` adds three scenarios covering `s3://`, `file://`, and a local file name containing a colon, and `TestUnfetchableURLScheme` pins the detector against Windows drive paths, uppercase schemes, and plain relative paths.
 * Read-Only Write-Back: `save.atago.yaml` adds three scenarios pinning that a read-only `--save-dir`, a read-only `--save --force`, and a zero-row `UPDATE` each report "nothing to save" and leave the workdir untouched, asserted through `changes` so a stray file would fail.
 
@@ -28,6 +31,7 @@
 
 ### Dependencies
 * filesql v0.22.0: upgraded from v0.21.0 for the non-Latin table-name fix.
+* prompt v0.0.12: upgraded from v0.0.11 for `WithContinuationPrefix`.
 
 ## [v0.29.0](https://github.com/nao1215/sqly/compare/v0.28.0...v0.29.0) (2026-07-29)
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,12 @@ $ sqly --sql "SELECT p.name, p.price, s.quantity, ROUND(p.price * s.quantity, 2)
 
 Run `sqly` without `--sql` to open the shell. It behaves like `sqlite3` or `mysql`: type SQL, or a helper command that begins with a dot. Tab completes keywords and table names, and history is kept across sessions.
 
-A SQL statement is buffered until it ends with `;`, so a multi-line or pasted query runs as one statement instead of executing each line. Dot-commands are single-line and run on Enter. To run a query without typing `;`, press Enter on a blank line.
+A SQL statement is buffered until it ends with `;`, so a multi-line or pasted query runs as one statement instead of executing each line. While a statement is being buffered the prompt becomes `   ...> `. Dot-commands are single-line and run on Enter. To run a query without typing `;`, press Enter on a blank line.
+
+```text
+sqly:~/sqly(table)$ SELECT user_name,
+   ...> identifier FROM user;
+```
 
 ![shell demo](./doc/img/shell-demo.gif)
 

--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -215,6 +215,53 @@ scenarios:
           stdout:
             contains: "no such table"
 
+  # A statement without a trailing ";" is buffered until it is complete. The
+  # continuation prompt is the only thing that says so: without it the cursor
+  # dropped to a bare line, which is indistinguishable from a hung shell.
+  - name: a statement without a semicolon shows the continuation prompt
+    steps:
+      - fixture: *people
+      - pty:
+          command: sqly people.csv
+          rows: 30
+          cols: 220
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: "SELECT name,\r" # incomplete: the buffer continues instead of running
+            - expect: '\.\.\.>' # the continuation marker, not a bare line
+            - send: "age FROM people WHERE age = 41;\r"
+            - expect: "Carol" # the two lines ran as one statement
+            - expect: '\(table\)\$' # and the main prompt came back
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "...>"
+              - "Carol"
+
+  # A dot-command is always complete, so it must run on the first Enter rather
+  # than opening a continuation the user then has to escape.
+  - name: a dot-command never opens a continuation
+    steps:
+      - fixture: *people
+      - pty:
+          command: sqly people.csv
+          rows: 30
+          cols: 220
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: ".tables\r"
+            - expect: "people"
+            - expect: '\(table\)\$'
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            not_contains: "...>"
+
   - name: EOF at the prompt exits the shell cleanly
     steps:
       - fixture: *people

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/nao1215/filesql v0.22.0
-	github.com/nao1215/prompt v0.0.11
+	github.com/nao1215/prompt v0.0.12
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/spf13/pflag v1.0.10
 	github.com/xuri/excelize/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/nao1215/fileparser v0.5.2 h1:IXhH5m3UJf/TMidfTcVen8CSlZ4KEFEgBz6+2o+5
 github.com/nao1215/fileparser v0.5.2/go.mod h1:Jb16QbtYfgzQ2BR+UOVNSa1WeKMP2o+xnwBYFUNAG2Y=
 github.com/nao1215/filesql v0.22.0 h1:b2EPL2Sfv98mYlWb735kyw7wtRgqYNp2KNAQUDM0DXE=
 github.com/nao1215/filesql v0.22.0/go.mod h1:qm+43sfrlIr4Mcuo9EP+XSY2xi4R/oIGz8nY/sHHSpM=
-github.com/nao1215/prompt v0.0.11 h1:K2PAlrBMkhpbnKHOh2SHD5WZQpL7JU3cUjjwH8OFhTY=
-github.com/nao1215/prompt v0.0.11/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
+github.com/nao1215/prompt v0.0.12 h1:4Q/U8zpaav0xQ5zvskhS0WumLZq/0pZcFJ1/I7mzAnM=
+github.com/nao1215/prompt v0.0.12/go.mod h1:UqCLZ1fyxwWhEBTLAVvRVIzW8Tyl74o4Du0e0gQrWN4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -171,6 +171,7 @@ func NewShell(
 				prompt.WithTheme(prompt.ThemeNightOwl),
 				prompt.WithMultiline(true),
 				prompt.WithIsComplete(sqlInputComplete),
+				prompt.WithContinuationPrefix(continuationPrefix),
 				prompt.WithWordEscape(),
 				prompt.WithKeyMap(sqlyKeyMap()),
 				prompt.WithPersistentRawMode(),
@@ -689,6 +690,13 @@ func (s *Shell) prompt(p promptSession) (string, error) {
 	p.SetPrefix(s.promptPrefix())
 	return p.Run()
 }
+
+// continuationPrefix marks the lines of a statement sqly is still collecting.
+// A query typed without a trailing ";" is buffered (see sqlInputComplete), and
+// without a marker the cursor simply dropped to a bare line, which looks exactly
+// like a hung program: nothing says the shell is waiting for the rest of the
+// statement rather than stuck. sqlite3, psql, and mysql all show one.
+const continuationPrefix = "   ...> "
 
 func (s *Shell) promptPrefix() string {
 	return fmt.Sprintf("sqly:%s(%s)$ ", s.state.shortCWD(), s.state.mode.displayName())


### PR DESCRIPTION
## Summary

A SQL statement typed in the interactive shell is buffered until it ends with `;`, so a multi-line or pasted query runs as one statement. Nothing said so: the cursor dropped to a bare line with nothing in front of it, which is indistinguishable from a hung program. Typing `hello` and pressing Enter left a session that looked frozen — a pty scenario driving the REPL sat there until the thirty-second timeout killed it. The documented recovery (press Enter on a blank line) was invisible at the moment it was needed.

The shell now shows `   ...> ` for those lines, the way sqlite3, psql, and mysql do.

## Changes

- `shell/shell.go`: a `continuationPrefix` constant passed to `prompt.WithContinuationPrefix`, next to the existing `WithIsComplete(sqlInputComplete)` that decides when a statement is buffered.
- `go.mod` / `go.sum`: prompt v0.0.11 to v0.0.12, which added `WithContinuationPrefix` (nao1215/prompt#18).
- `e2e/atago/pty.atago.yaml`: two scenarios driving the real REPL over a pty. One types an incomplete statement, asserts the continuation marker appears, finishes the statement, and asserts both lines ran as one. The other asserts a dot-command runs on the first Enter and never opens a continuation.
- `README.md`: the shell section shows the continuation prompt in the multi-line paragraph, with a transcript.
- `CHANGELOG.md`: entries under Bug Fixes, Testing, and Dependencies.

## Design Decisions

The marker is `   ...> `, eight columns wide, so it is visually distinct from the main prompt without competing with it. sqlite3 uses the same shape, which is the reference most sqly users already have.

The fix is a display change only. `sqlInputComplete` is untouched, so what counts as a complete statement, and the blank-line force-submit, behave exactly as before. Narrowing `sqlInputComplete` so a bare word submits immediately was the alternative, and it would have broken genuine multi-line entry: `SELECT id` followed by `FROM users` would run as two statements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a continuation prompt (`...>`) when entering multi-line SQL statements that do not yet end with `;`.
  - Completed statements execute normally and return to the primary prompt.
  - Dot-commands such as `.tables` remain immediately executable without triggering continuation mode.

- **Documentation**
  - Updated the interactive shell guide with clearer buffering behavior and a multi-line example.

- **Tests**
  - Added end-to-end coverage for continuation prompts and dot-command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->