### PR TITLE
feat!: classify failures with distinct exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Exit codes now classify the failure instead of reporting every one as `1`. A bad command line or an unrunnable script exits `2`, an input that could not be read exits `3`, a destination that could not be written exits `4`, and a statement that ran and failed still exits `1`. A wrapper that only checks for non-zero is unaffected; one that checks for `1` specifically has to widen the check. The class is decided from the failure itself, so a `.save` that cannot write exits `4` inside a script exactly as it does on its own.
 
 ### New Features
-* SIGINT and SIGTERM cancel the run and exit `130` instead of killing the process. The query is cancelled, the deferred cleanup runs, and the temp directories a download or a staged stdin dataset created are removed. The interactive shell is unaffected: the prompt reads Ctrl-C as a keystroke.
+* SIGINT and SIGTERM cancel the run and exit `130` instead of killing the process. The query is canceled, the deferred cleanup runs, and the temp directories a download or a staged stdin dataset created are removed. The interactive shell is unaffected: the prompt reads Ctrl-C as a keystroke.
 
 ## [v1.0.0-rc1](https://github.com/nao1215/sqly/compare/v0.31.0...v1.0.0-rc1) (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+* Exit codes now classify the failure instead of reporting every one as `1`. A bad command line or an unrunnable script exits `2`, an input that could not be read exits `3`, a destination that could not be written exits `4`, and a statement that ran and failed still exits `1`. A wrapper that only checks for non-zero is unaffected; one that checks for `1` specifically has to widen the check. The class is decided from the failure itself, so a `.save` that cannot write exits `4` inside a script exactly as it does on its own.
+
+### New Features
+* SIGINT and SIGTERM cancel the run and exit `130` instead of killing the process. The query is cancelled, the deferred cleanup runs, and the temp directories a download or a staged stdin dataset created are removed. The interactive shell is unaffected: the prompt reads Ctrl-C as a keystroke.
+
 ## [v1.0.0-rc1](https://github.com/nao1215/sqly/compare/v0.31.0...v1.0.0-rc1) (2026-08-04)
 
 The release candidate for v1.0.0. The command surface below is what v1.0.0 commits to; this tag exists so it can be used before it is frozen.

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -584,6 +585,59 @@ func TestDialectsPage_PassThroughClaimsAreSpecified(t *testing.T) {
 	for _, m := range queries {
 		if !strings.Contains(string(specData), m[1]) {
 			t.Errorf("%s documents %q as a pass-through divergence, but %s does not assert it", page, m[1], spec)
+		}
+	}
+}
+
+// TestExitCodes_DocumentedTableMatchesTheConstants keeps the reference's exit
+// code table and the codes sqly actually returns from drifting apart. The table
+// is what a script author writes their `case $?` against, so a code that exists
+// and is undocumented is unusable and a documented code that no longer exists is
+// a wrong branch nobody notices until it is taken.
+func TestExitCodes_DocumentedTableMatchesTheConstants(t *testing.T) {
+	t.Parallel()
+
+	const (
+		page    = "website/content/reference.md"
+		section = "## Exit codes"
+	)
+
+	data, err := os.ReadFile(page)
+	if err != nil {
+		t.Fatalf("read %s: %v", page, err)
+	}
+	body := string(data)
+	start := strings.Index(body, section)
+	if start < 0 {
+		t.Fatalf("%s no longer has the %q section", page, section)
+	}
+	rest := body[start+len(section):]
+	if end := strings.Index(rest, "\n## "); end >= 0 {
+		rest = rest[:end]
+	}
+
+	documented := make(map[string]bool)
+	for _, m := range regexp.MustCompile("(?m)^\\| `(\\d+)` \\|").FindAllStringSubmatch(rest, -1) {
+		documented[m[1]] = true
+	}
+
+	defined := map[string]string{
+		strconv.Itoa(shell.ExitOK):        "ExitOK",
+		strconv.Itoa(shell.ExitFailure):   "ExitFailure",
+		strconv.Itoa(shell.ExitUsage):     "ExitUsage",
+		strconv.Itoa(shell.ExitInput):     "ExitInput",
+		strconv.Itoa(shell.ExitOutput):    "ExitOutput",
+		strconv.Itoa(shell.ExitInterrupt): "ExitInterrupt",
+	}
+
+	for code, name := range defined {
+		if !documented[code] {
+			t.Errorf("shell.%s is %s, which %s does not document", name, code, page)
+		}
+	}
+	for code := range documented {
+		if _, ok := defined[code]; !ok {
+			t.Errorf("%s documents exit code %s, which sqly no longer returns", page, code)
 		}
 	}
 }

--- a/e2e/atago/ach_fedwire_writeback.atago.yaml
+++ b/e2e/atago/ach_fedwire_writeback.atago.yaml
@@ -73,6 +73,6 @@ scenarios:
       - run:
           command: sqly --sql "SELECT * FROM payment_entries" --output out.ach payment.ach
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "input-only"

--- a/e2e/atago/cli.atago.yaml
+++ b/e2e/atago/cli.atago.yaml
@@ -41,7 +41,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" does_not_exist.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: does not exist
 
@@ -64,7 +64,7 @@ scenarios:
       - run:
           command: sqly --no-such-flag
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "unknown flag"
 
@@ -78,7 +78,7 @@ scenarios:
       - run:
           command: sqly --output-format unsupported --sql "SELECT 1" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "invalid output format"
 
@@ -152,6 +152,6 @@ scenarios:
       - run:
           command: sqly user.csv --nope
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "unknown flag"

--- a/e2e/atago/collision.atago.yaml
+++ b/e2e/atago/collision.atago.yaml
@@ -22,6 +22,6 @@ scenarios:
       - run:
           command: sqly --inspect a-b.csv a_b.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: collision

--- a/e2e/atago/cookbook.atago.yaml
+++ b/e2e/atago/cookbook.atago.yaml
@@ -227,7 +227,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" ragged.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: column count mismatch
 

--- a/e2e/atago/dialect.atago.yaml
+++ b/e2e/atago/dialect.atago.yaml
@@ -421,7 +421,7 @@ scenarios:
       - run:
           command: sqly --dialect oracle --sql "SELECT 1" users.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains:
               - "unknown SQL dialect"

--- a/e2e/atago/empty_args.atago.yaml
+++ b/e2e/atago/empty_args.atago.yaml
@@ -53,6 +53,6 @@ scenarios:
           command: sqly
           stdin: ".import \"\"\n.tables\n"
       - assert:
-          exit_code: 3
+          exit_code: 2
           stderr:
-            contains: "empty import path"
+            contains: "was given an empty path"

--- a/e2e/atago/empty_args.atago.yaml
+++ b/e2e/atago/empty_args.atago.yaml
@@ -53,6 +53,6 @@ scenarios:
           command: sqly
           stdin: ".import \"\"\n.tables\n"
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: "empty import path"

--- a/e2e/atago/excel_sheets.atago.yaml
+++ b/e2e/atago/excel_sheets.atago.yaml
@@ -119,7 +119,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" blank.xlsx
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: "produced no table"
       - assert:
@@ -136,7 +136,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" broken.xlsx
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: broken.xlsx
 

--- a/e2e/atago/exit_codes.atago.yaml
+++ b/e2e/atago/exit_codes.atago.yaml
@@ -235,6 +235,11 @@ scenarios:
   # so the ready marker cannot appear before sqly has the FIFO open. A sleep
   # would only be a guess about how long that takes.
   #
+  # The FIFO writer runs with its stdio on /dev/null and `exec`s the sleep, so it
+  # is one process that `kill` reaches directly and that never holds the test
+  # runner's capture pipes open. Backgrounding a subshell that keeps them was
+  # enough to error these scenarios on macOS while passing on Linux.
+  #
   # Second, the exit status alone proves nothing here, for two reasons. A process
   # killed by the default SIGINT handler is also reported as 130 by the shell —
   # so stderr is asserted, and a process killed outright never gets to write it.
@@ -254,7 +259,7 @@ scenarios:
             id
             1
       - run:
-          command: sh -c 'mkfifo pipe; (exec 3> pipe; touch writer-ready; sleep 30) & holder=$!; sqly rows.csv < pipe > /dev/null 2> err.log & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; start=$(date +%s); kill -INT $child; wait $child; code=$?; elapsed=$(( $(date +%s) - start )); kill $holder 2>/dev/null; echo "exit=$code"; [ "$elapsed" -le 5 ] && echo prompt || echo "slow after ${elapsed}s"'
+          command: sh -c 'mkfifo pipe; (exec 3> pipe; touch writer-ready; exec sleep 30) >/dev/null 2>&1 & holder=$!; sqly rows.csv < pipe > /dev/null 2> err.log & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; start=$(date +%s); kill -INT $child; wait $child; code=$?; elapsed=$(( $(date +%s) - start )); kill $holder 2>/dev/null; wait $holder 2>/dev/null; echo "exit=$code"; [ "$elapsed" -le 5 ] && echo prompt || echo "slow after ${elapsed}s"'
           shell: true
       - assert:
           exit_code: 0
@@ -282,7 +287,7 @@ scenarios:
           # run created. The staging directory is made before the read blocks, so
           # by the time the signal arrives there is something to clean up: a
           # process killed outright would leave it behind.
