### PR TITLE
feat: bound what a remote input may cost

### DIFF
--- a/e2e/atago/http_limits.atago.yaml
+++ b/e2e/atago/http_limits.atago.yaml
@@ -1,0 +1,112 @@
+# Resource limits on a remote input. A URL is the one input to sqly that nobody
+# local vouched for: the server chooses the size, the redirect chain, and where
+# the chain ends. A timeout bounds how long it may take; these bound the rest.
+#
+# The download size cap is not exercised here. It is 2 GiB, and a suite that
+# moved that much per run to prove a comparison would be paid for on every CI
+# run; it is covered in shell/remote_limits_test.go against an injected limit.
+# What is left is the redirect policy, which is cheap to drive end to end and is
+# the part a unit test cannot show reaching the real binary.
+#
+# The servers are plain python3, waited for by connecting rather than sleeping,
+# for the same reason as http_import.atago.yaml.
+version: "1"
+
+suite:
+  name: HTTP input limits
+
+scenarios:
+  - name: refuses a redirect that leaves http for another scheme
+    # A server answering with "Location: file:///etc/passwd" is asking sqly to
+    # read a local file as though the user had named it on the command line.
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: server.py
+          content: |
+            import http.server
+
+            class Handler(http.server.BaseHTTPRequestHandler):
+                def do_GET(self):
+                    self.send_response(302)
+                    self.send_header("Location", "file:///etc/passwd")
+                    self.end_headers()
+
+                def log_message(self, *args):
+                    pass
+
+            http.server.HTTPServer(("127.0.0.1", 18091), Handler).serve_forever()
+      - run:
+          command: sh -c 'python3 server.py & pid=$!; trap "kill $pid" EXIT; i=0; until python3 -c "import socket,sys; sys.exit(socket.socket().connect_ex((\"127.0.0.1\",18091)))"; do i=$((i+1)); [ $i -ge 50 ] && { echo "the local HTTP fixture never started listening" >&2; exit 1; }; sleep 0.1; done; sqly --sql "SELECT 1" http://127.0.0.1:18091/data.csv'
+      - assert:
+          exit_code: 3
+          stdout:
+            empty: true
+          stderr:
+            contains: "sqly downloads over http and https only"
+
+  - name: stops a redirect chain that does not settle
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: server.py
+          content: |
+            import http.server
+
+            class Handler(http.server.BaseHTTPRequestHandler):
+                def do_GET(self):
+                    self.send_response(302)
+                    self.send_header("Location", "http://127.0.0.1:18092/again.csv")
+                    self.end_headers()
+
+                def log_message(self, *args):
+                    pass
+
+            http.server.HTTPServer(("127.0.0.1", 18092), Handler).serve_forever()
+      - run:
+          command: sh -c 'python3 server.py & pid=$!; trap "kill $pid" EXIT; i=0; until python3 -c "import socket,sys; sys.exit(socket.socket().connect_ex((\"127.0.0.1\",18092)))"; do i=$((i+1)); [ $i -ge 50 ] && { echo "the local HTTP fixture never started listening" >&2; exit 1; }; sleep 0.1; done; sqly --sql "SELECT 1" http://127.0.0.1:18092/start.csv'
+      - assert:
+          exit_code: 3
+          stdout:
+            empty: true
+          stderr:
+            contains: "stopped after 5 redirects"
+
+  - name: still follows an ordinary redirect within http
+    # The limits must not cost the case they exist to protect: a plain redirect
+    # to the real file is what a hosted dataset actually does.
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: user.csv
+          content: |
+            user_name,identifier
+            booker12,1
+      - fixture:
+          file: server.py
+          content: |
+            import http.server
+
+            class Handler(http.server.SimpleHTTPRequestHandler):
+                def do_GET(self):
+                    if self.path == "/go":
+                        self.send_response(302)
+                        self.send_header("Location", "/user.csv")
+                        self.end_headers()
+                        return
+                    super().do_GET()
+
+                def log_message(self, *args):
+                    pass
+
+            http.server.HTTPServer(("127.0.0.1", 18093), Handler).serve_forever()
+      - run:
+          command: sh -c 'python3 server.py & pid=$!; trap "kill $pid" EXIT; i=0; until python3 -c "import socket,sys; sys.exit(socket.socket().connect_ex((\"127.0.0.1\",18093)))"; do i=$((i+1)); [ $i -ge 50 ] && { echo "the local HTTP fixture never started listening" >&2; exit 1; }; sleep 0.1; done; sqly --output-format csv --sql "SELECT user_name FROM user" http://127.0.0.1:18093/go'
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: booker12

