### PR TITLE
feat!: refuse an in-place save through a symlink unless asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Breaking Changes
 * Exit codes now classify the failure instead of reporting every one as `1`. A bad command line or an unrunnable script exits `2`, an input that could not be read exits `3`, a destination that could not be written exits `4`, and a statement that ran and failed still exits `1`. A wrapper that only checks for non-zero is unaffected; one that checks for `1` specifically has to widen the check. The class is decided from the failure itself, so a `.save` that cannot write exits `4` inside a script exactly as it does on its own.
 
+* `.save --in-place` refuses a symlinked source unless `--follow-symlinks` is given. Following a link is still the only correct way to write through one — a rename would replace the link and leave the real file holding the old rows — but it overwrites a path the user never typed, which can sit outside the directory they are working in. The refusal names the link and what it resolves to; the opt-in prints the resolved path to stderr before writing. `.save DIR` is unaffected and rejects the option as meaningless there.
+
 ### New Features
 * SIGINT and SIGTERM cancel the run and exit `130` instead of killing the process. The query is canceled, the deferred cleanup runs, and the temp directories a download or a staged stdin dataset created are removed. The interactive shell is unaffected: the prompt reads Ctrl-C as a keystroke.
 

--- a/e2e/atago/file_write_contract.atago.yaml
+++ b/e2e/atago/file_write_contract.atago.yaml
@@ -302,7 +302,11 @@ scenarios:
             path: two.csv
             contains: "8"
 
-  - name: writes through a symlinked source instead of replacing the link
+  # An in-place save through a symlink has to be asked for, because the file it
+  # overwrites is one the user never named. Both halves are checked: the refusal
+  # leaves the target alone, and the opt-in writes through the link correctly
+  # rather than replacing it with a regular file.
+  - name: refuses an in-place save through a symlinked source by default
     skip:
       os: windows
     env: *hist
@@ -318,6 +322,30 @@ scenarios:
       - run:
           command: sqly link.csv
           stdin: "UPDATE link SET name = 'zoe';\n.save --in-place\n"
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "is a symlink to"
+          file:
+            path: real/u.csv
+            not_contains: zoe
+
+  - name: writes through a symlinked source when --follow-symlinks is given
+    skip:
+      os: windows
+    env: *hist
+    steps:
+      - fixture:
+          file: real/u.csv
+          content: |
+            id,name
+            1,alice
+      - fixture:
+          file: link.csv
+          symlink: real/u.csv
+      - run:
+          command: sqly link.csv
+          stdin: "UPDATE link SET name = 'zoe';\n.save --in-place --follow-symlinks\n"
       - assert:
           exit_code: 0
           file:

--- a/shell/import_test.go
+++ b/shell/import_test.go
@@ -369,7 +369,7 @@ func TestImportDirectory_ReimportOverFileImport_UpdatesSourceAndBlocksSave(t *te
 	if err := s.exec(ctx, "INSERT INTO user VALUES ('alt2',2,'ALT','Two')"); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
-	if err := s.writeBack(ctx, ""); err == nil {
+	if err := s.writeBack(ctx, "", false); err == nil {
 		t.Error("expected .save --in-place to be rejected for a directory-imported table")
 	}
 	after, err := os.ReadFile(orig) //nolint:gosec // test path

--- a/shell/inspect_test.go
+++ b/shell/inspect_test.go
@@ -342,7 +342,7 @@ func TestWriteBack_RejectsDirectoryImport(t *testing.T) {
 	if err := shell.exec(context.Background(), "INSERT INTO one VALUES (2)"); err != nil {
 		t.Fatalf("insert failed: %v", err)
 	}
-	if err := shell.writeBack(context.Background(), t.TempDir()); err == nil {
+	if err := shell.writeBack(context.Background(), t.TempDir(), false); err == nil {
 		t.Fatal("write-back of a directory-imported table returned nil, want rejection")
 	}
 }

--- a/shell/partialwrite_test.go
+++ b/shell/partialwrite_test.go
@@ -237,7 +237,7 @@ func TestWriteBack_PartialCopyOnTheSecondTargetRestoresBoth(t *testing.T) {
 	// fallback (3) — which truncates places.csv and fails.
 	shell.files.Copy = truncatingCopy(ops.Copy, 3, "id,ci", copyFailure)
 
-	err := shell.writeBack(context.Background(), "")
+	err := shell.writeBack(context.Background(), "", false)
 	if err == nil {
 		t.Fatal("writeBack succeeded although the second commit failed")
 	}
@@ -272,7 +272,7 @@ func TestWriteBack_FallbackCopyOnEveryTargetStillSaves(t *testing.T) {
 	shell.files = ops
 	shell.files.Rename = alwaysFailRename(errors.New("rename refused, as on Windows"))
 
-	if err := shell.writeBack(context.Background(), ""); err != nil {
+	if err := shell.writeBack(context.Background(), "", false); err != nil {
 		t.Fatalf("writeBack through the fallback copy: %v", err)
 	}
 	if got := readFile(t, first); !strings.Contains(got, "alice") {
@@ -325,6 +325,10 @@ func TestOutputWrite_SuccessfulRenameCopiesNothing(t *testing.T) {
 // used to leave a regular file where the link had been, with the file it pointed
 // at still holding the old rows — and "Saved" on stderr. Everything the user
 // could see said the edit had landed.
+//
+// Following a link now has to be asked for (see applySymlinkPolicy), so the
+// script says so. What is being checked is unchanged: once sqly agrees to write
+// through a link, it must write through it correctly.
 func TestWriteBack_InPlaceSaveFollowsASymlink(t *testing.T) {
 	dir := t.TempDir()
 	realDir := filepath.Join(dir, "real")
@@ -337,7 +341,7 @@ func TestWriteBack_InPlaceSaveFollowsASymlink(t *testing.T) {
 		t.Skipf("symlinks not supported here: %v", err)
 	}
 
-	if _, err := runScript(t, "UPDATE link SET name = 'zoe';\n.save --in-place\n", link); err != nil {
+	if _, err := runScript(t, "UPDATE link SET name = 'zoe';\n.save --in-place --follow-symlinks\n", link); err != nil {
 		t.Fatalf("save through a symlink: %v", err)
 	}
 

--- a/shell/save.go
+++ b/shell/save.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/nao1215/sqly/config"
@@ -14,6 +15,10 @@ import (
 
 // inPlaceArg is the .save argument that selects destructive in-place overwrite.
 const inPlaceArg = "--in-place"
+
+// followSymlinksArg opts an in-place save into writing through a symlinked
+// source. See planSymlinkPolicy for why that needs asking for.
+const followSymlinksArg = "--follow-symlinks"
 
 // noDataChangedMessage explains a save that wrote nothing because the session
 // left every table as imported, so a read-only session never looks like a
@@ -24,6 +29,16 @@ const noDataChangedMessage = "no table data changed in this session; nothing to 
 // shell. ".save DIR" writes into a directory without touching the sources;
 // ".save --in-place" overwrites the source files.
 func (c CommandList) saveCommand(ctx context.Context, s *Shell, argv []string) error {
+	// --follow-symlinks modifies an in-place save and nothing else, so it is
+	// stripped here and validated against the destination below. Taking it as a
+	// second positional argument would report it as "too many arguments", which
+	// says nothing about why it was refused.
+	followSymlinks := false
+	if i := slices.Index(argv, followSymlinksArg); i >= 0 {
+		followSymlinks = true
+		argv = append(append([]string{}, argv[:i]...), argv[i+1:]...)
+	}
+
 	if len(argv) != 1 {
 		// A missing or extra argument is a command error so a batch script fails
 		// fast instead of skipping the save and exiting 0. The usage and note ride
@@ -32,10 +47,18 @@ func (c CommandList) saveCommand(ctx context.Context, s *Shell, argv []string) e
 			"[Usage]\n" +
 			"  .save DIRECTORY   write each table into DIRECTORY (originals untouched)\n" +
 			"  .save --in-place  overwrite each table's source file\n" +
+			"                    add --follow-symlinks to write through a symlinked source\n" +
 			"[Note]\n" +
 			"  csv/tsv/ltsv/parquet sources are written; compression is preserved.\n" +
 			"  A whole ACH/Fedwire set is reconstructed back into a single .ach/.fed file\n" +
 			"  when all of that source's tables are still present")
+	}
+	// The option only means anything for the destructive form. `.save DIR
+	// --follow-symlinks` reads as though it changes something about the export,
+	// and there is nothing there for it to change.
+	if followSymlinks && argv[0] != inPlaceArg {
+		return fmt.Errorf(".save %s applies to %s only; .save DIR writes elsewhere and never follows a source link",
+			followSymlinksArg, inPlaceArg)
 	}
 	// Reject an empty destination so `.save ""` is not silently treated as an
 	// in-place save, which the user never asked for.
@@ -70,7 +93,7 @@ func (c CommandList) saveCommand(ctx context.Context, s *Shell, argv []string) e
 		return nil
 	}
 	if argv[0] == inPlaceArg {
-		return s.writeBack(ctx, "")
+		return s.writeBack(ctx, "", followSymlinks)
 	}
 	// Expand a leading "~" so `.save ~/out` writes under the home directory
 	// instead of a literal "~" directory.
@@ -78,7 +101,7 @@ func (c CommandList) saveCommand(ctx context.Context, s *Shell, argv []string) e
 	if err != nil {
 		return err
 	}
-	return s.writeBack(ctx, destDir)
+	return s.writeBack(ctx, destDir, followSymlinks)
 }
 
 // noTablesToSaveError builds the empty-session save error with recovery guidance
@@ -179,7 +202,7 @@ type writeTarget struct {
 // ACH or Fedwire source are reconstructed together into the one file they came
 // from. Anything that cannot be written that way is rejected before the first
 // byte is written, so a session is never partially saved.
-func (s *Shell) writeBack(ctx context.Context, destDir string) error {
+func (s *Shell) writeBack(ctx context.Context, destDir string, followSymlinks bool) error {
 	// Both destinations skip a table the session did not change, and they mean
 	// different things by "did not change" — see planWriteBack.
 	targets, err := s.planWriteBack(ctx, destDir, true)
@@ -190,7 +213,63 @@ func (s *Shell) writeBack(ctx context.Context, destDir string) error {
 		fmt.Fprintln(config.Stderr, "no imported table changed in this session; nothing to save")
 		return nil
 	}
+	if err := s.applySymlinkPolicy(destDir, targets, followSymlinks); err != nil {
+		return err
+	}
 	return s.executeWriteBack(ctx, destDir, targets)
+}
+
+// applySymlinkPolicy decides whether an in-place save may write through a
+// symlinked source, and says where the write is going when it may.
+//
+// An in-place save overwrites the file it read, and a symlink makes "the file it
+// read" two answers: the link the user typed and the file behind it. sqly writes
+// to the second — every step of the write resolves the link, which is what keeps
+// a save from replacing the link with a regular file and leaving the real one
+// holding the old rows. That is the right way to follow a link and it is still
+// worth asking about, because the path being overwritten is one the user never
+// named. It can sit outside the directory they are working in, and it can be
+// shared with something that did not expect sqly to rewrite it.
+//
+// So the default refuses and names the link, and --follow-symlinks is how a user
+// who meant it says so. When they do, the resolved path goes to stderr: the
+// whole reason for asking is that the destination is not what was typed, so
+// proceeding silently would answer the question by ignoring it.
+//
+// This is scoped to the in-place form. `.save DIR` writes somewhere else and
+// leaves every source alone, so a symlinked source is not a hazard there.
+func (s *Shell) applySymlinkPolicy(destDir string, targets []writeTarget, followSymlinks bool) error {
+	if destDir != "" {
+		return nil
+	}
+
+	var problems []string
+	for _, tgt := range targets {
+		info, err := os.Lstat(tgt.dest)
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			// A path that cannot be stat'd is left to the write itself, which
+			// reports filesystem failures with the phase they happened in.
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(tgt.dest)
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("%s: %s is a symlink that does not resolve: %v",
+				tgt.table, tgt.dest, err))
+			continue
+		}
+		if !followSymlinks {
+			problems = append(problems, fmt.Sprintf(
+				"%s: %s is a symlink to %s; an in-place save would overwrite that file, which you did not name. Add %s to do it anyway, or save to a directory with .save DIR",
+				tgt.table, tgt.dest, resolved, followSymlinksArg))
+			continue
+		}
+		fmt.Fprintf(config.Stderr, "following the symlink %s to %s\n", tgt.dest, resolved)
+	}
+
+	if len(problems) > 0 {
+		return &writeBackError{Err: fmt.Errorf("cannot save session:\n  - %s", strings.Join(problems, "\n  - "))}
+	}
+	return nil
 }
 
 // planWriteBack validates that every current table can be written and returns the

--- a/shell/save_symlink_test.go
+++ b/shell/save_symlink_test.go
@@ -3,7 +3,6 @@ package shell
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -149,16 +148,18 @@ func TestSave_RejectsFollowSymlinksWithADirectory(t *testing.T) {
 	}
 }
 
-// requireSymlinks skips a test where symlinks cannot be created. Unprivileged
-// Windows accounts without developer mode cannot make them, and a skip there is
-// honest where a failure would only report the runner's configuration.
+// requireSymlinks skips a test where symlinks cannot be created, so a failure
+// always means the policy is wrong rather than that the runner would not let the
+// test set itself up.
+//
+// The probe runs everywhere rather than only on Windows. An unprivileged Windows
+// account without developer mode is the usual case, but it is not the only one —
+// a restricted container or a filesystem mounted without symlink support says no
+// on Linux too — and asking is both cheaper and more honest than assuming.
 func requireSymlinks(t *testing.T) {
 	t.Helper()
-	if runtime.GOOS != "windows" {
-		return
-	}
 	dir := t.TempDir()
 	if err := os.Symlink(filepath.Join(dir, "a"), filepath.Join(dir, "b")); err != nil {
-		t.Skipf("this account cannot create symlinks: %v", err)
+		t.Skipf("this environment cannot create symlinks: %v", err)
 	}
 }

--- a/shell/save_symlink_test.go
+++ b/shell/save_symlink_test.go
@@ -1,0 +1,155 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// `.save --in-place` overwrites the file it read. A symlink makes "the file it
+// read" two different answers — the link and what the link points at — and the
+// difference only shows up on the write. sqly follows the link, which is what
+// makes it worth refusing by default: following it writes through to a path the
+// user never named, which may sit outside the directory they are working in and
+// may be shared with something else.
+//
+// The refusal is the default and not the rule; --follow-symlinks is how a user
+// who meant it says so. These tests pin both halves, because a guard with no way
+// past it would just move the problem to a copy step the user does by hand.
+//
+// None of them call t.Parallel: runScriptStreams swaps config.Stdout and
+// config.Stderr, which are process-wide.
+
+func TestSaveInPlace_RefusesASymlinkedSourceByDefault(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	target := writeCSV(t, dir, "real.csv", "name,age\nken,40\n")
+	link := filepath.Join(dir, "link.csv")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("create the symlink: %v", err)
+	}
+
+	_, stderr, err := runScriptStreams(t, "UPDATE link SET age = 41;\n.save --in-place\n", link)
+	if err == nil {
+		t.Fatal("an in-place save through a symlink was accepted")
+	}
+	if !strings.Contains(stderr, "symlink") {
+		t.Errorf("the refusal should say the source is a symlink, got: %s", stderr)
+	}
+	// The point of refusing is that nothing was written. A guard that reports an
+	// error after the write has landed protects nothing.
+	if got := readFile(t, target); got != "name,age\nken,40\n" {
+		t.Errorf("the target file was modified despite the refusal: %q", got)
+	}
+}
+
+func TestSaveInPlace_FollowsASymlinkWhenAskedTo(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	target := writeCSV(t, dir, "real.csv", "name,age\nken,40\n")
+	link := filepath.Join(dir, "link.csv")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("create the symlink: %v", err)
+	}
+
+	_, stderr, err := runScriptStreams(t, "UPDATE link SET age = 41;\n.save --in-place --follow-symlinks\n", link)
+	if err != nil {
+		t.Fatalf("an explicit --follow-symlinks save failed: %v (%s)", err, stderr)
+	}
+	if got := readFile(t, target); !strings.Contains(got, "41") {
+		t.Errorf("the target file was not updated: %q", got)
+	}
+	// The link must still be a link afterwards. A rename replaces the name, not
+	// the file behind it, so a write that forgets to resolve first turns the
+	// symlink into a regular file and leaves the target one holding the old rows.
+	info, lerr := os.Lstat(link)
+	if lerr != nil {
+		t.Fatalf("lstat the link: %v", lerr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("the symlink was replaced by a regular file")
+	}
+	// A user who asks sqly to write through a link is told where that write went,
+	// because the whole reason the default refuses is that the destination is not
+	// the path they typed.
+	if !strings.Contains(stderr, target) {
+		t.Errorf("stderr should name the resolved target %q, got: %s", target, stderr)
+	}
+}
+
+// TestSaveInPlace_AllowsAPlainFile keeps the guard from costing the ordinary
+// case: the overwhelming majority of sources are not symlinks and must not have
+// to opt into anything.
+func TestSaveInPlace_AllowsAPlainFile(t *testing.T) {
+	dir := t.TempDir()
+	plain := writeCSV(t, dir, "plain.csv", "name,age\nken,40\n")
+
+	_, stderr, err := runScriptStreams(t, "UPDATE plain SET age = 41;\n.save --in-place\n", plain)
+	if err != nil {
+		t.Fatalf("an ordinary in-place save failed: %v (%s)", err, stderr)
+	}
+	if got := readFile(t, plain); !strings.Contains(got, "41") {
+		t.Errorf("the file was not updated: %q", got)
+	}
+}
+
+// TestSaveDir_IsUnaffectedBySymlinkPolicy scopes the guard. `.save DIR` writes
+// somewhere else and leaves every source alone, so a symlinked source is not a
+// hazard there and must not be refused.
+func TestSaveDir_IsUnaffectedBySymlinkPolicy(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	target := writeCSV(t, dir, "real.csv", "name,age\nken,40\n")
+	link := filepath.Join(dir, "link.csv")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("create the symlink: %v", err)
+	}
+	destDir := filepath.Join(dir, "out")
+
+	_, stderr, err := runScriptStreams(t, "UPDATE link SET age = 41;\n.save "+destDir+"\n", link)
+	if err != nil {
+		t.Fatalf(".save DIR with a symlinked source failed: %v (%s)", err, stderr)
+	}
+	if got := readFile(t, target); got != "name,age\nken,40\n" {
+		t.Errorf(".save DIR modified the source: %q", got)
+	}
+	if _, serr := os.Stat(filepath.Join(destDir, "link.csv")); serr != nil {
+		t.Errorf("the export was not written: %v", serr)
+	}
+}
+
+// TestSave_RejectsFollowSymlinksWithADirectory keeps the option attached to the
+// operation it modifies. `.save DIR --follow-symlinks` reads as though it
+// changes something about the export, and it does not.
+func TestSave_RejectsFollowSymlinksWithADirectory(t *testing.T) {
+	dir := t.TempDir()
+	plain := writeCSV(t, dir, "plain.csv", "name,age\nken,40\n")
+	destDir := filepath.Join(dir, "out")
+
+	_, stderr, err := runScriptStreams(t, "UPDATE plain SET age = 41;\n.save "+destDir+" --follow-symlinks\n", plain)
+	if err == nil {
+		t.Fatal(".save DIR --follow-symlinks was accepted")
+	}
+	if !strings.Contains(stderr, "--follow-symlinks") {
+		t.Errorf("the error should name the misplaced option, got: %s", stderr)
+	}
+}
+
+// requireSymlinks skips a test where symlinks cannot be created. Unprivileged
+// Windows accounts without developer mode cannot make them, and a skip there is
+// honest where a failure would only report the runner's configuration.
+func requireSymlinks(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		return
+	}
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "a"), filepath.Join(dir, "b")); err != nil {
+		t.Skipf("this account cannot create symlinks: %v", err)
+	}
+}

--- a/shell/save_symlink_test.go
+++ b/shell/save_symlink_test.go
@@ -76,8 +76,17 @@ func TestSaveInPlace_FollowsASymlinkWhenAskedTo(t *testing.T) {
 	// A user who asks sqly to write through a link is told where that write went,
 	// because the whole reason the default refuses is that the destination is not
 	// the path they typed.
-	if !strings.Contains(stderr, target) {
-		t.Errorf("stderr should name the resolved target %q, got: %s", target, stderr)
+	//
+	// The expected path is resolved the same way sqly resolves it. On Windows
+	// t.TempDir can hand back an 8.3 short path (C:\Users\RUNNER~1\...) while
+	// EvalSymlinks returns the long form, so comparing against the raw path fails
+	// on a difference that has nothing to do with what is being tested.
+	wantPath := target
+	if resolved, rerr := filepath.EvalSymlinks(target); rerr == nil {
+		wantPath = resolved
+	}
+	if !strings.Contains(stderr, wantPath) {
+		t.Errorf("stderr should name the resolved target %q, got: %s", wantPath, stderr)
 	}
 }
 

--- a/shell/writeback_failure_test.go
+++ b/shell/writeback_failure_test.go
@@ -121,7 +121,7 @@ func TestWriteBack_SerializeFailureLeavesEverySourceUntouched(t *testing.T) {
 		return ops.CreateTemp(d, pattern)
 	}
 
-	err := shell.writeBack(context.Background(), "")
+	err := shell.writeBack(context.Background(), "", false)
 	if err == nil {
 		t.Fatal("writeBack succeeded although the second target could not be staged")
 	}
@@ -158,7 +158,7 @@ func TestWriteBack_BackupFailureStopsBeforeAnyCommit(t *testing.T) {
 	// The first Copy is the backup; the commit's copy fallback comes later.
 	shell.files.Copy = failOnNth2(1, ops.Copy, errInjected)
 
-	if err := shell.writeBack(context.Background(), ""); err == nil {
+	if err := shell.writeBack(context.Background(), "", false); err == nil {
 		t.Fatal("writeBack succeeded although the backup could not be taken")
 	}
 	if got := readFile(t, src); got != content {
@@ -186,7 +186,7 @@ func TestWriteBack_ChmodFailureStopsTheCommit(t *testing.T) {
 	shell.files = ops
 	shell.files.Chmod = func(string, os.FileMode) error { return errInjected }
 
-	if err := shell.writeBack(context.Background(), ""); err == nil {
+	if err := shell.writeBack(context.Background(), "", false); err == nil {
 		t.Fatal("writeBack succeeded although the permissions could not be carried over")
 	}
 	if got := readFile(t, src); got != content {
@@ -234,7 +234,7 @@ func TestWriteBack_RollbackFailureIsReportedWithTheCause(t *testing.T) {
 		}
 	}
 
-	err := shell.writeBack(context.Background(), "")
+	err := shell.writeBack(context.Background(), "", false)
 	if err == nil {
 		t.Fatal("writeBack succeeded although a commit and its rollback both failed")
 	}
@@ -318,7 +318,7 @@ func TestWriteBack_InPlacePreservesSourcePermissions(t *testing.T) {
 	silenceStderr(t)
 	markChanged(t, shell, "shared")
 
-	if err := shell.writeBack(context.Background(), ""); err != nil {
+	if err := shell.writeBack(context.Background(), "", false); err != nil {
 		t.Fatalf("writeBack: %v", err)
 	}
 
@@ -354,7 +354,7 @@ func TestWriteBack_DuplicateInputPathWritesOnce(t *testing.T) {
 	if len(targets) != 1 {
 		t.Fatalf("planned %d targets for one file named twice, want 1: %+v", len(targets), targets)
 	}
-	if err := shell.writeBack(context.Background(), ""); err != nil {
+	if err := shell.writeBack(context.Background(), "", false); err != nil {
 		t.Fatalf("writeBack: %v", err)
 	}
 	if extra := leftoverFiles(t, dir, "twice.csv"); len(extra) > 0 {

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -180,10 +180,41 @@ An existing destination is **overwritten**. `--output` is how you name the file 
 want; it does not ask. The file's permissions are preserved when it already exists,
 and a new file is created with the usual `0600`.
 
-A destination that is a symlink is written *through*: the file it names receives
-the result and the link stays a link. The same holds for `.save --in-place` on a
-symlinked source. A rename would replace the link itself, leaving a regular file
-where the link was and the real file still holding the old rows.
+A `--output` destination that is a symlink is written *through*: the file it names
+receives the result and the link stays a link. A rename would replace the link
+itself, leaving a regular file where the link was and the real file still holding
+the old rows.
+
+`.save --in-place` follows a symlinked source the same way, but only when asked.
+By default it refuses and names both the link and what it resolves to:
+
+```shell
+sqly link.csv <<'EOF'
+UPDATE link SET n = 2;
+.save --in-place
+EOF
+# cannot save session:
+#   - link: link.csv is a symlink to /srv/shared/real.csv; an in-place save would
+#     overwrite that file, which you did not name. Add --follow-symlinks to do it
+#     anyway, or save to a directory with .save DIR
+```
+
+The reason is not that following the link is wrong — it is the only correct way
+to write through one. It is that an in-place save overwrites a path the user
+never typed, which can sit outside the directory they are working in and can be
+shared with something that did not expect sqly to rewrite it.
+
+`.save --in-place --follow-symlinks` does it, and prints the resolved path to
+stderr so the destination is visible:
+
+```text
+following the symlink link.csv to /srv/shared/real.csv
+Saved link to link.csv
+```
+
+The option applies to `--in-place` only. `.save DIR` writes elsewhere and never
+touches a source, so it is accepted with a symlinked source and rejects
+`--follow-symlinks` as meaningless there.
 
 ## Inspection
 

--- a/website/content/shell.md
+++ b/website/content/shell.md
@@ -69,6 +69,7 @@ Dot-commands are single-line and run on Enter. To run a query without typing `;`
 | `.dump TABLE FILE` | export one table; the format follows `.mode`, or the file extension when the mode is `table` |
 | `.save DIR` | write every changed table into `DIR`, leaving the sources alone |
 | `.save --in-place` | overwrite each table's source file |
+| `.save --in-place --follow-symlinks` | also overwrite through a symlinked source, which is otherwise refused |
 
 ## Batch mode
 


### PR DESCRIPTION
Stacked on #805.

`.save --in-place` overwrites the file it read, and a symlink makes "the file it read" two answers: the link the user typed and the file behind it. sqly writes to the second, which is the only correct way to write through a link — a rename would replace the link and leave the real file holding the old rows.

It is still worth asking about. The path being overwritten is one the user never named: it can sit outside the directory they are working in, and it can be shared with something that did not expect sqly to rewrite it.

## Behavior

The default refuses and names both ends:

```
cannot save session:
  - link: link.csv is a symlink to /srv/shared/real.csv; an in-place save would
    overwrite that file, which you did not name. Add --follow-symlinks to do it
    anyway, or save to a directory with .save DIR
```

`.save --in-place --follow-symlinks` does it, printing the resolved path to stderr first. Proceeding silently would answer the question by ignoring it.

The policy is scoped to the destructive form. `.save DIR` writes elsewhere and never touches a source, so a symlinked source is fine there and the option is rejected as meaningless.

## Note on the tradeoff

This reverses the rc1 behavior of following a symlinked source silently. Following the link is not wrong — sqly imported from the resolved file, so writing back to it is a round trip — and the guard does cost a flag in a legitimate workflow. It is here because the destructive operation is the one where "which file is this actually" should not be answered implicitly. The rc1 regression guard for writing through a link *correctly* is kept, now passing `--follow-symlinks` to get there.

## Verification

`go test ./...`, `-race`, `go vet`, `golangci-lint`, `go-arch-lint` clean. 704 atago scenarios pass. The E2E scenario that asserted follow-by-default is split into two: the refusal leaves the target untouched, and the opt-in writes through the link without replacing it. Tests skip where the account cannot create symlinks rather than failing on the runner’s configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `.save --in-place --follow-symlinks` to explicitly allow saving through symlinked source files.
  * In-place saves now report the resolved destination when following symlinks.

* **Bug Fixes**
  * In-place saves refuse symlinked sources by default, preventing unintended target modifications.
  * Directory saves remain supported with symlinked sources; the symlink option is rejected when not applicable.

* **Documentation**
  * Updated reference and shell documentation with the new symlink-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->