### PR TITLE
feat: add a vertical output mode for rows too wide to read across

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### New Features
+* Vertical Output Mode For Rows Too Wide To Read: `--vertical`, and `.mode vertical` in the shell, print one column per line in a block per record instead of laying the record out along the line. Every other mode fails at the width sqly was written for — a 300-column row is a single 2700-character line as a table, as CSV, as TSV, and as LTSV alike, so no terminal shows it and the column holding the bad value has no name beside it to search for. Vertical spends vertical space, which a terminal scrolls, and puts the name and the value on one short line, so the bad column is one `grep` away. The layout follows psql's expanded output: a numbered record rule, then names left-aligned in a gutter measured in terminal cells, so a full-width Japanese header lines up with an ASCII one. It names no file format, so `.dump` and `--output` take the format from the destination's extension exactly as they do in table mode.
+
 ### Bug Fixes
 * A One-Column Export Lost Its Empty Rows: in CSV and TSV a record of one empty field, written plainly, is a blank line — and a blank line is not a record, so a reader skips it. `sqly --csv --sql "SELECT v FROM t" --output out.csv` over three rows whose middle value was empty wrote three rows and read back as two, and the export reported success both times. Such a record is now written as `""`, which says "one field, and it is empty". A row of several columns is unaffected, because its delimiters already say how many fields there are. filesql had the same bug on its own dump path and is fixed in v0.29.0, taken below.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ The [cookbook](https://nao1215.github.io/sqly/cookbook/) is the fastest way in. 
 # Look at a file you have never seen
 sqly --inspect user.csv
 
+# Read a row too wide to fit a terminal: one column per line, in a block per record
+sqly --vertical --sql "SELECT * FROM wide LIMIT 1" wide.csv
+
 # Convert: csv -> json, excel, parquet, markdown, gzipped csv
 sqly --json    --output user.json    --sql "SELECT * FROM user" user.csv
 sqly --excel   --output user.xlsx    --sql "SELECT * FROM user" user.csv

--- a/config/argument.go
+++ b/config/argument.go
@@ -141,6 +141,7 @@ const (
 	outJSON     = "json"
 	outNDJSON   = "ndjson"
 	outParquet  = "parquet"
+	outVertical = "vertical"
 	// Typed JSON variants: same JSON/NDJSON format, but native scalars instead of
 	// strings. They select the JSON/NDJSON mode and set Output.JSONTyped.
 	outJSONTyped   = "json-typed"
@@ -157,6 +158,7 @@ type outputFlag struct {
 	json     bool
 	ndjson   bool
 	parquet  bool
+	vertical bool
 
 	jsonTyped   bool
 	ndjsonTyped bool
@@ -178,6 +180,7 @@ func (of outputFlag) selectedNames() []string {
 		{outJSON, of.json},
 		{outNDJSON, of.ndjson},
 		{outParquet, of.parquet},
+		{outVertical, of.vertical},
 		{outJSONTyped, of.jsonTyped},
 		{outNDJSONTyped, of.ndjsonTyped},
 	}
@@ -231,6 +234,7 @@ func newArg(args []string) (*Arg, error) {
 	flag.BoolVarP(&oFlag.json, outJSON, "j", false, "change output format to json (default: table)")
 	flag.BoolVarP(&oFlag.ndjson, outNDJSON, "n", false, "change output format to ndjson (default: table)")
 	flag.BoolVarP(&oFlag.parquet, outParquet, "p", false, "export results as parquet (export-only; use with --output or .dump)")
+	flag.BoolVar(&oFlag.vertical, outVertical, false, "change output format to one column per line, in a block per record (default: table); for rows too wide to read across")
 	flag.BoolVar(&oFlag.jsonTyped, outJSONTyped, false, "change output format to json with native scalars (numbers, booleans, nulls) instead of strings")
 	flag.BoolVar(&oFlag.ndjsonTyped, outNDJSONTyped, false, "change output format to ndjson with native scalars (numbers, booleans, nulls) instead of strings")
 	sheetName := flag.StringP("sheet", "S", "", "excel sheet name you want to import")
@@ -480,6 +484,8 @@ func newOutput(filePath string, of outputFlag) *Output {
 		output.JSONTyped = true
 	case of.parquet:
 		output.Mode = model.PrintModeParquet
+	case of.vertical:
+		output.Mode = model.PrintModeVertical
 	default:
 		output.Mode = model.PrintModeTable
 	}

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -30,6 +30,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -j, --json                    change output format to json (default: table)
   -n, --ndjson                  change output format to ndjson (default: table)
   -p, --parquet                 export results as parquet (export-only; use with --output or .dump)
+      --vertical                change output format to one column per line, in a block per record (default: table); for rows too wide to read across
       --json-typed              change output format to json with native scalars (numbers, booleans, nulls) instead of strings
       --ndjson-typed            change output format to ndjson with native scalars (numbers, booleans, nulls) instead of strings
   -S, --sheet string            excel sheet name you want to import

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/nao1215/sqly/domain"
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
@@ -82,6 +83,7 @@ const (
 	formatJSON     = "json"
 	formatNDJSON   = "ndjson"
 	formatParquet  = "parquet"
+	formatVertical = "vertical"
 )
 
 // Extension name constants.
@@ -117,6 +119,11 @@ const (
 	// PrintModeParquet is an export-only mode; on screen it renders like CSV and
 	// only writes a Parquet file via .dump or --output (same pattern as Excel).
 	PrintModeParquet
+	// PrintModeVertical prints one column per line, in a block per record. It is
+	// display-only, like PrintModeTable: a row wider than the terminal is what the
+	// table, csv, tsv, and ltsv modes all fail at, and a 300-column row is the case
+	// sqly exists for.
+	PrintModeVertical
 )
 
 // String return string of PrintMode.
@@ -140,8 +147,22 @@ func (p PrintMode) String() string {
 		return formatNDJSON
 	case PrintModeParquet:
 		return formatParquet
+	case PrintModeVertical:
+		return formatVertical
 	}
 	return "unknown"
+}
+
+// IsDisplayOnly reports whether the mode only decides what the screen looks like,
+// so it names no export format.
+//
+// The export path asks this to decide whether the mode chose the destination's
+// format or the destination's extension did: `.dump out.tsv` while the session is
+// in a display-only mode writes a TSV, where the same call in csv mode is a
+// conflict the caller has to resolve. Table and vertical are the two — vertical is
+// a way of reading a wide row, not a file format anything else can parse back.
+func (p PrintMode) IsDisplayOnly() bool {
+	return p == PrintModeTable || p == PrintModeVertical
 }
 
 // Table is DB table.
@@ -316,6 +337,8 @@ func (t *Table) Print(out io.Writer, mode PrintMode) error {
 		// Export-only: on screen, render like CSV. The Parquet file is written
 		// by the export path (.dump / --output), not here.
 		return t.printCSV(out)
+	case PrintModeVertical:
+		return t.printVertical(out)
 	default:
 		return t.printTable(out)
 	}
@@ -491,6 +514,58 @@ func (t *Table) printLTSV(out io.Writer) error {
 		}
 		if _, err := fmt.Fprintln(out, strings.Join(r, "\t")); err != nil {
 			return fmt.Errorf("failed to write LTSV record %v: %w", r, err)
+		}
+	}
+	return nil
+}
+
+// verticalRecordRuleWidth is the total width of a record's separator line, so
+// the rules line up whatever the record number is.
+const verticalRecordRuleWidth = 60
+
+// printVertical prints one column per line, in a block per record.
+//
+// Every other mode lays a record out across the line, which stops working at the
+// width sqly exists for: a 300-column row is one 2700-character line in table,
+// csv, tsv, and ltsv alike, and no terminal shows it. Turning the row on its side
+// costs vertical space, which a terminal scrolls, instead of horizontal space,
+// which it does not.
+//
+// The layout follows psql's expanded output: a numbered record rule, then the
+// column names left-aligned in a gutter as wide as the longest one, so scanning
+// down the names reads as a list. The gutter is measured in terminal cells, not
+// runes or bytes: a full-width character such as 名 occupies two cells, so a
+// Japanese header counted by runes left the ASCII names beside it out of line.
+//
+// A value is written as it is, including a newline. Vertical output is for
+// reading, not for parsing, and the modes that have to stay machine-readable —
+// csv, tsv, ltsv, json — are unaffected.
+func (t *Table) printVertical(out io.Writer) error {
+	gutter := 0
+	for _, h := range t.Header() {
+		if n := runewidth.StringWidth(h); n > gutter {
+			gutter = n
+		}
+	}
+
+	for i, record := range t.Records() {
+		rule := fmt.Sprintf("-[ RECORD %d ]", i+1)
+		if pad := verticalRecordRuleWidth - runewidth.StringWidth(rule); pad > 0 {
+			rule += strings.Repeat("-", pad)
+		}
+		if _, err := fmt.Fprintln(out, rule); err != nil {
+			return fmt.Errorf("failed to write vertical record rule: %w", err)
+		}
+
+		for j, header := range t.Header() {
+			value := ""
+			if j < len(record) {
+				value = record[j]
+			}
+			name := header + strings.Repeat(" ", gutter-runewidth.StringWidth(header))
+			if _, err := fmt.Fprintf(out, "%s | %s\n", name, value); err != nil {
+				return fmt.Errorf("failed to write vertical column %s: %w", header, err)
+			}
 		}
 	}
 	return nil

--- a/domain/model/vertical_test.go
+++ b/domain/model/vertical_test.go
@@ -1,0 +1,196 @@
+package model
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestTablePrintVertical pins the vertical layout.
+//
+// Every other mode lays a record out across the line, which stops working at the
+// width sqly exists for: a 300-column row is one 2700-character line in table,
+// csv, tsv, and ltsv alike. Vertical turns the row on its side, so the cost is
+// vertical space, which a terminal scrolls.
+func TestTablePrintVertical(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		header  Header
+		records []Record
+		want    string
+	}{
+		{
+			name:    "one record, names padded to the longest",
+			header:  Header{"id", "user_name"},
+			records: []Record{{"1", "alice"}},
+			want: "-[ RECORD 1 ]-----------------------------------------------\n" +
+				"id        | 1\n" +
+				"user_name | alice\n",
+		},
+		{
+			name:    "each record gets its own numbered rule",
+			header:  Header{"id"},
+			records: []Record{{"1"}, {"2"}, {"3"}},
+			want: "-[ RECORD 1 ]-----------------------------------------------\n" +
+				"id | 1\n" +
+				"-[ RECORD 2 ]-----------------------------------------------\n" +
+				"id | 2\n" +
+				"-[ RECORD 3 ]-----------------------------------------------\n" +
+				"id | 3\n",
+		},
+		{
+			name:    "an empty value keeps its line",
+			header:  Header{"a", "b"},
+			records: []Record{{"", "x"}},
+			want: "-[ RECORD 1 ]-----------------------------------------------\n" +
+				"a | \n" +
+				"b | x\n",
+		},
+		{
+			name:    "the gutter is measured in runes, not bytes",
+			header:  Header{"名前", "id"},
+			records: []Record{{"アリス", "1"}},
+			want: "-[ RECORD 1 ]-----------------------------------------------\n" +
+				"名前 | アリス\n" +
+				"id   | 1\n",
+		},
+		{
+			name:    "a value carrying a newline is written as it is",
+			header:  Header{"note"},
+			records: []Record{{"first\nsecond"}},
+			want: "-[ RECORD 1 ]-----------------------------------------------\n" +
+				"note | first\nsecond\n",
+		},
+		{
+			name:    "a value carrying the separator needs no escaping",
+			header:  Header{"expr"},
+			records: []Record{{"a | b"}},
+			want: "-[ RECORD 1 ]-----------------------------------------------\n" +
+				"expr | a | b\n",
+		},
+		{
+			name:    "no records prints nothing",
+			header:  Header{"id", "name"},
+			records: []Record{},
+			want:    "",
+		},
+		{
+			name:    "a record shorter than the header still lists every column",
+			header:  Header{"a", "b", "c"},
+			records: []Record{{"1"}},
+			want: "-[ RECORD 1 ]-----------------------------------------------\n" +
+				"a | 1\n" +
+				"b | \n" +
+				"c | \n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			tbl := NewTable("t", tt.header, tt.records)
+			if err := tbl.Print(&buf, PrintModeVertical); err != nil {
+				t.Fatalf("Print() error = %v, want nil", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("Print(vertical) =\n%q\nwant\n%q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTablePrintVerticalWideRow is the case the mode exists for: a row too wide
+// to read across becomes one line per column, each short enough to read and to
+// grep. The horizontal modes are measured alongside it so the comparison is not
+// an assertion about a number nobody checked.
+func TestTablePrintVerticalWideRow(t *testing.T) {
+	t.Parallel()
+
+	const columns = 300
+	header := make(Header, columns)
+	record := make(Record, columns)
+	for i := range columns {
+		header[i] = fmt.Sprintf("col_%03d", i+1)
+		record[i] = fmt.Sprintf("v%d", i+1)
+	}
+	record[157] = "BAD"
+	tbl := NewTable("wide", header, []Record{record})
+
+	var flat bytes.Buffer
+	if err := tbl.Print(&flat, PrintModeCSV); err != nil {
+		t.Fatal(err)
+	}
+	csvDataLine := strings.Split(strings.TrimRight(flat.String(), "\n"), "\n")[1]
+	if len(csvDataLine) < 1000 {
+		t.Fatalf("the csv data line is %d characters; this test assumes a row too wide to read across", len(csvDataLine))
+	}
+
+	var vertical bytes.Buffer
+	if err := tbl.Print(&vertical, PrintModeVertical); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(vertical.String(), "\n"), "\n")
+	if len(lines) != columns+1 {
+		t.Errorf("vertical produced %d lines, want %d (one rule + one per column)", len(lines), columns+1)
+	}
+	for _, line := range lines {
+		if len(line) > 80 {
+			t.Errorf("a vertical line is %d characters, which defeats the point: %q", len(line), line)
+		}
+	}
+	// The column holding the odd value is findable by name, which is the whole
+	// point: the flat line gives no name to grep for.
+	if !strings.Contains(vertical.String(), "col_158 | BAD") {
+		t.Errorf("vertical output should name the column holding BAD:\n%s", vertical.String())
+	}
+}
+
+// TestPrintModeIsDisplayOnly pins which modes name no export format. The export
+// path asks this to decide whether the mode chose a destination's format or the
+// destination's extension did, so a mode landing on the wrong side turns `.dump
+// out.tsv` into either a conflict error or a file in the wrong format.
+func TestPrintModeIsDisplayOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mode PrintMode
+		want bool
+	}{
+		{mode: PrintModeTable, want: true},
+		{mode: PrintModeVertical, want: true},
+		{mode: PrintModeCSV, want: false},
+		{mode: PrintModeTSV, want: false},
+		{mode: PrintModeLTSV, want: false},
+		{mode: PrintModeMarkdownTable, want: false},
+		{mode: PrintModeJSON, want: false},
+		{mode: PrintModeNDJSON, want: false},
+		{mode: PrintModeExcel, want: false},
+		{mode: PrintModeParquet, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mode.String(), func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.mode.IsDisplayOnly(); got != tt.want {
+				t.Errorf("%s.IsDisplayOnly() = %v, want %v", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExportFormatFromVertical pins that vertical falls back to CSV like table
+// does, so a `.dump` with no extension in vertical mode writes something a reader
+// can load rather than the on-screen layout.
+func TestExportFormatFromVertical(t *testing.T) {
+	t.Parallel()
+
+	if got, want := ExportFormatFromPrintMode(PrintModeVertical), ExportCSV; got != want {
+		t.Errorf("ExportFormatFromPrintMode(vertical) = %v, want %v", got, want)
+	}
+}

--- a/e2e/atago/vertical_mode.atago.yaml
+++ b/e2e/atago/vertical_mode.atago.yaml
@@ -1,0 +1,146 @@
+# Vertical output: one column per line, in a block per record.
+#
+# Every other mode lays a record out across the line, which stops working at the
+# width sqly exists for. A 300-column row is a single 2700-character line in
+# table, csv, tsv, and ltsv alike, and no terminal shows it; the column holding
+# the bad value has no name on that line to search for. Turning the row on its
+# side spends vertical space, which a terminal scrolls.
+#
+# Run with: make test-e2e
+version: "1"
+
+suite:
+  name: sqly vertical output mode
+
+scenarios:
+  - name: --vertical prints one column per line, in a block per record
+    steps:
+      - fixture: &user
+          file: user.csv
+          content: |
+            user_name,identifier,first_name
+            booker12,1,Rachel
+            jenkins46,2,Mary
+      - run:
+          command: sqly --vertical --sql "SELECT * FROM user ORDER BY identifier" user.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: |
+              -[ RECORD 1 ]-----------------------------------------------
+              user_name  | booker12
+              identifier | 1
+              first_name | Rachel
+              -[ RECORD 2 ]-----------------------------------------------
+              user_name  | jenkins46
+              identifier | 2
+              first_name | Mary
+
+  - name: .mode vertical switches the session and announces it
+    steps:
+      - fixture: *user
+      - run:
+          command: sqly user.csv
+          stdin: ".mode vertical\nSELECT user_name FROM user ORDER BY identifier LIMIT 1;\n"
+      - assert:
+          exit_code: 0
+          stderr:
+            contains: "Change output mode from table to vertical"
+          stdout:
+            equals: |
+              -[ RECORD 1 ]-----------------------------------------------
+              user_name | booker12
+
+  - name: .mode vertical accepts being set again, like every other mode
+    steps:
+      - fixture: *user
+      - run:
+          command: sqly --vertical user.csv
+          stdin: ".mode vertical\nSELECT 1 AS x;\n"
+      - assert:
+          exit_code: 0
+
+  - name: the column names line up when a header is full-width
+    steps:
+      - fixture:
+          file: ja.csv
+          content: |
+            名前,id,備考
+            アリス,1,ok
+      - run:
+          command: sqly --vertical --sql "SELECT * FROM ja" ja.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: |
+              -[ RECORD 1 ]-----------------------------------------------
+              名前 | アリス
+              id   | 1
+              備考 | ok
+
+  - name: a wide row becomes one short line per column, each greppable by name
+    steps:
+      - fixture:
+          file: wide.csv
+          content: |
+            col_001,col_002,col_003,col_004,col_005
+            v1,v2,BAD,v4,v5
+      # The flat modes put every value on one line, so the odd one has no column
+      # name beside it to search for.
+      - run:
+          command: sqly --csv --sql "SELECT * FROM wide" wide.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: |
+              col_001,col_002,col_003,col_004,col_005
+              v1,v2,BAD,v4,v5
+      - run:
+          command: sqly --vertical --sql "SELECT * FROM wide" wide.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "col_003 | BAD"
+
+  - name: vertical is display-only, so a dump takes its format from the destination
+    steps:
+      - fixture: *user
+      - run:
+          command: sqly --vertical user.csv
+          stdin: ".dump user out.tsv\n"
+      - assert:
+          exit_code: 0
+      - assert:
+          file:
+            path: out.tsv
+            equals: "user_name\tidentifier\tfirst_name\nbooker12\t1\tRachel\njenkins46\t2\tMary\n"
+
+  - name: vertical cannot be combined with a report flag, like any output mode
+    steps:
+      - fixture: *user
+      - run:
+          command: sqly --profile --vertical user.csv
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "--profile cannot be combined with an output mode flag (--vertical)"
+
+  - name: vertical conflicts with another output mode flag
+    steps:
+      - fixture: *user
+      - run:
+          command: sqly --vertical --csv --sql "SELECT 1" user.csv
+      - assert:
+          exit_code: 1
+          stderr:
+            empty: false
+
+  - name: an empty result set prints nothing in vertical mode
+    steps:
+      - fixture: *user
+      - run:
+          command: sqly --vertical --sql "SELECT * FROM user WHERE identifier = 999" user.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: ""

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/wire v0.7.0
 	github.com/mattn/go-colorable v0.1.15
+	github.com/mattn/go-runewidth v0.0.27
 	github.com/nao1215/filesql v0.29.0
 	github.com/nao1215/prompt v0.0.13
 	github.com/olekukonko/tablewriter v1.1.4
@@ -40,7 +41,6 @@ require (
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
-	github.com/mattn/go-runewidth v0.0.27 // indirect
 	github.com/mattn/go-tty v0.0.8 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect

--- a/shell/dump.go
+++ b/shell/dump.go
@@ -23,9 +23,10 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 			"[Usage]\n" +
 			"  .dump TABLE_NAME FILE_PATH\n" +
 			"[Note]\n" +
-			"  The format comes from .mode. When .mode is table, it is inferred from the\n" +
-			"  file extension (e.g. .tsv, .parquet), falling back to CSV (written to the\n" +
-			"  path as given) when the extension is unknown.\n" +
+			"  The format comes from .mode. When .mode only decides what the screen looks\n" +
+			"  like (table, vertical), the format is inferred from the file extension\n" +
+			"  (e.g. .tsv, .parquet), falling back to CSV (written to the path as given)\n" +
+			"  when the extension is unknown.\n" +
 			"  Compression is inferred from the path (.gz, .xz, .zst, .z, .snappy, .s2, .lz4).\n" +
 			"  A .mode that disagrees with the extension is rejected instead of normalizing.\n" +
 			"  ACH/Fedwire tables can be dumped to csv/tsv/xlsx, but not back to .ach/.fed format")
@@ -70,10 +71,11 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 	// a typed mode; ignored for every other export format.
 	table.SetJSONTyped(s.state.mode.jsonTyped)
 
-	// The current .mode sets the format unless it is table; otherwise the format
-	// (and any compression) is inferred from the destination path.
+	// The current .mode sets the format unless it is display-only (table,
+	// vertical); otherwise the format (and any compression) is inferred from the
+	// destination path.
 	mode := s.state.mode.PrintMode
-	exportFmt, compression, err := model.ResolveOutputTarget(userPath, model.ExportFormatFromPrintMode(mode), mode != model.PrintModeTable)
+	exportFmt, compression, err := model.ResolveOutputTarget(userPath, model.ExportFormatFromPrintMode(mode), !mode.IsDisplayOnly())
 	if err != nil {
 		return err
 	}

--- a/shell/help.go
+++ b/shell/help.go
@@ -30,7 +30,7 @@ func helpGroups() []helpGroup {
 	return []helpGroup{
 		{"Session", []helpLine{
 			{helpCommand, "show this help"},
-			{modeCommand + " MODE", "change output mode (table, csv, tsv, ltsv, json, ndjson, markdown, ...)"},
+			{modeCommand + " MODE", "change output mode (table, vertical, csv, tsv, ltsv, json, ndjson, markdown, ...)"},
 			{dialectCommand + " [NAME]", "show or set the query dialect (sqlite, mysql, postgresql, googlesql)"},
 			{clearCommand, "clear the terminal screen"},
 			{exitCommand, "exit sqly"},

--- a/shell/mode.go
+++ b/shell/mode.go
@@ -17,6 +17,7 @@ func (c CommandList) modeCommand(_ context.Context, s *Shell, argv []string) err
 			"  .mode OUTPUT_MODE   ※ current mode=%s\n"+
 			"[Output mode list]\n"+
 			"  table\n"+
+			"  vertical ※ one column per line, in a block per record; for rows too wide to read across\n"+
 			"  markdown\n"+
 			"  csv\n"+
 			"  tsv\n"+

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -1154,7 +1154,7 @@ func (s *Shell) outputToFile(table *model.Table) error {
 	}
 	mode := s.state.mode.PrintMode
 	explicit := model.ExportFormatFromPrintMode(mode)
-	exportFmt, compression, err := model.ResolveOutputTarget(s.argument.Output.FilePath, explicit, mode != model.PrintModeTable)
+	exportFmt, compression, err := model.ResolveOutputTarget(s.argument.Output.FilePath, explicit, !mode.IsDisplayOnly())
 	if err != nil {
 		return err
 	}

--- a/shell/state.go
+++ b/shell/state.go
@@ -168,6 +168,8 @@ func (m *mode) changeOutputModeIfNeeded(modeName string) error {
 	case model.PrintModeParquet.String():
 		target = model.PrintModeParquet
 		suffix = " (active only when executing .dump, otherwise same as csv mode)"
+	case model.PrintModeVertical.String():
+		target = model.PrintModeVertical
 	default:
 		return fmt.Errorf("invalid output mode: %s", modeName)
 	}

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -30,6 +30,7 @@ sqly - execute SQL against CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire wit
   -j, --json                    change output format to json (default: table)
   -n, --ndjson                  change output format to ndjson (default: table)
   -p, --parquet                 export results as parquet (export-only; use with --output or .dump)
+      --vertical                change output format to one column per line, in a block per record (default: table); for rows too wide to read across
       --json-typed              change output format to json with native scalars (numbers, booleans, nulls) instead of strings
       --ndjson-typed            change output format to ndjson with native scalars (numbers, booleans, nulls) instead of strings
   -S, --sheet string            excel sheet name you want to import

--- a/shell/testdata/golden/help_command.golden
+++ b/shell/testdata/golden/help_command.golden
@@ -2,7 +2,7 @@ sqly helper commands (run inside the shell; SQL needs no leading dot):
 
 Session
   .help              show this help
-  .mode MODE         change output mode (table, csv, tsv, ltsv, json, ndjson, markdown, ...)
+  .mode MODE         change output mode (table, vertical, csv, tsv, ltsv, json, ndjson, markdown, ...)
   .dialect [NAME]    show or set the query dialect (sqlite, mysql, postgresql, googlesql)
   .clear             clear the terminal screen
   .exit              exit sqly

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -56,6 +56,37 @@ sqly --json --output user.json --sql "SELECT * FROM user" user.csv
 
 Full list on the [reference page](/reference/#output-formats).
 
+### A row too wide to read across
+
+Every format above lays a record out along the line, and that stops working on the
+files sqly was written for. A 300-column row is one 2700-character line as a table,
+as CSV, as TSV, and as LTSV alike — no terminal shows it, and the column holding the
+bad value has no name beside it to search for.
+
+`--vertical` turns the row on its side: one column per line, in a block per record.
+
+```shell
+sqly --vertical --sql "SELECT * FROM wide LIMIT 1" wide.csv
+```
+
+```text
+-[ RECORD 1 ]-----------------------------------------------
+col_001 | v1
+col_002 | v2
+col_003 | BAD
+```
+
+Now the name and the value sit on one short line, so the bad column is one `grep`
+away:
+
+```shell
+sqly --vertical --sql "SELECT * FROM wide" wide.csv | grep BAD
+```
+
+In the shell it is `.mode vertical`. Vertical output is for reading, not for
+parsing — it names no file format, so `.dump` and `--output` take the format from
+the destination's extension, exactly as they do in table mode.
+
 ## 4. Four ways in
 
 | Input | How |

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -11,6 +11,7 @@ sqly is flag-driven and has no subcommands. Use `sqly --help` and `sqly --versio
 | Flag | Format |
 |:--|:--|
 | (default) | ASCII table |
+| `--vertical` | one column per line, in a block per record; for rows too wide to read across |
 | `-c`, `--csv` | CSV |
 | `-t`, `--tsv` | TSV |
 | `-l`, `--ltsv` | LTSV |

--- a/website/content/shell.md
+++ b/website/content/shell.md
@@ -38,7 +38,7 @@ Dot-commands are single-line and run on Enter. To run a query without typing `;`
 | Command | Does |
 |:--|:--|
 | `.help` | show the command list |
-| `.mode MODE` | change the output mode: `table`, `csv`, `tsv`, `ltsv`, `json`, `ndjson`, `json-typed`, `ndjson-typed`, `markdown`, `excel`, `parquet` |
+| `.mode MODE` | change the output mode: `table`, `vertical`, `csv`, `tsv`, `ltsv`, `json`, `ndjson`, `json-typed`, `ndjson-typed`, `markdown`, `excel`, `parquet` |
 | `.dialect [NAME]` | show or set the query dialect: `sqlite`, `mysql`, `postgresql`, `googlesql` |
 | `.clear` | clear the screen |
 | `.exit` | quit (so does `Ctrl-D`) |


### PR DESCRIPTION
## Summary

Every output mode lays a record out along the line, and that stops working at the width sqly was written for. A 300-column row is a single 2700-character line as a table, as CSV, as TSV, and as LTSV alike — no terminal shows it, and the column holding the bad value has no name beside it to search for.

That is the problem [about.md](https://nao1215.github.io/sqly/about/) says sqly exists to solve — "finding the bad column among 300 by hand, in a spreadsheet, is not an engineer's job" — and until now no output mode could show one.

`--vertical`, and `.mode vertical` in the shell, print one column per line in a block per record:

```
$ sqly --vertical --sql "SELECT * FROM wide LIMIT 1" wide.csv
-[ RECORD 1 ]-----------------------------------------------
col_001 | v1
col_002 | v2
col_003 | BAD
```

The name and the value are on one short line, so the bad column is one `grep` away. Measured on a 300-column row: the table mode line is 3001 characters, the CSV line 1390; vertical is 301 lines, none over 80 characters.

## Why this shape

- **A new mode, not a `\G` terminator.** sqly already has an output-mode axis (`.mode`, `--csv`/`--json`/…), and this belongs on it. `\G` is a statement-terminator variant, so supporting it would mean stripping it from the SQL before handing the statement to filesql — a display concern reaching into the parse path — and would put a second command vocabulary beside the `.`-commands. sqly has no subcommands either, so a subcommand was out.
- **psql's layout, not mysql's or sqlite3's.** A numbered record rule plus names left-aligned in a gutter reads as a list when scanning down 300 of them; sqlite3's `.mode line` has no record boundary, and mysql's right-aligned names are harder to scan. The word `vertical` is self-describing for someone who has not used mysql.
- **The gutter is measured in terminal cells, not runes.** A full-width character occupies two, so counting runes left the ASCII names beside a Japanese header out of line. The unit test for that failed on the first implementation.

## Display-only

Vertical names no file format, so `PrintMode.IsDisplayOnly` now says which modes only decide what the screen looks like. The export path asked `mode != PrintModeTable` for that; left as it was, `.dump out.tsv` in vertical mode would have been a format conflict instead of writing a TSV. `.dump`'s own help said "when .mode is table" and now names both.

## Tests

`domain/model/vertical_test.go` covers the layout, per-record rules, an empty value, the full-width gutter, a value carrying a newline or the separator, no records, a record shorter than its header, `IsDisplayOnly` for all ten modes, and the wide-row case — where it also measures the CSV line, so the comparison is not an assertion about a number nobody checked.

`e2e/atago/vertical_mode.atago.yaml` adds 9 binary scenarios: both entry points, the mode banner, setting the mode twice, full-width alignment, a wide row against the flat mode beside it, a `.dump` taking its format from the destination, rejection alongside `--profile`, conflict with another mode flag, and an empty result set.