-          command: sh -c 'mkdir -p tmp; export TMPDIR="$PWD/tmp"; mkfifo pipe; (exec 3> pipe; touch writer-ready; sleep 30) & holder=$!; sqly --stdin-format csv --sql "SELECT 1" < pipe > /dev/null 2>/dev/null & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; kill -INT $child; wait $child; kill $holder 2>/dev/null; ls tmp | grep -c sqly- || echo 0'
+          command: sh -c 'mkdir -p tmp; export TMPDIR="$PWD/tmp"; mkfifo pipe; (exec 3> pipe; touch writer-ready; exec sleep 30) >/dev/null 2>&1 & holder=$!; sqly --stdin-format csv --sql "SELECT 1" < pipe > /dev/null 2>/dev/null & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; kill -INT $child; wait $child; kill $holder 2>/dev/null; wait $holder 2>/dev/null; ls tmp | grep -c sqly- || echo 0'
           shell: true
       - assert:
           exit_code: 0

--- a/e2e/atago/exit_codes.atago.yaml
+++ b/e2e/atago/exit_codes.atago.yaml
@@ -229,8 +229,22 @@ scenarios:
   # 130: the run was stopped by a signal. This is the class a unit test cannot
   # reach — it is the process's own exit status, produced by the signal handler,
   # the cancellation reaching a blocking read, and the cleanup that follows.
-  - name: an interrupted run exits 130
-    # Needs a POSIX shell for job control and kill.
+  #
+  # Two things make these scenarios prove something. First, the FIFO writer is
+  # what synchronizes: `exec > pipe` blocks until a reader opens the other end,
+  # so the ready marker cannot appear before sqly has the FIFO open. A sleep
+  # would only be a guess about how long that takes.
+  #
+  # Second, the exit status alone proves nothing here, for two reasons. A process
+  # killed by the default SIGINT handler is also reported as 130 by the shell —
+  # so stderr is asserted, and a process killed outright never gets to write it.
+  # And a run that ignores the cancellation still exits 130 eventually, once the
+  # FIFO writer goes away and the read finally returns: that is the original bug,
+  # and it is invisible to any assertion that does not care how long it took. So
+  # the elapsed time between the signal and the exit is what is checked, not just
+  # the code.
+  - name: an interrupted run exits 130 after reporting the cancellation itself
+    # Needs a POSIX shell for job control, FIFOs, and kill.
     skip:
       os: windows
     steps:
@@ -240,16 +254,19 @@ scenarios:
             id
             1
       - run:
-          # A FIFO whose writer never writes: sqly reads it as a script and
-          # blocks. Before the signal handler observed cancellation this hung
-          # forever on SIGINT instead of exiting, which is the regression the
-          # scenario exists to catch.
-          command: sh -c 'mkfifo pipe; sleep 30 > pipe & holder=$!; sqly rows.csv < pipe >/dev/null 2>/dev/null & child=$!; sleep 1; kill -INT $child; wait $child; code=$?; kill $holder 2>/dev/null; echo "exit=$code"'
+          command: sh -c 'mkfifo pipe; (exec 3> pipe; touch writer-ready; sleep 30) & holder=$!; sqly rows.csv < pipe > /dev/null 2> err.log & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; start=$(date +%s); kill -INT $child; wait $child; code=$?; elapsed=$(( $(date +%s) - start )); kill $holder 2>/dev/null; echo "exit=$code"; [ "$elapsed" -le 5 ] && echo prompt || echo "slow after ${elapsed}s"'
           shell: true
       - assert:
           exit_code: 0
           stdout:
-            contains: "exit=130"
+            contains:
+              - "exit=130"
+              - "prompt"
+      - assert:
+          # A process killed outright never gets to say this.
+          file:
+            path: err.log
+            contains: "context canceled"
 
   - name: an interrupted run leaves no staged temp directory behind
     skip:
@@ -261,10 +278,11 @@ scenarios:
             id
             1
       - run:
-          # TMPDIR is redirected into the workdir so the check sees only what
-          # this run created. A signal that killed the process outright would
-          # leave the staged stdin dataset behind.
-          command: sh -c 'mkdir -p tmp; export TMPDIR="$PWD/tmp"; mkfifo pipe; sleep 30 > pipe & holder=$!; sqly --stdin-format csv --sql "SELECT 1" < pipe >/dev/null 2>/dev/null & child=$!; sleep 1; kill -INT $child; wait $child; kill $holder 2>/dev/null; ls tmp | grep -c sqly- || echo 0'
+          # TMPDIR is redirected into the workdir so the check sees only what this
+          # run created. The staging directory is made before the read blocks, so
+          # by the time the signal arrives there is something to clean up: a
+          # process killed outright would leave it behind.
+          command: sh -c 'mkdir -p tmp; export TMPDIR="$PWD/tmp"; mkfifo pipe; (exec 3> pipe; touch writer-ready; sleep 30) & holder=$!; sqly --stdin-format csv --sql "SELECT 1" < pipe > /dev/null 2>/dev/null & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; kill -INT $child; wait $child; kill $holder 2>/dev/null; ls tmp | grep -c sqly- || echo 0'
           shell: true
       - assert:
           exit_code: 0

--- a/e2e/atago/exit_codes.atago.yaml
+++ b/e2e/atago/exit_codes.atago.yaml
@@ -1,0 +1,227 @@
+# The exit code contract. A wrapper that runs sqly from a shell script or CI has
+# one question when it fails: whose fault was it. Each class below is a different
+# answer and a different next step, so they are checked against the real binary —
+# a unit test on the classifier cannot see the code the process actually returns.
+#
+# The hermetic runner (scripts/run_e2e.sh) builds sqly and puts it on PATH.
+# Run with: make test-e2e
+version: "1"
+
+suite:
+  name: sqly exit code contract
+
+scenarios:
+  - name: a run that succeeds exits 0
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly --sql "SELECT actor FROM actor" actor.csv
+      - assert:
+          exit_code: 0
+
+  # 2: the command line or the script is not acceptable. Nothing was read and
+  # nothing was written, so the fix is always on the command line.
+  - name: an unknown flag exits 2
+    steps:
+      - run:
+          command: sqly --no-such-flag
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "unknown flag"
+
+  - name: no arguments and no stdin script exits 2
+    steps:
+      - run:
+          command: sqly
+          stdin: ""
+      - assert:
+          exit_code: 2
+
+  - name: two flags that contradict exit 2
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly --inspect --sql "SELECT 1" actor.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "--inspect cannot be combined with --sql"
+
+  - name: a binary output format with nowhere to write it exits 2
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly --output-format parquet --sql "SELECT 1" actor.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "add --output FILE"
+
+  - name: a helper command in a SQL file exits 2
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - fixture:
+          file: q.sql
+          content: |
+            SELECT 1;
+            .save --in-place
+      - run:
+          command: sqly --sql-file q.sql actor.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "helper command"
+
+  - name: two results in a format that cannot separate them exits 2
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - fixture:
+          file: q.sql
+          content: |
+            SELECT 1;
+            SELECT 2;
+      - run:
+          command: sqly --output-format csv --sql-file q.sql actor.csv
+      - assert:
+          exit_code: 2
+
+  # 3: an input could not be read. The command line was fine; a different file,
+  # or a fixed one, is the next step.
+  - name: an input path that does not exist exits 3
+    steps:
+      - run:
+          command: sqly no_such_file.csv
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "path does not exist"
+
+  - name: one missing input among several exits 3
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly --sql "SELECT 1" actor.csv no_such_file.csv
+      - assert:
+          exit_code: 3
+
+  - name: a --sql-file that does not exist exits 3
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly --sql-file no_such_query.sql actor.csv
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "--sql-file"
+
+  # 4: a destination could not be written. Results may already have been
+  # produced, so a retry has to consider what is on disk.
+  - name: an output destination whose parent is missing exits 4
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly --sql "SELECT 1" --output no_such_dir/out.csv actor.csv
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "does not exist"
+
+  - name: saving a table with no file behind it exits 4
+    steps:
+      - run:
+          command: sqly --stdin-format csv --stdin-table piped
+          stdin: |
+            a,b
+            1,2
+      - assert:
+          exit_code: 2
+
+  - name: a save to a source format sqly cannot write exits 4
+    steps:
+      - fixture:
+          file: rows.json
+          content: |
+            {"a": 1}
+      - run:
+          command: sqly rows.json
+          stdin: "UPDATE rows SET data = '{\"a\": 2}';\n.save --in-place\n"
+      - assert:
+          exit_code: 4
+
+  # 1: the invocation and the data were both fine and a statement failed. This
+  # is the only class where the SQL itself is what needs changing.
+  - name: a query against a table that does not exist exits 1
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly --sql "SELECT * FROM no_such_table" actor.csv
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "no such table"
+
+  - name: a syntax error in a piped script exits 1
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly actor.csv
+          stdin: "SELECT FROM WHERE;\n"
+      - assert:
+          exit_code: 1
+
+  # The classes must stay distinct: results go to stdout and every diagnostic to
+  # stderr, so a pipeline that reads stdout never sees an error message.
+  - name: a failing run writes nothing to stdout
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,age
+            Ken,40
+      - run:
+          command: sqly --sql "SELECT * FROM no_such_table" actor.csv
+      - assert:
+          exit_code: 1
+          stdout:
+            empty: true

--- a/e2e/atago/exit_codes.atago.yaml
+++ b/e2e/atago/exit_codes.atago.yaml
@@ -225,3 +225,48 @@ scenarios:
           exit_code: 1
           stdout:
             empty: true