--- a/shell/remote.go
+++ b/shell/remote.go
@@ -73,6 +73,11 @@ func newRemoteClient() *http.Client {
 		// mid-download cannot hang the CLI indefinitely.
 		Timeout: 15 * time.Minute,
 		Transport: &http.Transport{
+			// A custom Transport replaces http.DefaultTransport wholesale, which
+			// is where proxy support lives. Without this a user behind a corporate
+			// proxy cannot fetch a URL at all, and the failure looks like the host
+			// being unreachable rather than like a setting sqly ignored.
+			Proxy:                 http.ProxyFromEnvironment,
 			ResponseHeaderTimeout: 30 * time.Second,
 		},
 		CheckRedirect: checkRemoteRedirect,

--- a/shell/remote.go
+++ b/shell/remote.go
@@ -11,6 +11,15 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
+)
+
+// schemeHTTP and schemeHTTPS are the two schemes sqly downloads over. They are
+// named because three separate checks — is this a URL, may a redirect go here,
+// is this an unfetchable scheme — have to agree on the answer.
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
 )
 
 const (
@@ -19,6 +28,78 @@ const (
 	remoteJSONContentType      = "application/json"
 	remoteJSONFilename         = "download.json"
 )
+
+// A timeout bounds how long a remote server may take. These bound what it may
+// cost, which is the other half and the one the server chooses: a URL is the one
+// input to sqly that nobody local vouched for.
+//
+// The numbers are set where an ordinary dataset is nowhere near them and a
+// runaway response is stopped before it matters. A 2 GiB CSV is far past what
+// belongs in an in-memory SQLite database — the import would exhaust memory long
+// before the disk — so the download limit is not what makes such a file fail, it
+// is only what keeps a server from filling the disk on the way there. Both are
+// documented at https://nao1215.github.io/sqly/formats/ so a user who hits one
+// knows what they hit.
+//
+// Why not make them flags: a limit that is routinely raised is not protecting
+// anything, and every input sqly reads locally is already unbounded. The remote
+// case is different because the size is not the user's to know in advance.
+const (
+	// maxRemoteDownloadBytes caps what one URL may transfer.
+	maxRemoteDownloadBytes int64 = 2 << 30 // 2 GiB
+	// maxRemoteRedirects caps the redirect chain. Go's default is 10 with an
+	// error that does not say sqly chose it; a smaller number and sqly's own
+	// message make the refusal explainable.
+	maxRemoteRedirects = 5
+)
+
+// downloadLimit returns the byte cap for one download. Tests lower it so the
+// limit can be exercised without moving two gigabytes through the disk; nothing
+// outside tests sets the field, so a run always uses the constant above.
+func (s *Shell) downloadLimit() int64 {
+	if s.maxDownloadBytes > 0 {
+		return s.maxDownloadBytes
+	}
+	return maxRemoteDownloadBytes
+}
+
+// newRemoteClient builds the HTTP client sqly downloads inputs with. The
+// policies it carries are part of the download contract, so they live with the
+// rest of it rather than inline in the shell constructor — and a test that
+// swaps in a server's transport keeps them.
+func newRemoteClient() *http.Client {
+	return &http.Client{
+		// Bound the full request/response body read so a server that stalls
+		// mid-download cannot hang the CLI indefinitely.
+		Timeout: 15 * time.Minute,
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: 30 * time.Second,
+		},
+		CheckRedirect: checkRemoteRedirect,
+	}
+}
+
+// checkRemoteRedirect decides whether to follow a redirect. It bounds the chain
+// and, more importantly, keeps it inside HTTP.
+//
+// A redirect changes the URL sqly fetches to one the user never wrote. Go's
+// default client refuses a redirect to a non-HTTP scheme in the sense that its
+// transport has no handler for one, but the resulting error describes a missing
+// protocol rather than a server having tried to redirect sqly at
+// file:///etc/passwd. Saying that plainly is worth the four lines.
+func checkRemoteRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRemoteRedirects {
+		return fmt.Errorf("stopped after %d redirects; the chain starting at %s does not settle",
+			maxRemoteRedirects, via[0].URL)
+	}
+	switch strings.ToLower(req.URL.Scheme) {
+	case schemeHTTP, schemeHTTPS:
+		return nil
+	default:
+		return fmt.Errorf("refused a redirect to the %q scheme (%s); sqly downloads over http and https only",
+			req.URL.Scheme, req.URL)
+	}
+}
 
 // isRemoteURL reports whether raw is an absolute HTTP/HTTPS URL sqly can
 // download as an input dataset.
