### PR TITLE
chore(release): publish a pre-release tag as a GitHub pre-release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,6 +32,12 @@ snapshot:
 # Curated release notes: a short human summary first, then changes grouped by
 # user-facing category instead of a raw commit dump.
 release:
+  # A tag carrying a pre-release suffix (-rc1, -beta, -alpha) is published as a
+  # GitHub pre-release, so it does not become the Latest release a visitor to the
+  # repository is offered. Without this, v1.0.0-rc1 was presented as the current
+  # release of sqly. Go's module proxy already excludes such versions from
+  # `@latest`; this is the same rule applied to the release page.
+  prerelease: auto
   header: |
     ## sqly {{ .Tag }}
 


### PR DESCRIPTION
## Summary

`v1.0.0-rc1` was published as an ordinary release, so a visitor to the repository was offered a release candidate as the current version of sqly. goreleaser defaults `prerelease` to false and the config never set it, because until now sqly had never tagged anything but a final version.

`prerelease: auto` makes goreleaser read the tag: a suffix such as `-rc1`, `-beta`, or `-alpha` publishes as a GitHub pre-release, and a plain `vX.Y.Z` publishes as a release exactly as before.

## Changes

`.goreleaser.yml`: `prerelease: auto` added to the `release` block.

The already-published `v1.0.0-rc1` release was flagged by hand (`gh release edit v1.0.0-rc1 --prerelease`), which moved the repository's Latest release back to `v0.31.0`. This change is what makes the next one right without a manual step.

## Design Decisions

`auto` rather than a hardcoded `true`. The value has to be correct for every tag the workflow runs on, and the release workflow is the same one final versions go through — setting it to `true` would publish `v1.0.0` itself as a pre-release. goreleaser derives it from the tag, which is the only input that knows the difference.

Nothing changes for Go users either way: the module proxy already excludes a version with a pre-release suffix from `@latest`. What this fixes is the release page and the `releases/latest` API, which had no such rule.

## Limitations

`goreleaser check` still reports the `brews` property as deprecated. That predates this change and is left alone here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated releases with pre-release suffixes to be marked as GitHub pre-releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->