+
+  # 130: the run was stopped by a signal. This is the class a unit test cannot
+  # reach — it is the process's own exit status, produced by the signal handler,
+  # the cancellation reaching a blocking read, and the cleanup that follows.
+  - name: an interrupted run exits 130
+    # Needs a POSIX shell for job control and kill.
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: rows.csv
+          content: |
+            id
+            1
+      - run:
+          # A FIFO whose writer never writes: sqly reads it as a script and
+          # blocks. Before the signal handler observed cancellation this hung
+          # forever on SIGINT instead of exiting, which is the regression the
+          # scenario exists to catch.
+          command: sh -c 'mkfifo pipe; sleep 30 > pipe & holder=$!; sqly rows.csv < pipe >/dev/null 2>/dev/null & child=$!; sleep 1; kill -INT $child; wait $child; code=$?; kill $holder 2>/dev/null; echo "exit=$code"'
+          shell: true
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "exit=130"
+
+  - name: an interrupted run leaves no staged temp directory behind
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: rows.csv
+          content: |
+            id
+            1
+      - run:
+          # TMPDIR is redirected into the workdir so the check sees only what
+          # this run created. A signal that killed the process outright would
+          # leave the staged stdin dataset behind.
+          command: sh -c 'mkdir -p tmp; export TMPDIR="$PWD/tmp"; mkfifo pipe; sleep 30 > pipe & holder=$!; sqly --stdin-format csv --sql "SELECT 1" < pipe >/dev/null 2>/dev/null & child=$!; sleep 1; kill -INT $child; wait $child; kill $holder 2>/dev/null; ls tmp | grep -c sqly- || echo 0'
+          shell: true
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "0"

--- a/e2e/atago/export_inference.atago.yaml
+++ b/e2e/atago/export_inference.atago.yaml
@@ -90,7 +90,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT identifier FROM user LIMIT 1" user.csv --output outdir
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: directory
           file:
@@ -107,7 +107,7 @@ scenarios:
           command: sqly user.csv
           stdin: ".dump user outdir\n"
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: directory
 

--- a/e2e/atago/file_write_contract.atago.yaml
+++ b/e2e/atago/file_write_contract.atago.yaml
@@ -161,7 +161,7 @@ scenarios:
       - run:
           command: sqly --output-format parquet --sql "SELECT a FROM rows" rows.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--output"
 
@@ -172,7 +172,7 @@ scenarios:
       - run:
           command: sqly --output-format csv --output out.ach --sql "SELECT a FROM rows" rows.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           file:
             path: out.ach
             exists: false

--- a/e2e/atago/flag_validation.atago.yaml
+++ b/e2e/atago/flag_validation.atago.yaml
@@ -18,7 +18,7 @@ scenarios:
       - run:
           command: sqly --output-format parquet --sql "SELECT * FROM user" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stdout:
             equals: ""
           stderr:
@@ -32,7 +32,7 @@ scenarios:
       - run:
           command: sqly --output-format excel --sql "SELECT * FROM user" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stdout:
             equals: ""
           stderr:
@@ -55,7 +55,7 @@ scenarios:
       - run:
           command: sqly --stdin-table piped --sql "SELECT 1" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--stdin-format"
 
@@ -129,7 +129,7 @@ scenarios:
       - run:
           command: sqly --output out.csv --sql-file two.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "result sets"
           file:
@@ -146,7 +146,7 @@ scenarios:
       - run:
           command: sqly --output out.csv --sql-file none.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "one result set"
           file:
@@ -168,7 +168,7 @@ scenarios:
       - run:
           command: sqly --output-format csv --sql-file two.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stdout:
             equals: ""
           stderr:
@@ -183,7 +183,7 @@ scenarios:
       - run:
           command: sqly --output-format json --sql-file two.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stdout:
             equals: ""
           stderr:
@@ -196,7 +196,7 @@ scenarios:
       - run:
           command: sqly --output-format jsonl --sql-file two.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stdout:
             equals: ""
           stderr:
@@ -237,7 +237,7 @@ scenarios:
       - run:
           command: sqly --output nodir/out.csv --sql "SELECT 1" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "does not exist"
           file:

--- a/e2e/atago/http_import.atago.yaml
+++ b/e2e/atago/http_import.atago.yaml
@@ -74,7 +74,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" s3://bucket/data.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains:
               - 's3://bucket/data.csv'
@@ -91,7 +91,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" file:///tmp/user.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains:
               - "file"
@@ -105,7 +105,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" weird:name.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: "path does not exist"
             not_contains: "only http and https URLs"

--- a/e2e/atago/import_failure.atago.yaml
+++ b/e2e/atago/import_failure.atago.yaml
@@ -17,7 +17,7 @@ scenarios:
       - run:
           command: sqly --output-format json --sql "SELECT user_name FROM user LIMIT 1" user.csv /no/such/file.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stdout:
             empty: true
           stderr:
@@ -30,7 +30,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" /no/such/a.csv /no/such/b.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stdout:
             empty: true
           stderr:
@@ -45,7 +45,7 @@ scenarios:
       - run:
           command: sqly --inspect user.csv /no/such/file.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stdout:
             empty: true
           stderr:
@@ -58,7 +58,7 @@ scenarios:
           command: sqly
           stdin: ".import user.csv /no/such/file.csv\n.tables\n"
       - assert:
-          exit_code: 1
+          exit_code: 3
           stdout:
             not_contains: "TABLE NAME"
           stderr:
@@ -69,7 +69,7 @@ scenarios:
       - run:
           command: sqly --stdin-format csv --output-format json --sql "SELECT COUNT(*) FROM stdin"
       - assert:
-          exit_code: 1
+          exit_code: 3
           stdout:
             empty: true
           stderr:

--- a/e2e/atago/import_quoting.atago.yaml
+++ b/e2e/atago/import_quoting.atago.yaml
@@ -72,6 +72,6 @@ scenarios:
           command: sqly
           stdin: ".import space name.csv\n"
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: space

--- a/e2e/atago/inspect_conflicts.atago.yaml
+++ b/e2e/atago/inspect_conflicts.atago.yaml
@@ -17,7 +17,7 @@ scenarios:
       - run:
           command: sqly --inspect --sql "SELECT * FROM user LIMIT 1" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--inspect"
 
@@ -27,7 +27,7 @@ scenarios:
       - run:
           command: sqly --inspect --output out.csv user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--inspect"
           file:

--- a/e2e/atago/inspect_contract.atago.yaml
+++ b/e2e/atago/inspect_contract.atago.yaml
@@ -82,7 +82,7 @@ scenarios:
       - run:
           command: sqly --inspect stable.csv --output-format table
       - assert:
-          exit_code: 1
+          exit_code: 2
       - run:
           command: sh -c "sqly --inspect stable.csv > one.json && sqly --inspect stable.csv > two.json && cmp one.json two.json"
           shell: true

--- a/e2e/atago/output_requires_sql.atago.yaml
+++ b/e2e/atago/output_requires_sql.atago.yaml
@@ -25,7 +25,7 @@ scenarios:
       - run:
           command: sqly user.csv --output out.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--output requires --sql"
           file:
@@ -43,7 +43,7 @@ scenarios:
           command: sqly user.csv --output out.csv
           stdin: "SELECT user_name FROM user ORDER BY identifier LIMIT 1\n"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--output requires --sql"
           file:

--- a/e2e/atago/path_validation.atago.yaml
+++ b/e2e/atago/path_validation.atago.yaml
@@ -58,7 +58,7 @@ scenarios:
       - run:
           command: sqly --inspect hosts_alias.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: "system directory not allowed"
 

--- a/e2e/atago/row_mismatch.atago.yaml
+++ b/e2e/atago/row_mismatch.atago.yaml
@@ -20,7 +20,7 @@ scenarios:
       - run:
           command: sqly --output-format json --sql "SELECT name FROM ragged" ragged.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stdout:
             empty: true
           stderr:
@@ -66,7 +66,7 @@ scenarios:
       - run:
           command: sqly --row-mismatch pad --sql "SELECT * FROM too_many_fields" too_many_fields.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stdout:
             empty: true
           stderr:
@@ -77,7 +77,7 @@ scenarios:
       - run:
           command: sqly --row-mismatch keep --sql "SELECT 1"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "invalid row-mismatch policy"
 
@@ -124,7 +124,7 @@ scenarios:
       - run:
           command: sqly --row-mismatch skip --sql "SELECT 1" docs.jsonl
       - assert:
-          exit_code: 1
+          exit_code: 2
           stdout:
             equals: ""
           stderr:

--- a/e2e/atago/save.atago.yaml
+++ b/e2e/atago/save.atago.yaml
@@ -173,7 +173,7 @@ scenarios:
           command: sqly
           stdin: ".save --in-place\n"
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains:
               - "no tables to save"

--- a/e2e/atago/script_contract.atago.yaml
+++ b/e2e/atago/script_contract.atago.yaml
@@ -36,7 +36,7 @@ scenarios:
       - run:
           command: sqly --sql-file save.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains:
               - "line 2"
@@ -58,7 +58,7 @@ scenarios:
       - run:
           command: sqly --sql-file imp.sql
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains:
               - "line 1"
@@ -77,7 +77,7 @@ scenarios:
       - run:
           command: sqly --sql-file mode.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains:
               - "line 3"
@@ -95,7 +95,7 @@ scenarios:
       - run:
           command: sqly --sql-file mixed.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           file:
             path: out
             exists: false
@@ -223,7 +223,7 @@ scenarios:
           command: sqly user.csv
           stdin: "SELECT 1; .tables\n"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "must start its own line"
 
@@ -325,7 +325,7 @@ scenarios:
           command: sqly --stdin-format csv
           stdin: "a\n1\n"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "no script to run"
 
@@ -340,6 +340,6 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" --sql-file q.sql user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "cannot be used together"

--- a/e2e/atago/sql_file.atago.yaml
+++ b/e2e/atago/sql_file.atago.yaml
@@ -86,7 +86,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" --sql-file q.sql actor.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--sql-file"
 
@@ -96,7 +96,7 @@ scenarios:
       - run:
           command: sqly --sql-file no_such.sql actor.csv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: "sql-file"
 
@@ -109,7 +109,7 @@ scenarios:
       - run:
           command: sqly --sql-file empty.sql actor.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: empty
 