@@ -31,7 +112,7 @@ func isRemoteURL(raw string) bool {
 		return false
 	}
 	switch strings.ToLower(u.Scheme) {
-	case "http", "https":
+	case schemeHTTP, schemeHTTPS:
 		return true
 	default:
 		return false
@@ -118,6 +199,16 @@ func (s *Shell) downloadRemoteInput(ctx context.Context, rawURL string) (string,
 		return "", nil, fmt.Errorf("download %s: unexpected HTTP status %s", rawURL, resp.Status)
 	}
 
+	// A declared size over the limit is refused before a byte of the body is
+	// read. ContentLength is -1 for a chunked response, which is why this is the
+	// cheap path and not the check: the one that has to hold is below, while the
+	// body is being copied.
+	limit := s.downloadLimit()
+	if resp.ContentLength > limit {
+		return "", nil, fmt.Errorf("download %s: too large: the server declared %d bytes and the limit is %d",
+			rawURL, resp.ContentLength, limit)
+	}
+
 	filename, err := s.remoteDownloadFilename(rawURL, resp)
 	if err != nil {
 		return "", nil, err
@@ -139,11 +230,21 @@ func (s *Shell) downloadRemoteInput(ctx context.Context, rawURL string) (string,
 		return "", nil, fmt.Errorf("create staging file for %s: %w", rawURL, err)
 	}
 
-	_, copyErr := io.Copy(f, resp.Body)
+	// Read one byte past the limit rather than exactly the limit, so a body that
+	// is precisely at it is still distinguishable from one that ran over.
+	written, copyErr := io.Copy(f, io.LimitReader(resp.Body, limit+1))
 	closeErr := f.Close()
 	if copyErr != nil {
 		cleanup()
 		return "", nil, fmt.Errorf("download %s: %w", rawURL, copyErr)
+	}
+	if written > limit {
+		// The staged file goes with the refusal. A partial download left on disk
+		// turns a rejected import into a slow leak across repeated runs, and half a
+		// CSV is worse than none: it parses.
+		cleanup()
+		return "", nil, fmt.Errorf("download %s: too large: the response exceeded the %d byte limit",
+			rawURL, limit)
 	}
 	if closeErr != nil {
 		cleanup()
@@ -156,10 +257,22 @@ func (s *Shell) downloadRemoteInput(ctx context.Context, rawURL string) (string,
 // Content-Disposition filename when present, then the URL path, then a
 // Content-Type-derived extension. Candidate ranking reuses the importer's
 // supported-format check so the extension list stays in one authority.
+//
+// The URL it reads is the one the response came from, not the one the user
+// typed. A dataset published behind a redirect — a short link, a "latest"
+// alias — would otherwise be named after the alias, so `sqly host/latest`
+// landing on `sales.csv` gave a table named after the Content-Type fallback
+// rather than after the file that actually arrived.
 func (s *Shell) remoteDownloadFilename(rawURL string, resp *http.Response) (string, error) {
+	finalURL := rawURL
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL.String()
+	}
+
 	var first string
 	for _, candidate := range []string{
 		contentDispositionFilename(resp.Header.Get("Content-Disposition")),
+		remoteFilenameHint(finalURL),
 		remoteFilenameHint(rawURL),
 		filenameFromContentType(resp.Header.Get("Content-Type")),
 	} {

--- a/shell/remote_limits_test.go
+++ b/shell/remote_limits_test.go
@@ -1,0 +1,365 @@
+package shell
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// A remote input is the one sqly reads that nobody local vouched for. A timeout
+// bounds how long a server may take; these bound how much it may cost, which is
+// the other half and the one an attacker controls. Each limit is checked through
+// downloadRemoteInput itself, over a real server, because what the limit has to
+// survive — a missing Content-Length, a chunked body, a redirect chain — lives in
+// the HTTP layer and not in a size comparison.
+
+// TestDownloadRemoteInput_RejectsABodyOverTheSizeLimit is the base case: a
+// server that keeps sending is stopped, and stopped with a message that names
+// the limit rather than a truncated CSV that parses into wrong answers.
+func TestDownloadRemoteInput_RejectsABodyOverTheSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	// The server offers far more than the limit and counts what it managed to
+	// hand over. A limit that only checked the total after the copy would let all
+	// of this reach the disk first, so the byte count is asserted as well as the
+	// error: it is the difference between refusing a huge download and merely
+	// reporting one that already happened.
+	const offered = 64
+	var served atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		body := strings.Repeat("a,b\n1,2\n", 1024)
+		for range offered * int(testDownloadLimit) / len(body) {
+			n, err := w.Write([]byte(body))
+			served.Add(int64(n))
+			if err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	s, cleanup := newLimitShell(t, server)
+	defer cleanup()
+
+	path, done, err := s.downloadRemoteInput(context.Background(), server.URL+"/big.csv")
+	if done != nil {
+		done()
+	}
+	if err == nil {
+		t.Fatalf("a body over the limit was accepted and staged at %s", path)
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("error should say the download was too large, got: %v", err)
+	}
+
+	// Generous slack for the transport's buffering; the point is that it is a
+	// small multiple of the limit rather than the whole body.
+	if ceiling := testDownloadLimit * 8; served.Load() > ceiling {
+		t.Errorf("the server got to send %d bytes against a %d byte limit; the read is not bounded",
+			served.Load(), testDownloadLimit)
+	}
+}
+
+// TestDownloadRemoteInput_RejectsAnOversizeBodyWithNoContentLength is the case a
+// Content-Length check alone would miss. A chunked response declares no size, so
+// refusing early on a header is not available and the limit has to hold while
+// the body is being read.
+func TestDownloadRemoteInput_RejectsAnOversizeBodyWithNoContentLength(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		// No Content-Length: writing before the first flush makes this chunked.
+		flusher, _ := w.(http.Flusher)
+		chunk := strings.Repeat("a,b\n1,2\n", 1024)
+		for written := int64(0); written < testDownloadLimit+int64(len(chunk)); written += int64(len(chunk)) {
+			if _, err := w.Write([]byte(chunk)); err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	defer server.Close()
+
+	s, cleanup := newLimitShell(t, server)
+	defer cleanup()
+
+	_, done, err := s.downloadRemoteInput(context.Background(), server.URL+"/chunked.csv")
+	if done != nil {
+		done()
+	}
+	if err == nil {
+		t.Fatal("a chunked body over the limit was accepted")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("error should say the download was too large, got: %v", err)
+	}
+}
+
+// TestDownloadRemoteInput_RejectsAContentLengthOverTheLimit checks the cheap
+// path: when the server does declare a size over the limit, the body is never
+// read at all.
+func TestDownloadRemoteInput_RejectsAContentLengthOverTheLimit(t *testing.T) {
+	t.Parallel()
+
+	bodyRead := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Length", strconv.FormatInt(testDownloadLimit+1, 10))
+		w.WriteHeader(http.StatusOK)
+		bodyRead = true
+	}))
+	defer server.Close()
+
+	s, cleanup := newLimitShell(t, server)
+	defer cleanup()
+
+	_, done, err := s.downloadRemoteInput(context.Background(), server.URL+"/declared.csv")
+	if done != nil {
+		done()
+	}
+	if err == nil {
+		t.Fatal("a declared size over the limit was accepted")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("error should say the download was too large, got: %v", err)
+	}
+	_ = bodyRead
+}
+
+// TestDownloadRemoteInput_LeavesNoTempFileWhenALimitIsExceeded is the half that
+// matters after the refusal. A partial download that stays on disk turns a
+// rejected import into a slow disk leak across repeated runs.
+// It redirects the temp directory to see what was left there, which is a
+// process-wide setting, so this one test does not run in parallel.
+func TestDownloadRemoteInput_LeavesNoTempFileWhenALimitIsExceeded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		chunk := strings.Repeat("a,b\n1,2\n", 1024)
+		for written := int64(0); written < testDownloadLimit+int64(len(chunk)); written += int64(len(chunk)) {
+			if _, err := w.Write([]byte(chunk)); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	// os.TempDir reads a different variable per platform, so all three are set
+	// rather than assuming the one this test happens to run on.
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	t.Setenv("TMP", tempDir)
+	t.Setenv("TEMP", tempDir)
+
+	s, cleanup := newLimitShell(t, server)
+	defer cleanup()
+
+	_, done, err := s.downloadRemoteInput(context.Background(), server.URL+"/big.csv")
+	if done != nil {
+		done()
+	}
+	if err == nil {
+		t.Fatal("a body over the limit was accepted")
+	}
+
+	entries, readErr := os.ReadDir(tempDir)
+	if readErr != nil {
+		t.Fatalf("read the temp dir: %v", readErr)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "sqly-http-") {
+			t.Errorf("a refused download left %s behind", filepath.Join(tempDir, e.Name()))
+		}
+	}
+}
+
+// TestDownloadRemoteInput_RejectsTooManyRedirects stops a redirect loop with a
+// message about redirects. Go's default client already caps the chain, but at 10
+// and with an error that says "stopped after 10 redirects" without saying that
+// sqly chose that number or why.
+func TestDownloadRemoteInput_RejectsTooManyRedirects(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, server.URL+"/next.csv", http.StatusFound)
+	}))
+	defer server.Close()
+
+	s, cleanup := newLimitShell(t, server)
+	defer cleanup()
+
+	_, done, err := s.downloadRemoteInput(context.Background(), server.URL+"/start.csv")
+	if done != nil {
+		done()
+	}
+	if err == nil {
+		t.Fatal("an endless redirect chain was followed to completion")
+	}
+	// Bind to sqly's own limit, not merely to the word "redirect": Go's default
+	// client stops at 10 with a message that also contains it, so a looser
+	// assertion here passes whether or not sqly has a policy at all.
+	want := fmt.Sprintf("stopped after %d redirects", maxRemoteRedirects)
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error should be sqly's own redirect limit (%q), got: %v", want, err)
+	}
+}
+
+// TestDownloadRemoteInput_RejectsARedirectToAnotherScheme is the one a redirect
+// cap does not cover. A server that answers an https request with a redirect to
+// file:///etc/passwd is asking sqly to read a local file as though the user had
+// named it, and the number of hops taken to get there is irrelevant.
+func TestDownloadRemoteInput_RejectsARedirectToAnotherScheme(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "file:///etc/passwd", http.StatusFound)
+	}))
+	defer server.Close()
+
+	s, cleanup := newLimitShell(t, server)
+	defer cleanup()
+
+	_, done, err := s.downloadRemoteInput(context.Background(), server.URL+"/start.csv")
+	if done != nil {
+		done()
+	}
+	if err == nil {
+		t.Fatal("a redirect to file:// was followed")
+	}
+	// Again, sqly's own wording. Go's transport fails a file:// request with
+	// "unsupported protocol scheme", which contains "scheme" and would satisfy a
+	// looser check even with no policy in place — while saying nothing about a
+	// server having tried to redirect sqly at a local file.
+	if !strings.Contains(err.Error(), "sqly downloads over http and https only") {
+		t.Errorf("error should be sqly's own scheme refusal, got: %v", err)
+	}
+}
+
+// TestDownloadRemoteInput_AllowsARedirectWithinHTTP keeps the limits from
+// costing the ordinary case: a plain http-to-https redirect is what a real
+// download does, and it must still work.
+func TestDownloadRemoteInput_AllowsARedirectWithinHTTP(t *testing.T) {
+	t.Parallel()
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		fmt.Fprint(w, "a,b\n1,2\n")
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/data.csv", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	s, cleanup := newLimitShell(t, redirector)
+	defer cleanup()
+
+	path, done, err := s.downloadRemoteInput(context.Background(), redirector.URL+"/start.csv")
+	if done != nil {
+		defer done()
+	}
+	if err != nil {
+		t.Fatalf("an ordinary redirect was refused: %v", err)
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is the temp file this test just staged
+	if err != nil {
+		t.Fatalf("read the staged file: %v", err)
+	}
+	if string(data) != "a,b\n1,2\n" {
+		t.Errorf("staged content = %q, want the redirected body", data)
+	}
+}
+
+// TestDownloadRemoteInput_AcceptsABodyUnderTheLimit is the other half of the
+// same guard: a limit that also rejects ordinary inputs is not a limit, it is an
+// outage.
+func TestDownloadRemoteInput_AcceptsABodyUnderTheLimit(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		fmt.Fprint(w, "a,b\n1,2\n")
+	}))
+	defer server.Close()
+
+	s, cleanup := newLimitShell(t, server)
+	defer cleanup()
+
+	path, done, err := s.downloadRemoteInput(context.Background(), server.URL+"/small.csv")
+	if done != nil {
+		defer done()
+	}
+	if err != nil {
+		t.Fatalf("an ordinary download was refused: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("the staged file is missing: %v", err)
+	}
+}
+
+// newLimitShell builds a shell whose HTTP client is the one sqly ships, with the
+// test server's transport swapped in. Using the real constructor is the point:
+// a test client built by hand would not carry the redirect policy under test.
+// testDownloadLimit stands in for the shipped 2 GiB cap. The limit under test is
+// the comparison and the cleanup around it, neither of which cares about the
+// number — and a suite that moved two gigabytes per case to prove it would be
+// paid for on every CI run.
+const testDownloadLimit int64 = 64 << 10
+
+func newLimitShell(t *testing.T, server *httptest.Server) (*Shell, func()) {
+	t.Helper()
+
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.httpClient.Transport = server.Client().Transport
+	s.maxDownloadBytes = testDownloadLimit
+	return s, cleanup
+}
+
+// TestDownloadRemoteInput_NamesTheFileFromTheRedirectTarget checks which URL the
+// table name comes from. A dataset published behind a redirect — a short link, a
+// "latest" alias — is named after the file that arrived, not after the alias
+// that pointed at it, which is the only one of the two the user can then write
+// in a query.
+func TestDownloadRemoteInput_NamesTheFileFromTheRedirectTarget(t *testing.T) {
+	t.Parallel()
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		fmt.Fprint(w, "a,b\n1,2\n")
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/sales.csv", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	s, cleanup := newLimitShell(t, redirector)
+	defer cleanup()
+
+	path, done, err := s.downloadRemoteInput(context.Background(), redirector.URL+"/latest")
+	if done != nil {
+		defer done()
+	}
+	if err != nil {
+		t.Fatalf("download through a redirect: %v", err)
+	}
+	if got := filepath.Base(path); got != "sales.csv" {
+		t.Errorf("staged file = %q, want it named after the redirect target (sales.csv)", got)
+	}
+}

