### PR TITLE
chore: prepare v0.30.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v0.30.0](https://github.com/nao1215/sqly/compare/v0.29.0...v0.30.0) (2026-07-29)
+
 ### Bug Fixes
 * MySQL And GoogleSQL `CONCAT` Swallowed A NULL: both dialects return NULL when any argument is NULL, but SQLite's own `concat()` treats a NULL as an empty string and the call was passed straight through. `CONCAT(first_name, middle_name)` with a NULL middle name answered the first name where MySQL and BigQuery answer NULL, so a query written to detect incomplete rows reported them as complete. PostgreSQL's `concat()` genuinely does ignore NULLs and is unchanged, as is `CONCAT_WS`. Requires filesql v0.25.0.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ sqly runs each statement in its own transaction on an in-memory database, so a f
 |--------:|--------:|------------:|--------------:|-------------------:|
 | 100,000 | 12 | 515 ms | 161 MB | 2.82M |
 
-Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.29.0.
+Measured on an AMD Ryzen 7 5800U, Go 1.25, sqly v0.30.0.
 
 The same query on the same file (top 10 countries by row count), best of 5 end-to-end runs:
 


### PR DESCRIPTION
## Summary

Roll the Unreleased entries into v0.30.0. The release is a bug-hunting cycle: nine defects found by probing the CLI, two of them data-loss, plus the documentation rebuilt around runnable examples.

## What is in it

Data loss, all now covered by regression specs:

- A rejected ACH or Fedwire write destroyed the file it was overwriting — an 891-byte file came back empty, and Fedwire deleted it outright. Every write is staged and moved into place.
- A multi-file `--save` that failed partway left the session half-persisted, with no record of which files had changed. The save is now all-or-nothing, with the already-committed targets rolled back.

Wrong or missing answers:

- A file named in Japanese, Chinese, Korean, Cyrillic, or accented Latin lost its table name entirely, so two such files collided and one failed to import.
- MySQL and GoogleSQL `CONCAT` dropped a NULL argument instead of propagating it, so a query written to find incomplete rows reported them as complete.

Things that looked broken:

- A statement typed without a trailing `;` left the shell looking hung; it now shows a continuation prompt.
- A read-only `--save`/`--save-dir` exited 0 in silence, so `--save-dir` looked like it had written the directory.
- A URL with a scheme sqly cannot fetch was reported as a missing file.
- `.mode`/`.import-mode` set to the value already in effect was a fatal error, which killed any script that set a mode defensively.

Documentation:

- The site is rebuilt as a Hugo build under `website/`, leading with runnable commands: a cookbook of ~90 one-liners indexed by task, and a dialects page that documents what `--dialect` does not do, not only what it translates. The README is 730 lines to 250.
- Four drift guards keep it honest: every documented `sqly` invocation is run through the real argument parser, every documented dot-command is checked against the ones the shell registers, every cookbook section names the spec that runs it, and every site-internal link is resolved.

Dependencies: filesql v0.21.0 to v0.25.0, prompt v0.0.11 to v0.0.13.

## Changes

- `CHANGELOG.md`: the Unreleased entries become `[v0.30.0]`.
- `README.md`: the benchmark caption's version string, which `TestREADMEVersionMatchesChangelog` keeps in step with the changelog.