--- a/e2e/atago/sqlfile_output.atago.yaml
+++ b/e2e/atago/sqlfile_output.atago.yaml
@@ -62,7 +62,7 @@ scenarios:
       - run:
           command: sqly --sql-file q.sql --output out.csv user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "result set"
           file:
@@ -80,7 +80,7 @@ scenarios:
       - run:
           command: sqly --sql-file q.sql --output out.csv user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "result sets"
           file:

--- a/e2e/atago/state_integrity.atago.yaml
+++ b/e2e/atago/state_integrity.atago.yaml
@@ -177,7 +177,7 @@ scenarios:
           command: sqly ./shop
           stdin: ".import shop/sample.xlsx\nUPDATE sample_test SET label = 'edited';\n.save --in-place\n"
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: sample_test
       - assert:
@@ -224,7 +224,7 @@ scenarios:
           command: sqly ./shop
           stdin: ".import shop/a.csv\nUPDATE b SET label = 'edited';\n.save --in-place\n"
       - assert:
-          exit_code: 1
+          exit_code: 4
           file:
             path: shop/b.csv
             contains: b-original
@@ -261,7 +261,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1" collide.xlsx
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains:
               - "Q1 sales"
@@ -278,7 +278,7 @@ scenarios:
           command: sqly collide.xlsx
           stdin: ".tables\n"
       - assert:
-          exit_code: 1
+          exit_code: 3
           stdout:
             not_contains: collide_Q1_sales
 

--- a/e2e/atago/stdin_dataset.atago.yaml
+++ b/e2e/atago/stdin_dataset.atago.yaml
@@ -117,7 +117,7 @@ scenarios:
             id,name
             1,alice
       - assert:
-          exit_code: 1
+          exit_code: 2
           stdout:
             not_contains: affected
           stderr:
@@ -134,7 +134,7 @@ scenarios:
             id,name
             1,alice
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "stdin-table"
 
@@ -146,7 +146,7 @@ scenarios:
             a
             1
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "stdin-table"
           file:

--- a/e2e/atago/v0_18_bugs.atago.yaml
+++ b/e2e/atago/v0_18_bugs.atago.yaml
@@ -12,7 +12,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1 AS x" --output ""
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--output"
 
@@ -21,7 +21,7 @@ scenarios:
       - run:
           command: sqly --sql-file ""
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--sql-file"
 
@@ -33,7 +33,7 @@ scenarios:
             id,name
             1,a
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--stdin-format"
 
@@ -42,7 +42,7 @@ scenarios:
       - run:
           command: sqly --output-format unsupported --sql "SELECT 1 AS x"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "invalid output format"
 
@@ -69,7 +69,7 @@ scenarios:
       - run:
           command: sqly --sql "UPDATE u SET first_name='X' WHERE identifier=1" --output out.csv u.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--output"
           file:
@@ -99,7 +99,7 @@ scenarios:
       - run:
           command: sqly --sql-file q.sql
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "no executable"
 
@@ -139,7 +139,7 @@ scenarios:
             id,name
             1,a
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--stdin-format"
 
@@ -174,7 +174,7 @@ scenarios:
       - run:
           command: sqly --inspect dir
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: collision
 
@@ -215,7 +215,7 @@ scenarios:
             UPDATE user SET first_name='P' WHERE identifier=1;
             .save .
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: source
 
@@ -237,7 +237,7 @@ scenarios:
             UPDATE user SET first_name='Q' WHERE identifier=1;
             .save out
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "already exists"
 
@@ -254,7 +254,7 @@ scenarios:
             UPDATE sample_test_sheet SET name='X' WHERE id=1;
             .save out
       - assert:
-          exit_code: 1
+          exit_code: 4
           stdout:
             not_contains: affected
           stderr:

--- a/e2e/atago/v0_19_bugs.atago.yaml
+++ b/e2e/atago/v0_19_bugs.atago.yaml
@@ -139,7 +139,7 @@ scenarios:
       - run:
           command: sqly --stdin-table weird --output-format csv --sql "SELECT 1 AS x"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "stdin-table"
 
@@ -148,7 +148,7 @@ scenarios:
       - run:
           command: sqly --inspect-sample 0 --output-format csv --sql "SELECT 1 AS x"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "inspect-sample"
 
@@ -158,7 +158,7 @@ scenarios:
       - run:
           command: sqly --inspect --output-format csv user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: inspect
 
@@ -194,7 +194,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1 AS x" --output "outdir/" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: separator
 
@@ -204,7 +204,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT identifier FROM user LIMIT 1" --output out.ach user.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "input-only"
 

--- a/e2e/atago/v0_20_bugs.atago.yaml
+++ b/e2e/atago/v0_20_bugs.atago.yaml
@@ -402,7 +402,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT * FROM user LIMIT 1" --output out.ach.gz.zst user.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "ACH/Fedwire"
           file:
@@ -457,6 +457,6 @@ scenarios:
       - run:
           command: sqly --sql "SELECT * FROM dup" dup.ltsv
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             empty: false

--- a/e2e/atago/v0_21_bugs.atago.yaml
+++ b/e2e/atago/v0_21_bugs.atago.yaml
@@ -147,7 +147,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1 AS x; SELECT 2 AS y" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "single SQL statement"
 
@@ -158,7 +158,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1 AS x; UPDATE user SET first_name='z'" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "single SQL statement"
 
@@ -168,7 +168,7 @@ scenarios:
       - run:
           command: sqly --output-format csv --sql "SELECT 1 AS x; SELECT 2 AS y" --output out.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "single SQL statement"
           file:

--- a/e2e/atago/v0_22_bugs.atago.yaml
+++ b/e2e/atago/v0_22_bugs.atago.yaml
@@ -95,7 +95,7 @@ scenarios:
       - run:
           command: sqly --sql "SELECT 1 AS x" --output fake.ach.gzip.zst
       - assert:
-          exit_code: 1
+          exit_code: 4
           file:
             path: fake.ach.gzip.zst
             exists: false

--- a/e2e/atago/v0_25_bugs.atago.yaml
+++ b/e2e/atago/v0_25_bugs.atago.yaml
@@ -128,7 +128,7 @@ scenarios:
           command: sqly user.csv
           stdin: ".import\n"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: ".import requires"
 

--- a/e2e/atago/v0_25_bugs.atago.yaml
+++ b/e2e/atago/v0_25_bugs.atago.yaml
@@ -22,7 +22,7 @@ scenarios:
       - run:
           command: sqly --sql "" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--sql requires a non-empty SQL statement"
 
@@ -33,7 +33,7 @@ scenarios:
           command: sqly
           stdin: "\n"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "no TTY detected"
 
@@ -45,7 +45,7 @@ scenarios:
           command: sqly user.csv
           stdin: "\n"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "no TTY detected"
 
@@ -56,7 +56,7 @@ scenarios:
           command: sqly --stdin-format csv --sql "SELECT COUNT(*) FROM stdin"
           stdin: "\n"
       - assert:
-          exit_code: 1
+          exit_code: 3
           stderr:
             contains: "stdin (--stdin-format csv)"
 
@@ -167,7 +167,7 @@ scenarios:
       - run:
           command: sqly help
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains:
               - "--help"
@@ -182,7 +182,7 @@ scenarios:
       - run:
           command: sqly version
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "--version"
       - assert:

--- a/e2e/atago/vertical_mode.atago.yaml
+++ b/e2e/atago/vertical_mode.atago.yaml
@@ -121,7 +121,7 @@ scenarios:
       - run:
           command: sqly --output-format unsupported --sql "SELECT 1" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
 

--- a/main.go
+++ b/main.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/nao1215/sqly/config"
 	"github.com/nao1215/sqly/di"
+	"github.com/nao1215/sqly/shell"
 )
 
 // osExit is a variable that holds the os.Exit function.
@@ -22,21 +25,37 @@ func main() {
 }
 
 // run execute sqly command. This function do dependency injection