--- a/shell/remote_limits_test.go
+++ b/shell/remote_limits_test.go
@@ -31,7 +31,14 @@ func TestDownloadRemoteInput_RejectsABodyOverTheSizeLimit(t *testing.T) {
 	// of this reach the disk first, so the byte count is asserted as well as the
 	// error: it is the difference between refusing a huge download and merely
 	// reporting one that already happened.
-	const offered = 64
+	//
+	// The threshold is a fraction of what was offered, not a multiple of the
+	// limit. How much the transport buffers past the point the reader stops is
+	// the runner's business — a CI machine was seen handing over 594 KiB against
+	// a 64 KiB limit, which is bounded reading with a big socket buffer, not a
+	// missing limit. What distinguishes the two is whether the whole body got
+	// through.
+	const offered = 256
 	var served atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/csv")
@@ -60,11 +67,9 @@ func TestDownloadRemoteInput_RejectsABodyOverTheSizeLimit(t *testing.T) {
 		t.Errorf("error should say the download was too large, got: %v", err)
 	}
 
-	// Generous slack for the transport's buffering; the point is that it is a
-	// small multiple of the limit rather than the whole body.
-	if ceiling := testDownloadLimit * 8; served.Load() > ceiling {
-		t.Errorf("the server got to send %d bytes against a %d byte limit; the read is not bounded",
-			served.Load(), testDownloadLimit)
+	if ceiling := offered * testDownloadLimit / 2; served.Load() > ceiling {
+		t.Errorf("the server handed over %d of the %d bytes it offered against a %d byte limit; the read is not bounded",
+			served.Load(), offered*testDownloadLimit, testDownloadLimit)
 	}
 }
 

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
@@ -162,6 +161,10 @@ type Shell struct {
 	// httpClient downloads remote datasets for HTTP/HTTPS imports. It is
 	// overridable in tests so httptest servers can supply their own transport.
 	httpClient *http.Client
+	// maxDownloadBytes overrides the download size cap. Zero means the shipped
+	// limit; only tests set it, so the limit can be exercised without moving two
+	// gigabytes through the disk on every CI run.
+	maxDownloadBytes int64
 }
 
 type promptSession interface {
@@ -214,14 +217,7 @@ func NewShell(
 		isTTY:          config.IsInputFromTTY,
 		historyEnabled: true,
 		tableSources:   make(map[string]string),
-		httpClient: &http.Client{
-			// Bound the full request/response body read so a server that stalls
-			// mid-download cannot hang the CLI indefinitely.
-			Timeout: 15 * time.Minute,
-			Transport: &http.Transport{
-				ResponseHeaderTimeout: 30 * time.Second,
-			},
-		},
+		httpClient:     newRemoteClient(),
 	}, nil
 }
 

--- a/website/content/formats.md
+++ b/website/content/formats.md
@@ -135,9 +135,13 @@ The limits are not flags. A limit that is routinely raised protects nothing, and
 exhaust memory long before the download reached the cap. It is there to stop a
 server filling the disk on the way, not to size your data.
 
-The table is named after the file that arrives, not the URL you typed. A dataset
-behind a short link or a `latest` alias is named from the redirect target, then
-from `Content-Disposition`, then from the URL path, then from `Content-Type`.
+The table is named after the file that arrives, not the URL you typed. The name
+is taken from the first of these that gives a supported filename:
+`Content-Disposition`, the final response URL, the URL you typed, then
+`Content-Type`. A dataset behind a short link or a `latest` alias is therefore
+named after its redirect target.
+
+`HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` are honored.
 
 ## Text encodings
 

--- a/website/content/formats.md
+++ b/website/content/formats.md
@@ -108,6 +108,37 @@ Excel compares sheet names case-insensitively itself.)
 
 An Excel source cannot be written back in place, because several tables share one file. Export to a new workbook with `--output-format excel --output`.
 
+## Remote inputs
+
+A positional argument may be an `http` or `https` URL. sqly downloads it to a
+temporary file, imports that, and removes it when the run ends — including when
+the run fails or is interrupted.
+
+A URL is the one input nobody local vouched for: the server chooses the size and
+where a redirect leads. These bounds apply to it and to nothing else.
+
+| Bound | Value | On breach |
+|:--|:--|:--|
+| Download size | 2 GiB | the download is refused and the partial file removed |
+| Redirects | 5 | the chain is reported as not settling |
+| Redirect scheme | `http`, `https` | a redirect to any other scheme is refused by name |
+| Response headers | 30 seconds | the request fails |
+| Whole transfer | 15 minutes | the request fails |
+
+The size cap holds whether or not the server declares a `Content-Length`: a
+chunked response is stopped while it is being read, so a body that never ends
+cannot fill the disk. A declared size over the limit is refused before the body
+is read at all.
+
+The limits are not flags. A limit that is routinely raised protects nothing, and
+2 GiB is far past what fits in an in-memory SQLite database — the import would
+exhaust memory long before the download reached the cap. It is there to stop a
+server filling the disk on the way, not to size your data.
+
+The table is named after the file that arrives, not the URL you typed. A dataset
+behind a short link or a `latest` alias is named from the redirect target, then
+from `Content-Disposition`, then from the URL path, then from `Content-Type`.
+
 ## Text encodings
 
 A text input without a Unicode BOM is decoded as UTF-8 unless `--encoding` says otherwise: `utf-8`, `shift-jis` (accepting `cp932`, `ms932`, `windows-31j`, `sjis`), `euc-jp`, `iso-2022-jp`, `utf-16le`, `utf-16be`. A BOM always wins over the flag.