-// and run the interactive shell.
-// Returns 0 for success case, 1 for error case.
+// and run the interactive shell. The exit code classifies the failure; see
+// shell.ExitCode for what each one means.
+//
+// SIGINT and SIGTERM cancel the run's context rather than killing the process,
+// so the deferred cleanup still removes the temp directories a download or a
+// staged stdin dataset created. The interactive shell is unaffected: the prompt
+// puts the terminal in raw mode, where Ctrl-C arrives as a keystroke and no
+// signal is delivered at all.
 func run(args []string) int {
-	shell, cleanup, err := di.NewShell(args)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	sqlyShell, cleanup, err := di.NewShell(args)
 	if err != nil {
 		fmt.Fprintln(config.Stderr, startupErrorMessage(err))
-		return 1
+		return shell.ExitCode(err)
 	}
 	defer cleanup()
 
-	if err := shell.Run(context.Background()); err != nil {
+	if err := sqlyShell.Run(ctx); err != nil {
 		fmt.Fprintf(config.Stderr, "%v\n", err)
-		return 1
+		// A cancelled context is reported as an interrupt whatever the failing
+		// statement called it. A query that notices the cancellation first returns
+		// a driver error that says nothing about a signal, so the signal's own
+		// record of what happened is what decides.
+		if ctx.Err() != nil {
+			return shell.ExitInterrupt
+		}
+		return shell.ExitCode(err)
 	}
-	return 0
+	return shell.ExitOK
 }
 
 // startupErrorMessage renders the stderr line for an error returned by

--- a/main.go
+++ b/main.go
@@ -36,6 +36,16 @@ func main() {
 func run(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	// Trapping a signal takes away the one guarantee the default handler gave:
+	// that it always kills the process. Cancellation reaches every blocking read
+	// sqly does itself, but not one inside a dependency or the kernel, and a CLI
+	// that can swallow Ctrl-C is worse than one that exits untidily. Restoring the
+	// default disposition after the first signal means a second one kills it
+	// outright, which is the usual "press it again" contract.
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
 
 	sqlyShell, cleanup, err := di.NewShell(args)
 	if err != nil {
@@ -46,7 +56,7 @@ func run(args []string) int {
 
 	if err := sqlyShell.Run(ctx); err != nil {
 		fmt.Fprintf(config.Stderr, "%v\n", err)
-		// A cancelled context is reported as an interrupt whatever the failing
+		// A canceled context is reported as an interrupt whatever the failing
 		// statement called it. A query that notices the cancellation first returns
 		// a driver error that says nothing about a signal, so the signal's own
 		// record of what happened is what decides.

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/nao1215/sqly/config"
+	"github.com/nao1215/sqly/shell"
 	"github.com/nao1215/sqly/testutil"
 )
 
@@ -89,17 +90,39 @@ func Test_run(t *testing.T) {
 }
 
 func Test_runErrPatern(t *testing.T) {
-	t.Run("empty argument", func(t *testing.T) {
+	t.Run("empty argument is a usage error", func(t *testing.T) {
 		got := run([]string{})
-		if got != 1 {
-			t.Errorf("mismatch got=%d, want=%d", got, 1)
+		if got != shell.ExitUsage {
+			t.Errorf("mismatch got=%d, want=%d", got, shell.ExitUsage)
 		}
 	})
 
-	t.Run("specify ocsv file that do not exist", func(t *testing.T) {
+	t.Run("an unknown flag is a usage error", func(t *testing.T) {
+		got := run([]string{"sqly", "--no-such-flag"})
+		if got != shell.ExitUsage {
+			t.Errorf("mismatch got=%d, want=%d", got, shell.ExitUsage)
+		}
+	})
+
+	t.Run("a csv file that does not exist is an input error", func(t *testing.T) {
 		got := run([]string{"sqly", "not_exist.csv"})
-		if got != 1 {
-			t.Errorf("mismatch got=%d, want=%d", got, 1)
+		if got != shell.ExitInput {
+			t.Errorf("mismatch got=%d, want=%d", got, shell.ExitInput)
+		}
+	})
+
+	t.Run("an output destination whose parent is missing is an output error", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "no-such-dir", "out.csv")
+		got := run([]string{"sqly", "--sql", "SELECT 1", "--output", dest, "testdata/actor.csv"})
+		if got != shell.ExitOutput {
+			t.Errorf("mismatch got=%d, want=%d", got, shell.ExitOutput)
+		}
+	})
+
+	t.Run("a failing query is the general failure code", func(t *testing.T) {
+		got := run([]string{"sqly", "--sql", "SELECT * FROM no_such_table", "testdata/actor.csv"})
+		if got != shell.ExitFailure {
+			t.Errorf("mismatch got=%d, want=%d", got, shell.ExitFailure)
 		}
 	})
 

--- a/shell/applicability.go
+++ b/shell/applicability.go
@@ -44,12 +44,12 @@ var delimitedImportExtensions = map[string]bool{
 // run reads no file and writes nothing.
 func (s *Shell) validateOptionApplicability() error {
 	if s.argument.IsExplicit("encoding") && !s.hasInputMatching(textImportExtensions) {
-		return fmt.Errorf("--encoding %s applies to csv, tsv, ltsv, json, and jsonl inputs, and this run has none; drop the flag",
-			s.argument.Encoding)
+		return &invocationError{Err: fmt.Errorf("--encoding %s applies to csv, tsv, ltsv, json, and jsonl inputs, and this run has none; drop the flag",
+			s.argument.Encoding)}
 	}
 	if s.argument.IsExplicit("row-mismatch") && !s.hasInputMatching(delimitedImportExtensions) {
-		return fmt.Errorf("--row-mismatch %s applies to csv and tsv inputs, and this run has none; drop the flag",
-			s.argument.RowMismatch)
+		return &invocationError{Err: fmt.Errorf("--row-mismatch %s applies to csv and tsv inputs, and this run has none; drop the flag",
+			s.argument.RowMismatch)}
 	}
 	return nil
 }

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -56,7 +56,7 @@ func (s *Shell) runScriptElements(ctx context.Context, elements []scriptElement)
 			}
 			fmt.Fprintf(config.Stderr, "batch statement %d failed at %s: %q: %v\n",
 				i+1, loc, previewStatement(element.text), runErr)
-			failErr = errors.New("batch stopped: statement failed")
+			failErr = &batchStopError{Err: runErr}
 			break
 		}
 	}
@@ -554,15 +554,19 @@ func withMainVerb(stmt string) string {
 // inspect it with errors.Is) and rejects a file with no SQL, so an empty or
 // whitespace-only script fails loudly instead of running nothing.
 func readSQLFile(path string) (string, error) {
+	// The two kinds of failure below are told apart deliberately. A path that
+	// cannot be read is a problem with the file, like any other input; a file that
+	// was read and holds no statement is a problem with what the user wrote. They
+	// exit with different codes, so they are different types here.
 	data, err := os.ReadFile(path) //nolint:gosec // path is the user-specified --sql-file
 	if err != nil {
-		return "", fmt.Errorf("failed to read --sql-file %q: %w", path, err)
+		return "", &scriptSourceError{Err: fmt.Errorf("failed to read --sql-file %q: %w", path, err)}
 	}
 	// Strip a leading UTF-8 BOM so a BOM-prefixed script (common from Windows
 	// editors and export tools) parses the same as plain UTF-8.
 	content := strings.TrimPrefix(string(data), "\ufeff")
 	if strings.TrimSpace(content) == "" {
-		return "", fmt.Errorf("--sql-file %q is empty", path)
+		return "", &scriptError{Err: fmt.Errorf("--sql-file %q is empty", path)}
 	}
 	// A comment-only script has no executable SQL, which is the same failure as
 	// an empty file: splitting yields no terminated statements and the remainder
@@ -570,7 +574,7 @@ func readSQLFile(path string) (string, error) {
 	// of silently running nothing.
 	stmts, remainder := splitSQLStatements(content)
 	if len(stmts) == 0 && stripLeadingSQLComments(remainder) == "" {
-		return "", fmt.Errorf("--sql-file %q contains no executable SQL statements", path)
+		return "", &scriptError{Err: fmt.Errorf("--sql-file %q contains no executable SQL statements", path)}
 	}
 	return content, nil
 }

--- a/shell/coverage_shell_test.go
+++ b/shell/coverage_shell_test.go
@@ -349,7 +349,7 @@ func TestStageStdinDataset_UnsupportedFormat(t *testing.T) {
 	shell.argument.StdinFormat = "xml"
 	shell.argument.StdinTableName = "stdin"
 
-	_, _, err = shell.stageStdinDataset()
+	_, _, err = shell.stageStdinDataset(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "unsupported --stdin-format value") {
 		t.Fatalf("stageStdinDataset unsupported format error = %v, want format error", err)
 	}
@@ -370,7 +370,7 @@ func TestStageStdinDataset_SuccessStagesFile(t *testing.T) {
 	shell.argument.StdinTableName = "piped"
 	shell.stdin = strings.NewReader("a,b\n1,2\n")
 
-	path, stageCleanup, err := shell.stageStdinDataset()
+	path, stageCleanup, err := shell.stageStdinDataset(context.Background())
 	if err != nil {
 		t.Fatalf("stageStdinDataset error: %v", err)
 	}

--- a/shell/errors.go
+++ b/shell/errors.go
@@ -26,6 +26,29 @@ type scriptError struct{ Err error }
 func (e *scriptError) Error() string { return e.Err.Error() }
 func (e *scriptError) Unwrap() error { return e.Err }
 
+// scriptSourceError is a script sqly could not read: a --sql-file path that does
+// not exist, a stdin stream that failed mid-read. It is separate from
+// scriptError, which is a script that was read and cannot be run as written —
+// the first is a problem with the file, the second with its contents.
+type scriptSourceError struct{ Err error }
+
+func (e *scriptSourceError) Error() string { return e.Err.Error() }
+func (e *scriptSourceError) Unwrap() error { return e.Err }
+
+// batchStopError ends a script at the statement that failed. The detail — which
+// statement, which line, and what it said — is already on stderr by the time
+// this is returned, so its own message stays the one-line summary and does not
+// repeat it.
+//
+// It still wraps the cause. Nothing prints the wrapped error, but the exit code
+// is decided from it: a `.save` that could not write is an output failure
+// whether it ran at the prompt or as line 9 of a script, and a wrapper that
+// replaced the cause with a fresh error made every one of them look the same.
+type batchStopError struct{ Err error }
+
+func (e *batchStopError) Error() string { return "batch stopped: statement failed" }
+func (e *batchStopError) Unwrap() error { return e.Err }
+
 // resultCountError is a run that produced a number of result sets the chosen
 // destination or format cannot carry.
 type resultCountError struct {

--- a/shell/exitcode.go
+++ b/shell/exitcode.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"context"
 	"errors"
+	"io"
 
 	"github.com/nao1215/sqly/config"
 )
@@ -56,7 +57,12 @@ func ExitCode(err error) int {
 	// An interrupt is checked first because it is not a stage: it can arrive
 	// during any of them, and what it means — the user stopped this — does not
 	// depend on where the run had got to.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+	//
+	// Only context.Canceled. A context.DeadlineExceeded is a timeout, not a user
+	// signal, and sqly's only deadlines are on the HTTP client: treating one as an
+	// interrupt would report a download that timed out as 130 instead of as the
+	// input failure it is.
+	if errors.Is(err, context.Canceled) {
 		return ExitInterrupt
 	}
 
@@ -92,4 +98,38 @@ func ExitCode(err error) int {
 	}
 
 	return ExitFailure
+}
+
+// readAllContext is io.ReadAll that gives up when ctx is cancelled.
+//
+// It exists because trapping SIGINT is only half of handling it. main.go cancels
+// the run's context instead of letting the default handler kill the process,
+// which is what lets the deferred cleanup remove the temp directories a download
+// or a staged stdin dataset created. The cost is that every blocking read now has
+// to notice the cancellation itself: an io.ReadAll parked on a pipe whose writer
+// never closes — a harness that hands its child a reader, a FIFO with an idle
+// writer — used to be killed outright by the signal, and after trapping it would
+// simply sit there. "Ctrl-C quits" would have become "Ctrl-C does nothing".
+//
+// The read continues in its goroutine after a cancellation returns. There is no
+// way to interrupt it (the reader may be any io.Reader, with no deadline to set),
+// and nothing is waiting on it: the process is on its way out, and the goroutine
+// goes with it.
+func readAllContext(ctx context.Context, r io.Reader) ([]byte, error) {
+	type outcome struct {
+		data []byte
+		err  error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		data, err := io.ReadAll(r)
+		done <- outcome{data: data, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-done:
+		return res.data, res.err
+	}
 }

--- a/shell/exitcode.go
+++ b/shell/exitcode.go
@@ -100,7 +100,7 @@ func ExitCode(err error) int {
 	return ExitFailure
 }
 
-// readAllContext is io.ReadAll that gives up when ctx is cancelled.
+// readAllContext is io.ReadAll that gives up when ctx is canceled.
 //
 // It exists because trapping SIGINT is only half of handling it. main.go cancels
 // the run's context instead of letting the default handler kill the process,

--- a/shell/exitcode.go
+++ b/shell/exitcode.go
@@ -1,0 +1,95 @@
+package shell
+
+import (
+	"context"
+	"errors"
+
+	"github.com/nao1215/sqly/config"
+)
+
+// A caller that runs sqly from a script has one question when it fails: whose
+// fault was it, and what should happen next. "The command line was wrong" needs
+// a human; "the input would not import" needs a different file; "the disk was
+// full" needs a retry. One non-zero code answered none of them, so a wrapper had
+// to grep stderr — matching on wording that was free to change until it did.
+//
+// The codes below are that answer. They are decided from the error types in
+// errors.go rather than from message text, so the classification and the message
+// stay independent: rewording an error never moves a run into another class.
+const (
+	// ExitOK is a run that did what it was asked.
+	ExitOK = 0
+	// ExitFailure is a statement that ran and failed: a SQL error, a constraint,
+	// a missing table. The invocation was well-formed and the data was readable.
+	ExitFailure = 1
+	// ExitUsage is a command line or a script sqly will not accept: an unknown
+	// flag, two flags that contradict, a helper command where only SQL is
+	// allowed, a format that cannot carry the results the script produces.
+	// Nothing was read and nothing was written.
+	ExitUsage = 2
+	// ExitInput is an input that could not be read: a missing path, an
+	// unsupported format, a download that failed or exceeded its limits, a
+	// malformed row under --row-mismatch error.
+	ExitInput = 3
+	// ExitOutput is a destination that could not be written: a missing parent
+	// directory, a source with no writable form, a collision, a failed commit or
+	// rollback. Query results may already have been produced.
+	ExitOutput = 4
+	// ExitInterrupt is a run cut short by SIGINT or SIGTERM. 128+SIGINT is what
+	// a shell reports for a process killed by that signal, so a wrapper that
+	// already special-cases 130 keeps working.
+	ExitInterrupt = 130
+)
+
+// ExitCode maps a run's error to the code sqly exits with. A nil error is
+// ExitOK.
+//
+// The stages are tried in the order a run passes through them, so an error that
+// carries more than one classification is reported as the earliest one: a bad
+// invocation that would also have failed to write is a usage error, because
+// fixing the command line is what has to happen first.
+func ExitCode(err error) int {
+	if err == nil {
+		return ExitOK
+	}
+
+	// An interrupt is checked first because it is not a stage: it can arrive
+	// during any of them, and what it means — the user stopped this — does not
+	// depend on where the run had got to.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ExitInterrupt
+	}
+
+	var (
+		argErr         *config.ArgError
+		invocationErr  *invocationError
+		scriptErr      *scriptError
+		resultCountErr *resultCountError
+	)
+	if errors.As(err, &argErr) || errors.As(err, &invocationErr) ||
+		errors.As(err, &scriptErr) || errors.As(err, &resultCountErr) {
+		return ExitUsage
+	}
+
+	var (
+		partialErr      *partialImportError
+		importFailedErr *importFailedError
+		scriptSourceErr *scriptSourceError
+	)
+	if errors.As(err, &partialErr) || errors.As(err, &importFailedErr) ||
+		errors.As(err, &scriptSourceErr) {
+		return ExitInput
+	}
+
+	var (
+		outputPathErr *outputPathError
+		writeBackErr  *writeBackError
+		fileOpErr     *fileOpError
+	)
+	if errors.As(err, &outputPathErr) || errors.As(err, &writeBackErr) ||
+		errors.As(err, &fileOpErr) {
+		return ExitOutput
+	}
+
+	return ExitFailure
+}

--- a/shell/exitcode_test.go
+++ b/shell/exitcode_test.go
@@ -1,0 +1,175 @@
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nao1215/sqly/config"
+)
+
+func TestExitCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "no error is success",
+			err:  nil,
+			want: ExitOK,
+		},
+		{
+			name: "a bad command line is a usage error",
+			err:  mustArgError(t),
+			want: ExitUsage,
+		},
+		{
+			name: "flags that cannot mean anything together are a usage error",
+			err:  &invocationError{Err: errors.New("--output requires --sql or --sql-file")},
+			want: ExitUsage,
+		},
+		{
+			name: "a script sqly cannot parse is a usage error",
+			err:  &scriptError{Err: errors.New("a helper command must start its own line")},
+			want: ExitUsage,
+		},
+		{
+			name: "a format that cannot carry the results is a usage error",
+			err:  &resultCountError{Produced: 2, Err: errors.New("csv cannot separate two results")},
+			want: ExitUsage,
+		},
+		{
+			name: "an input that failed to import is an input error",
+			err:  &partialImportError{succeeded: 0, failed: 1, summary: "no.csv: path does not exist"},
+			want: ExitInput,
+		},
+		{
+			name: "a destination sqly will not write to is an output error",
+			err:  &outputPathError{Path: "out.csv", Err: errors.New("parent directory does not exist")},
+			want: ExitOutput,
+		},
+		{
+			name: "a save that cannot be planned is an output error",
+			err:  &writeBackError{Err: errors.New("came from a remote URL")},
+			want: ExitOutput,
+		},
+		{
+			name: "a filesystem step of a write is an output error",
+			err:  &fileOpError{Op: opCommit, Path: "out.csv", Err: errors.New("disk full")},
+			want: ExitOutput,
+		},
+		{
+			name: "an interrupted run is the shell interrupt code",
+			err:  context.Canceled,
+			want: ExitInterrupt,
+		},
+		{
+			name: "a failed query is the general failure code",
+			err:  errors.New("no such table: nope"),
+			want: ExitFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ExitCode(tt.err); got != tt.want {
+				t.Errorf("ExitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExitCode_ClassifiesThroughWrapping checks the classification survives the
+// wrapping every error picks up on its way out of a run. A code decided by the
+// outermost layer would report every failure inside a script as the same thing.
+func TestExitCode_ClassifiesThroughWrapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "an import error wrapped by the statement that hit it",
+			err:  fmt.Errorf("line 3: %w", &partialImportError{succeeded: 0, failed: 1, summary: "no.csv"}),
+			want: ExitInput,
+		},
+		{
+			name: "a write-back error wrapped by the save that planned it",
+			err:  fmt.Errorf(".save: %w", &writeBackError{Err: errors.New("no source file")}),
+			want: ExitOutput,
+		},
+		{
+			name: "a cancellation wrapped by the query that was running",
+			err:  fmt.Errorf("run query: %w", context.Canceled),
+			want: ExitInterrupt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ExitCode(tt.err); got != tt.want {
+				t.Errorf("ExitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExitCode_UsageBeatsTheRest pins the precedence that matters: an error
+// carrying more than one classification is reported as the earliest stage it
+// failed at, because that is the one the user has to fix first.
+func TestExitCode_UsageBeatsTheRest(t *testing.T) {
+	t.Parallel()
+
+	err := &invocationError{Err: &writeBackError{Err: errors.New("no source file")}}
+	if got := ExitCode(err); got != ExitUsage {
+		t.Errorf("ExitCode(usage wrapping output) = %d, want %d", got, ExitUsage)
+	}
+}
+
+// TestExitCodes_AreDistinct guards the contract itself: the codes exist to be
+// told apart by a shell script, so two of them meaning the same number would
+// silently merge two failure classes.
+func TestExitCodes_AreDistinct(t *testing.T) {
+	t.Parallel()
+
+	codes := map[int]string{
+		ExitOK:        "ExitOK",
+		ExitFailure:   "ExitFailure",
+		ExitUsage:     "ExitUsage",
+		ExitInput:     "ExitInput",
+		ExitOutput:    "ExitOutput",
+		ExitInterrupt: "ExitInterrupt",
+	}
+	if len(codes) != 6 {
+		t.Errorf("the six exit codes collapse to %d distinct values: %v", len(codes), codes)
+	}
+	for code := range codes {
+		if code < 0 || code > 125 && code != ExitInterrupt {
+			t.Errorf("%s = %d is outside the range a shell reports unambiguously", codes[code], code)
+		}
+	}
+}
+
+// mustArgError returns a real config.ArgError by parsing an invalid command
+// line, so the test binds to the type the parser actually produces rather than
+// to a hand-built stand-in.
+func mustArgError(t *testing.T) error {
+	t.Helper()
+	_, err := config.NewArg([]string{"sqly", "--no-such-flag"})
+	if err == nil {
+		t.Fatal("parsing an unknown flag returned no error")
+	}
+	var argErr *config.ArgError
+	if !errors.As(err, &argErr) {
+		t.Fatalf("parsing an unknown flag returned %T, want *config.ArgError", err)
+	}
+	return err
+}

--- a/shell/exitcode_test.go
+++ b/shell/exitcode_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/sqly/config"
 )
@@ -172,4 +175,53 @@ func mustArgError(t *testing.T) error {
 		t.Fatalf("parsing an unknown flag returned %T, want *config.ArgError", err)
 	}
 	return err
+}
+
+// TestRun_StdinScriptReadObservesCancellation is the half of interrupt handling
+// that a signal handler alone does not give you. main.go traps SIGINT and
+// cancels the run's context instead of letting the default handler kill the
+// process — which means every blocking read in the run has to notice, or
+// trapping the signal turns "Ctrl-C quits" into "Ctrl-C does nothing".
+//
+// A stdin script read is the blocking one that matters: a pipe whose writer
+// never closes (a harness, a FIFO with an idle writer) leaves io.ReadAll parked
+// forever. It is driven here through an io.Pipe left open on purpose.
+func TestRun_StdinScriptReadObservesCancellation(t *testing.T) {
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	// A pipe with a writer that is never closed and never writes: the reader
+	// blocks until something else intervenes.
+	reader, writer := io.Pipe()
+	defer func() { _ = writer.Close() }()
+	s.stdin = reader
+	s.isTTY = func() bool { return false }
+
+	backupOut, backupErr := config.Stdout, config.Stderr
+	var out, errOut strings.Builder
+	config.Stdout, config.Stderr = &out, &errOut
+	defer func() { config.Stdout, config.Stderr = backupOut, backupErr }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	// Give Run time to reach the read, then interrupt it the way a signal would.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case runErr := <-done:
+		if runErr == nil {
+			t.Fatal("an interrupted run returned no error")
+		}
+		if got := ExitCode(runErr); got != ExitInterrupt {
+			t.Errorf("ExitCode = %d, want %d (%v)", got, ExitInterrupt, runErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after the context was cancelled; the stdin read ignores cancellation")
+	}
 }

--- a/shell/exitcode_test.go
+++ b/shell/exitcode_test.go
@@ -222,6 +222,6 @@ func TestRun_StdinScriptReadObservesCancellation(t *testing.T) {
 			t.Errorf("ExitCode = %d, want %d (%v)", got, ExitInterrupt, runErr)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("Run did not return after the context was cancelled; the stdin read ignores cancellation")
+		t.Fatal("Run did not return after the context was canceled; the stdin read ignores cancellation")
 	}
 }

--- a/shell/import.go
+++ b/shell/import.go
@@ -62,7 +62,12 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 	if len(argv) == 0 {
 		// A missing path argument is a command error so a batch script fails fast
 		// instead of skipping the import and exiting 0. The usage rides on the error.
-		return errors.New(".import requires at least one file or directory path\n" + importUsageText())
+		//
+		// It is an invocationError, not an import failure: the command as written
+		// cannot be run, and nothing was read to fail at. That keeps a malformed
+		// .import in the usage class with every other "you typed it wrong", rather
+		// than reporting it as an input sqly could not read.
+		return &invocationError{Err: errors.New(".import requires at least one file or directory path\n" + importUsageText())}
 	}
 
 	var errorMessages []string
@@ -70,10 +75,11 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 
 	for _, path := range argv {
 		// Reject an empty path so `.import ""` does not silently import the
-		// current working directory.
+		// current working directory. Like a missing argument, this is decided from
+		// the command line alone, so it is a usage error rather than an input that
+		// could not be read.
 		if strings.TrimSpace(path) == "" {
-			errorMessages = append(errorMessages, "empty import path")
-			continue
+			return &invocationError{Err: errors.New(".import was given an empty path\n" + importUsageText())}
 		}
 
 		var pathImported bool

--- a/shell/import.go
+++ b/shell/import.go
@@ -42,6 +42,19 @@ func (e *partialImportError) Error() string {
 // Unwrap exposes errPartialImport so errors.Is keeps matching the sentinel.
 func (e *partialImportError) Unwrap() error { return errPartialImport }
 
+// importFailedError is an import where nothing loaded: every requested input
+// failed. It is the same class of problem as a partial import — an input sqly
+// could not read — and is a type for the same reason, so the exit code is
+// decided from what happened rather than from the shape of the message.
+type importFailedError struct {
+	failed  int
+	summary string
+}
+
+func (e *importFailedError) Error() string {
+	return fmt.Sprintf("all %d import(s) failed: %s", e.failed, e.summary)
+}
+
 // importCommand imports files into the in-memory database.
 // Each file/directory is loaded individually so that same-name tables from
 // different directories are overwritten (last-wins) rather than failing.
@@ -115,7 +128,7 @@ func (c CommandList) importCommand(ctx context.Context, s *Shell, argv []string)
 		// drop context already computed here.
 		summary := summarizeImportErrors(errorMessages)
 		if successCount == 0 {
-			return fmt.Errorf("all %d import(s) failed: %s", len(errorMessages), summary)
+			return &importFailedError{failed: len(errorMessages), summary: summary}
 		}
 		// A requested input failed while others succeeded. Return a
 		// partialImportError so non-interactive runs exit non-zero and callers can

--- a/shell/inspect.go
+++ b/shell/inspect.go
@@ -53,18 +53,18 @@ func (s *Shell) validateInspectFlags() error {
 	}
 	switch {
 	case s.argument.Query != "":
-		return errors.New("--inspect cannot be combined with --sql")
+		return &invocationError{Err: errors.New("--inspect cannot be combined with --sql")}
 	case s.argument.SQLFilePath != "":
-		return errors.New("--inspect cannot be combined with --sql-file")
+		return &invocationError{Err: errors.New("--inspect cannot be combined with --sql-file")}
 	case s.argument.Output.FilePath != "":
-		return errors.New("--inspect cannot be combined with --output")
+		return &invocationError{Err: errors.New("--inspect cannot be combined with --output")}
 	// --output-format selects a result format, but --inspect always emits its
 	// own JSON report. Reject the conflicting flag instead of silently discarding
 	// it, matching the other --inspect conflict checks. What counts is that the
 	// user wrote it: --output-format table is discarded exactly as much as
 	// --output-format csv is, and only the default nobody asked for is silent.
 	case s.argument.IsExplicit("output-format"):
-		return fmt.Errorf("--inspect cannot be combined with --output-format %s", outputModeFlagName(s.argument.Output))
+		return &invocationError{Err: fmt.Errorf("--inspect cannot be combined with --output-format %s", outputModeFlagName(s.argument.Output))}
 	}
 	return nil
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -243,7 +243,7 @@ func (s *Shell) Run(ctx context.Context) error {
 	// with a confusing "path does not exist" import error. Detect that exact
 	// accidental form and point the user at the right flag instead.
 	if hint, ok := positionalSubcommandHint(s.argument.FilePaths); ok {
-		return errors.New(hint)
+		return &invocationError{Err: errors.New(hint)}
 	}
 
 	// --inspect is self-contained; reject conflicting action/side-effect flags
@@ -256,7 +256,7 @@ func (s *Shell) Run(ctx context.Context) error {
 	// one result set). Without either (batch stdin or interactive) the flag was
 	// silently ignored, so reject it instead of looking successful.
 	if s.argument.Output.FilePath != "" && s.argument.Query == "" && s.argument.SQLFilePath == "" {
-		return errors.New("--output requires --sql or --sql-file")
+		return &invocationError{Err: errors.New("--output requires --sql or --sql-file")}
 	}
 
 	// Check the destination before the import, so a run that cannot write its
@@ -349,7 +349,7 @@ func (s *Shell) Run(ctx context.Context) error {
 		// stdin — is a silent no-op that still exits 0, so headless wrappers and CI
 		// mistake it for a completed query. Surface a hint and fail instead.
 		if !ranAny {
-			return errNoStatements
+			return &invocationError{Err: errNoStatements}
 		}
 		return s.finishNonInteractive(ctx)
 
@@ -377,13 +377,15 @@ func (s *Shell) loadScript() ([]scriptElement, error) {
 	case modeSQLFile:
 		loaded, err := readSQLFile(s.argument.SQLFilePath)
 		if err != nil {
+			// readSQLFile already classifies: a path it could not read is an input
+			// failure, a file holding no statement is a script failure.
 			return nil, err
 		}
 		script, origin = loaded, s.argument.SQLFilePath
 	case modeStdinScript:
 		data, err := io.ReadAll(s.stdin)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read the script from stdin: %w", err)
+			return nil, &scriptSourceError{Err: fmt.Errorf("failed to read the script from stdin: %w", err)}
 		}
 		script, origin = string(data), "stdin"
 	default:
@@ -541,8 +543,8 @@ func (s *Shell) validateBinaryOutputFormat() error {
 	}
 	switch s.argument.Output.Mode {
 	case model.PrintModeExcel, model.PrintModeParquet:
-		return fmt.Errorf("--output-format %s writes a binary file and cannot be printed; add --output FILE",
-			s.argument.Output.Mode)
+		return &invocationError{Err: fmt.Errorf("--output-format %s writes a binary file and cannot be printed; add --output FILE",
+			s.argument.Output.Mode)}
 	default:
 		return nil
 	}
@@ -613,7 +615,7 @@ func (s *Shell) init(ctx context.Context) error {
 		// stageStdinDataset reads stdin to EOF; on a terminal that would hang
 		// waiting for the user. --stdin-format is only meaningful with piped input.
 		if s.isTTY() {
-			return errors.New("--stdin-format requires piped or redirected stdin")
+			return &invocationError{Err: errors.New("--stdin-format requires piped or redirected stdin")}
 		}
 		stdinPath, cleanup, err := s.stageStdinDataset()
 		if err != nil {
@@ -1286,10 +1288,10 @@ func ensureWritableDestination(path string) error {
 		return nil
 	}
 	if strings.HasSuffix(path, "/") || strings.HasSuffix(path, string(os.PathSeparator)) {
-		return fmt.Errorf("output destination %q ends with a path separator; specify a file path, not a directory", path)
+		return &outputPathError{Path: path, Err: fmt.Errorf("output destination %q ends with a path separator; specify a file path, not a directory", path)}
 	}
 	if info, err := os.Stat(path); err == nil && info.IsDir() {
-		return fmt.Errorf("output destination %q is a directory; specify a file path", path)
+		return &outputPathError{Path: path, Err: fmt.Errorf("output destination %q is a directory; specify a file path", path)}
 	}
 	// The parent must already exist. sqly does not create directories for an
 	// output path: a typo in a directory name would otherwise leave a tree of
@@ -1298,10 +1300,10 @@ func ensureWritableDestination(path string) error {
 	parent := filepath.Dir(path)
 	info, err := os.Stat(parent)
 	if err != nil {
-		return fmt.Errorf("output destination %q: directory %q does not exist", path, parent)
+		return &outputPathError{Path: path, Err: fmt.Errorf("output destination %q: directory %q does not exist", path, parent)}
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("output destination %q: %q is not a directory", path, parent)
+		return &outputPathError{Path: path, Err: fmt.Errorf("output destination %q: %q is not a directory", path, parent)}
 	}
 	return nil
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -294,7 +294,7 @@ func (s *Shell) Run(ctx context.Context) error {
 	// Read and parse the script now, so a script that cannot run — a bad
 	// boundary, or a helper command in a SQL file — fails before the import
 	// spends time on files. The same parse is what executes below.
-	elements, err := s.loadScript()
+	elements, err := s.loadScript(ctx)
 	if err != nil {
 		return err
 	}
@@ -366,7 +366,7 @@ func (s *Shell) Run(ctx context.Context) error {
 // they come. The interactive shell and --inspect have no script; every other
 // mode has exactly one, parsed once here and executed later from the same
 // result.
-func (s *Shell) loadScript() ([]scriptElement, error) {
+func (s *Shell) loadScript(ctx context.Context) ([]scriptElement, error) {
 	var (
 		script string
 		origin string
@@ -383,7 +383,7 @@ func (s *Shell) loadScript() ([]scriptElement, error) {
 		}
 		script, origin = loaded, s.argument.SQLFilePath
 	case modeStdinScript:
-		data, err := io.ReadAll(s.stdin)
+		data, err := readAllContext(ctx, s.stdin)
 		if err != nil {
 			return nil, &scriptSourceError{Err: fmt.Errorf("failed to read the script from stdin: %w", err)}
 		}
@@ -617,7 +617,7 @@ func (s *Shell) init(ctx context.Context) error {
 		if s.isTTY() {
 			return &invocationError{Err: errors.New("--stdin-format requires piped or redirected stdin")}
 		}
-		stdinPath, cleanup, err := s.stageStdinDataset()
+		stdinPath, cleanup, err := s.stageStdinDataset(ctx)
 		if err != nil {
 			return err
 		}
@@ -682,7 +682,7 @@ var stdinFormatExtensions = map[string]string{
 // arguments (including table naming and joins). The returned cleanup removes the
 // temp directory; it is safe to call after import because the data is already
 // copied into the shared database.
-func (s *Shell) stageStdinDataset() (string, func(), error) {
+func (s *Shell) stageStdinDataset(ctx context.Context) (string, func(), error) {
 	ext, ok := stdinFormatExtensions[s.argument.StdinFormat]
 	if !ok {
 		return "", nil, fmt.Errorf("unsupported --stdin-format value %q: want csv, tsv, ltsv, json, or jsonl", s.argument.StdinFormat)
@@ -700,10 +700,18 @@ func (s *Shell) stageStdinDataset() (string, func(), error) {
 		cleanup()
 		return "", nil, fmt.Errorf("create stdin staging file: %w", err)
 	}
-	if _, err := io.Copy(f, s.stdin); err != nil {
+	// Cancellation-aware for the same reason the script read is: a piped dataset
+	// whose writer never closes would otherwise ignore the interrupt entirely.
+	data, err := readAllContext(ctx, s.stdin)
+	if err != nil {
 		_ = f.Close()
 		cleanup()
 		return "", nil, fmt.Errorf("read stdin data: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("write stdin staging file: %w", err)
 	}
 	if err := f.Close(); err != nil {
 		cleanup()

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -367,9 +367,10 @@ wrong" from "that file would not load" without reading stderr.
 | `4` | a destination could not be written: a missing parent directory, a source with no writable form, a collision, a failed commit or rollback | the destination |
 | `130` | SIGINT or SIGTERM stopped the run | — |
 
-Codes `2`, `3`, and `4` are decided before or during the stage they name, so a `2`
-means nothing was read and nothing was written. A `4` means the query may already
-have produced results.
+Most code-`2` failures are decided before anything is read or written. The
+exception is a script whose result sets the chosen format cannot separate: that
+is only known once the script has run, so the inputs were read even though
+nothing was printed. A `4` means the query may already have produced results.
 
 The class is the same whether a failure happens at the top level or inside a
 script: a `.save` that cannot write exits `4` as line 9 of a piped script exactly

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -355,10 +355,29 @@ A name that collides with a SQLite keyword is imported and a warning names it; q
 
 ## Exit codes
 
-| Code | Meaning |
-|:--|:--|
-| `0` | success |
-| `1` | an import, a query, a write, or a batch statement failed |
+A failing run says which stage failed, so a script can tell "the command line was
+wrong" from "that file would not load" without reading stderr.
+
+| Code | Meaning | What to change |
+|:--|:--|:--|
+| `0` | success | — |
+| `1` | a statement ran and failed: a SQL error, a missing table, a constraint | the SQL |
+| `2` | the command line or the script was not accepted: an unknown flag, two flags that contradict, a dot-command in a `--sql-file`, a format that cannot carry the results | the invocation |
+| `3` | an input could not be read: a missing path, an unsupported format, a download that failed or hit a limit, a malformed row under `--row-mismatch error` | the input |
+| `4` | a destination could not be written: a missing parent directory, a source with no writable form, a collision, a failed commit or rollback | the destination |
+| `130` | SIGINT or SIGTERM stopped the run | — |
+
+Codes `2`, `3`, and `4` are decided before or during the stage they name, so a `2`
+means nothing was read and nothing was written. A `4` means the query may already
+have produced results.
+
+The class is the same whether a failure happens at the top level or inside a
+script: a `.save` that cannot write exits `4` as line 9 of a piped script exactly
+as it does on its own.
+
+An interrupted run cancels the query and returns through the normal cleanup, so
+the temp directories a download or a staged stdin dataset created are removed
+before sqly exits.
 
 Errors go to stderr; query results go to stdout, so a pipeline stays clean.
 


### PR DESCRIPTION
Every sqly failure exited `1`, so a wrapper that wanted to tell "the command line was wrong" from "that file would not load" had to grep stderr — matching on wording that was free to change until it did.

## The contract

| Code | Meaning | What to change |
|:--|:--|:--|
| `0` | success | — |
| `1` | a statement ran and failed | the SQL |
| `2` | the command line or the script was not accepted | the invocation |
| `3` | an input could not be read | the input |
| `4` | a destination could not be written | the destination |
| `130` | SIGINT or SIGTERM stopped the run | — |

Codes are decided from the error types in `shell/errors.go` rather than from message text, so rewording an error never moves a run into another class. The error paths that returned bare errors are typed so the classification is structural.

`batchStopError` carries the cause without printing it, which is what makes the class the same at both levels: a `.save` that cannot write exits `4` as line 9 of a piped script exactly as it does on its own.

## Interrupts

SIGINT and SIGTERM now cancel the run context instead of killing the process, so the deferred cleanup removes the temp directories a download or a staged stdin dataset created. The interactive shell is unaffected: the prompt puts the terminal in raw mode, where Ctrl-C arrives as a keystroke and no signal is delivered.

## Breaking change

A wrapper that only checks for non-zero is unaffected. One that checks for `1` specifically has to widen the check.

## Verification

`go test ./...`, `go test -race ./...`, `go vet ./...`, `golangci-lint`, and `go-arch-lint` are clean locally. 704 atago E2E scenarios pass; 83 of them encoded the old exit-1-for-everything contract and were updated to the class each failure now reports. A new `e2e/atago/exit_codes.atago.yaml` checks every class against the real binary.

A drift test ties the reference exit code table to the constants, so a code that exists cannot go undocumented and a documented one cannot vanish. It was mutation-checked: changing either side fails it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized exit codes for success, usage errors, input failures, output failures, general failures, and interruptions.
  * Added graceful SIGINT/SIGTERM cancellation with cleanup of temporary data.
* **Bug Fixes**
  * Improved error classification across imports, SQL files, validation, and output destinations.
  * Failed queries no longer produce unintended standard output.
* **Documentation**
  * Documented exit codes, cancellation behavior, and cleanup guarantees.
* **Tests**
  * Added coverage to verify documented and actual exit codes remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->