### PR DESCRIPTION
Stacked on #804.

A URL is the one input to sqly that nobody local vouched for. A timeout already bounded how long a server may take; nothing bounded how much it could spend, which is the half the server chooses.

## What is bounded

| Bound | Value | On breach |
|:--|:--|:--|
| Download size | 2 GiB | refused, partial file removed |
| Redirects | 5 | reported as a chain that does not settle |
| Redirect scheme | `http`, `https` | refused by name |

The size cap holds whether or not a `Content-Length` is declared: a chunked body that never ends is cut off while it is being read, and a declared size over the limit is refused before the body is read at all. The partial file goes with the refusal, so a rejected import does not leak disk across repeated runs.

A redirect out of http/https is refused by name rather than surfacing as `unsupported protocol scheme` from the transport — a server answering with `Location: file:///etc/passwd` is asking sqly to read a local file as though the user had named it.

## Why constants and not flags

A limit that is routinely raised protects nothing, and 2 GiB is far past what fits in an in-memory SQLite database — the import would exhaust memory long before the download reached the cap. It is there to stop a server filling the disk on the way, not to size your data. Both limits are documented on the formats page.

## Incidental fix

A downloaded file is now named after the URL the response came from rather than the one typed, so a dataset behind a short link or a `latest` alias gets the table name of the file that actually arrived.

## Verification

The size limit is injectable so the tests exercise it against 64 KiB instead of moving two gigabytes through the disk on every CI run. All six limit tests were mutation-checked against unprotected code and all six fail there — the first draft of the two redirect tests passed on Go’s default client behavior and were tightened to bind to sqly’s own policy.

`go test ./...`, `-race`, `go vet`, `golangci-lint`, `go-arch-lint` clean. 704 atago scenarios pass, including a new `e2e/atago/http_limits.atago.yaml` driving the redirect policies through the real binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer HTTP(S) input downloads with download-size limits and timeout protections.
  * Restricted redirects to the same scheme and a maximum of five redirects.
  * File names now reflect the final redirected resource when applicable.
* **Bug Fixes**
  * Prevented incomplete temporary files from remaining after oversized downloads fail.
  * Added handling for oversized responses, including chunked transfers without a declared size.
* **Documentation**
  * Documented HTTP(S) input behavior, limits, cleanup, redirects, and table-name derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->