### PR TITLE
feat!: add --script-file, and make the docs verifiable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,8 @@ If the input matters, a few lines of it are more useful than a description of it
 What you expected to happen.
 
 **What happened**
-The output, including anything on stderr, and the exit code (`echo $?`).
+The output, including anything on stderr, and the exit code — `echo $?` in a
+POSIX shell, `$LASTEXITCODE` in PowerShell, `%ERRORLEVEL%` in cmd.
 
 **Environment**
  - sqly version (`sqly --version`):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,22 +11,24 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+The exact command you ran, and the input it ran against:
+
+```shell
+sqly ...
+```
+
+If the input matters, a few lines of it are more useful than a description of it.
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+What you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**What happened**
+The output, including anything on stderr, and the exit code (`echo $?`).
 
-**Desktop (please complete the following information):**
- - OS: [e.g. Ubuntu]
- - Go Version [e.g. 1.17]
- - Application Version [e.g. 1.0.1]
+**Environment**
+ - sqly version (`sqly --version`):
+ - OS and architecture:
+ - Input file format(s):
 
 **Additional context**
-Add any other context about the problem here.
+Anything else worth knowing.

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -49,7 +49,12 @@ jobs:
           hugo version
 
       - name: Build website
+        # The commit is stamped into every page so the deploy can be verified
+        # afterwards. Hugo reads HUGO_PARAMS_* as config overrides, which is why
+        # it arrives as a param rather than through getenv.
         run: make website
+        env:
+          HUGO_PARAMS_BUILDCOMMIT: ${{ github.sha }}
 
       - name: Index the site with Pagefind
         run: |
@@ -79,3 +84,66 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+  # A green deploy step means the artifact was accepted, not that the site a
+  # reader loads is the one just built. This fetches the live site and checks
+  # it: the build commit matches, the current flags are on the page, and the
+  # flags removed before v1.0.0 are not.
+  #
+  # The retry exists because a CDN takes a little while to serve the new copy.
+  # It is bounded in both attempts and total wait, and it fails loudly when the
+  # bound is reached rather than passing on a timeout.
+  verify:
+    if: github.event_name != 'pull_request'
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    env:
+      SITE: https://nao1215.github.io/sqly/
+      EXPECTED_SHA: ${{ github.sha }}
+      MAX_ATTEMPTS: "10"
+      SLEEP_SECONDS: "20"
+    steps:
+      - name: Wait for the deployed commit to go live
+        run: |
+          attempt=1
+          while [ "${attempt}" -le "${MAX_ATTEMPTS}" ]; do
+            live=$(curl -fsSL --max-time 30 "${SITE}?cachebust=${GITHUB_RUN_ID}-${attempt}" \
+              | grep -o 'name="sqly-build-commit" content="[0-9a-f]*"' \
+              | sed 's/.*content="//; s/"//') || live=""
+            if [ "${live}" = "${EXPECTED_SHA}" ]; then
+              echo "the live site is ${live}"
+              exit 0
+            fi
+            echo "attempt ${attempt}/${MAX_ATTEMPTS}: live is '${live}', want '${EXPECTED_SHA}'"
+            attempt=$((attempt + 1))
+            [ "${attempt}" -le "${MAX_ATTEMPTS}" ] && sleep "${SLEEP_SECONDS}"
+          done
+          echo "::error::the deployed commit ${EXPECTED_SHA} did not appear on ${SITE} within $((MAX_ATTEMPTS * SLEEP_SECONDS))s" >&2
+          exit 1
+
+      - name: Check the reference page shows the current flags
+        run: |
+          page=$(curl -fsSL --max-time 30 "${SITE}reference/?cachebust=${GITHUB_RUN_ID}")
+
+          # Present: flags v1.0.0 commits to. A page that lost one is a page a
+          # reader cannot use to write a working command.
+          for flag in --stdin-format --stdin-table --encoding --row-mismatch \
+                      --sql --sql-file --script-file --dialect \
+                      --output --output-format --inspect --inspect-sample; do
+            case "${page}" in
+              *"${flag}"*) ;;
+              *) echo "::error::${flag} is missing from the deployed reference page" >&2; exit 1 ;;
+            esac
+          done
+
+          # Absent: flags removed before v1.0.0. A page still advertising one
+          # sends a reader to write a command that fails.
+          for flag in --json-typed --ndjson-typed --import-mode --save-in-place \
+                      --save-tables --cache-clear --stdin-name; do
+            case "${page}" in
+              *"${flag}"*) echo "::error::${flag} was removed but is still on the deployed reference page" >&2; exit 1 ;;
+            esac
+          done
+          echo "the deployed reference page matches the v1.0.0 flag surface"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,45 @@
 # CHANGELOG
 
+## Release candidates and what v1.0.0 freezes
+
+`v1.0.0-rc1` is a broad candidate, not the final contract. Breaking changes are
+still being made, and they are being made now rather than after v1.0.0.
+
+* Breaking changes land before the final release candidate.
+* From the final RC onward, only bug fixes and documentation changes.
+* Nothing user-visible changes between the final RC and v1.0.0 — same flags,
+  same output, same exit codes.
+* Every change to what rc1 promised is listed under Breaking Changes below.
+
+The final RC is announced as the final one in its release notes. That is the
+point to pin a version against.
+
 ## [Unreleased]
 
 ### Breaking Changes
+* Added `--script-file FILE`, and `--sql-file` now points at it when it rejects a dot-command. `--sql-file` still holds SQL only; a script that mixes SQL and dot-commands has an entry point of its own instead of only working when piped. `--sql`, `--sql-file`, and `--script-file` are mutually exclusive, and `--output` does not apply to `--script-file` — a script writes files with `.dump`, where the destination means something.
+* An unsupported `--stdin-format` value is rejected while parsing rather than when stdin is staged, so it exits `2` as a usage error instead of `1` after the run had started.
 * Exit codes now classify the failure instead of reporting every one as `1`. A bad command line or an unrunnable script exits `2`, an input that could not be read exits `3`, a destination that could not be written exits `4`, and a statement that ran and failed still exits `1`. A wrapper that only checks for non-zero is unaffected; one that checks for `1` specifically has to widen the check. The class is decided from the failure itself, so a `.save` that cannot write exits `4` inside a script exactly as it does on its own.
-
 * `.save --in-place` refuses a symlinked source unless `--follow-symlinks` is given. Following a link is still the only correct way to write through one — a rename would replace the link and leave the real file holding the old rows — but it overwrites a path the user never typed, which can sit outside the directory they are working in. The refusal names the link and what it resolves to; the opt-in prints the resolved path to stderr before writing. `.save DIR` is unaffected and rejects the option as meaningless there.
 
 ### New Features
 * SIGINT and SIGTERM cancel the run and exit `130` instead of killing the process. The query is canceled, the deferred cleanup runs, and the temp directories a download or a staged stdin dataset created are removed. The interactive shell is unaffected: the prompt reads Ctrl-C as a keystroke.
+
+### Documentation
+* The formats page opens with a capability matrix: what each format can do for reading, stdin, URLs, compression, tables per file, query results, write-back, and types. The formats differ in all of those, and the page previously described them one at a time.
+* The reference documents `--help` and `--version`, which it had never listed despite promising every flag, and gained a section comparing `--sql-file`, `--script-file`, and a piped script.
+* CONTRIBUTING points at `website/content/` instead of the mkdocs tree that was replaced by Hugo, and the bug report template asks for the command, the exit code, and `sqly --version` instead of browser steps and a Go version.
+* A drift test derives the flag list from the parser and fails when the reference documents a flag that does not exist, or omits one that does. Another fails if the README goes back to stating a flag count; it said twelve while there were thirteen.
+
+### v1.0.0 CLI Surface
+This supersedes the list under v1.0.0-rc1, which is left as the record of what that tag promised.
+
+* Input: positional paths (files, directories, `http(s)` URLs), `--stdin-format FORMAT`, `--stdin-table NAME`, `--encoding ENCODING`, `--row-mismatch error|skip|pad`.
+* Query: `--sql/-s SQL`, `--sql-file/-f FILE`, `--script-file FILE`, `--dialect sqlite|mysql|postgresql|googlesql`.
+* Output: `--output/-o FILE`, `--output-format table|vertical|csv|tsv|ltsv|json|jsonl|markdown|excel|parquet`.
+* Inspection: `--inspect`, `--inspect-sample N`.
+* General: `--help/-h`, `--version/-v`.
+* Exit codes: `0` success, `1` a statement failed, `2` usage, `3` input, `4` output, `130` interrupted.
 
 ## [v1.0.0-rc1](https://github.com/nao1215/sqly/compare/v0.31.0...v1.0.0-rc1) (2026-08-04)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,17 @@ CI does not render GIFs; the `TestDemoAssetsInSync` test instead fails when a ta
 and its GIF, or the README and a GIF, fall out of sync.
 
 ## Documentation
-`README.md` (English) is the source of truth for user-facing documentation. When
-you add or change a feature, also update the GitHub Pages docs under
-`doc/pages/markdown/`. Avoid bold and emoji in documentation. Localized READMEs
-have been removed; please do not add new ones.
+`README.md` (English) introduces sqly and links out; the site under
+`website/content/` is where the detail lives. When you add or change a feature,
+update the page it belongs to — `reference.md` for flags and exit codes,
+`formats.md` for what sqly reads and writes, `shell.md` for dot-commands — and
+the README only if the change is one a first-time reader needs.
+
+The site is Hugo. `make website` builds it into `website/public/`, and a push to
+`main` that touches `website/**` deploys it.
+
+Avoid bold and emoji in documentation. Localized READMEs have been removed;
+please do not add new ones.
 
 ## Releasing
 Maintainers cut releases by pushing a `v*` tag. The process is documented in

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ All except ACH and Fedwire also read the compression extensions above. Text inpu
 
 ## Flags
 
-sqly has no subcommands: `sqly --help`, not `sqly help`. Twelve flags, in five groups — input, query, output, inspection, and the two meta ones. Everything else, including writing changes back, is a dot-command inside the shell.
+sqly has no subcommands: `sqly --help`, not `sqly help`. The flags fall into five groups — input, query, output, inspection, and the two meta ones — and `sqly --help` lists them that way. Everything else, including writing changes back, is a dot-command inside the shell, run at the prompt, from a piped script, or from a `--script-file`.
 
 The [reference](https://nao1215.github.io/sqly/reference/) lists every flag and what it applies to, the multi-result rules, the table name rules, and the exit codes.
 

--- a/config/argument.go
+++ b/config/argument.go
@@ -210,9 +210,16 @@ func newArg(args []string) (*Arg, error) {
 	// is a flag value like --row-mismatch or --dialect, so a typo should fail the
 	// same way they do: before anything is read, as a usage error naming the
 	// values that exist.
-	if *stdinFormat != "" && !validStdinFormats[strings.ToLower(strings.TrimSpace(*stdinFormat))] {
-		return nil, fmt.Errorf("unsupported --stdin-format value %q: want %s", *stdinFormat,
-			strings.ReplaceAll(stdinFormatHelp, ", ", ", "))
+	if *stdinFormat != "" {
+		normalized := strings.ToLower(strings.TrimSpace(*stdinFormat))
+		if !validStdinFormats[normalized] {
+			return nil, fmt.Errorf("unsupported --stdin-format value %q: want %s", *stdinFormat, stdinFormatHelp)
+		}
+		// Store what was validated, not what was typed. Accepting " CSV " here and
+		// passing the raw string on left the staging step looking it up in a map
+		// keyed by the canonical names and failing there instead — a value that
+		// passed validation and then failed anyway.
+		*stdinFormat = normalized
 	}
 
 	// --stdin-table only names the --stdin-format dataset, so it has no effect
@@ -437,10 +444,11 @@ func usage(flag pflag.FlagSet) string {
 	s += fmt.Sprintf("  %s [OPTIONS] [FILE|DIRECTORY|URL ...]\n", color.GreenString("sqly"))
 	s += "\n"
 	s += "  Each input is loaded into an in-memory SQLite database as a table named\n"
-	s += "  after the file. With --sql or --sql-file, sqly runs the query and exits;\n"
-	s += "  with neither, it opens an interactive shell, or runs SQL piped into it.\n"
-	s += "  sqly has no subcommands. Dot-commands run inside the shell, including\n"
-	s += "  .save, which writes changed tables back to their files.\n"
+	s += "  after the file. With --sql, --sql-file, or --script-file, sqly runs the\n"
+	s += "  work and exits; with none of them, it opens an interactive shell, or runs\n"
+	s += "  a script piped into it. sqly has no subcommands. Dot-commands run inside\n"
+	s += "  the shell, in a piped script, and in a --script-file — including .save,\n"
+	s += "  which writes changed tables back to their files.\n"
 	s += "\n"
 	s += "[Examples]\n"
 	s += fmt.Sprintf("  - %s\n", color.HiYellowString("open the shell with a file loaded"))

--- a/config/argument.go
+++ b/config/argument.go
@@ -56,6 +56,13 @@ type Arg struct {
 	// multiline statements with the same splitting rules as batch stdin mode and
 	// cannot be combined with --sql.
 	SQLFilePath string
+	// ScriptFilePath is the path to a sqly script to execute (for --script-file).
+	// A script is what the shell reads: SQL statements and dot-commands alike.
+	// It is a separate flag from --sql-file rather than a relaxation of it,
+	// because the two make different promises about what the file may do — a
+	// .sql file that silently ran .save would be a shell script wearing a SQL
+	// extension.
+	ScriptFilePath string
 	// InspectFlag, when true, prints a machine-readable JSON report of the
 	// imported tables (names, source mapping, columns, row counts, and sample
 	// rows) and exits without starting the shell.
@@ -91,6 +98,17 @@ type Arg struct {
 	Dialect dialect.Dialect
 	// Version print version message
 	Version func()
+}
+
+// validStdinFormats is the set --stdin-format accepts. It mirrors the shell's
+// stdinFormatExtensions; a value that parses here but has no extension there
+// would stage a file the importer cannot classify.
+var validStdinFormats = map[string]bool{
+	outputFormatCSV:   true,
+	outputFormatTSV:   true,
+	outputFormatLTSV:  true,
+	outputFormatJSON:  true,
+	outputFormatJSONL: true,
 }
 
 const (
@@ -153,7 +171,8 @@ func newArg(args []string) (*Arg, error) {
 	rowMismatch := flag.String("row-mismatch", model.RowMismatchError.String(), "for csv and tsv, what to do with a row whose field count differs from the header: error (fail the import), skip (drop the row), pad (fill a short row, fail on a long one)")
 	// Query.
 	query := flag.StringP("sql", "s", "", "run one SQL statement, then exit")
-	sqlFile := flag.StringP("sql-file", "f", "", "run every SQL statement in this file, then exit; a dot-command is rejected, so pipe such a script in instead; printing several results needs --output-format table, vertical, or markdown")
+	sqlFile := flag.StringP("sql-file", "f", "", "run every SQL statement in this file, then exit; a dot-command is rejected, so use --script-file for those; printing several results needs --output-format table, vertical, or markdown")
+	scriptFile := flag.String("script-file", "", "run this sqly script, then exit: SQL statements and dot-commands, exactly as when piped in; use it to script .save and .import from a file")
 	sqlDialect := flag.String("dialect", string(dialect.SQLite), "write the query in one of: sqlite, mysql, postgresql, googlesql; sqly translates it to SQLite")
 	// Output.
 	output := flag.StringP("output", "o", "", "write the one query result to this file instead of stdout")
@@ -180,8 +199,20 @@ func newArg(args []string) (*Arg, error) {
 	if flag.Changed("sql-file") && *sqlFile == "" {
 		return nil, errEmptySQLFile
 	}
+	if flag.Changed("script-file") && *scriptFile == "" {
+		return nil, errEmptyScriptFile
+	}
 	if flag.Changed("stdin-format") && *stdinFormat == "" {
 		return nil, errEmptyStdinFormat
+	}
+
+	// Reject an unknown --stdin-format here rather than when stdin is staged. It
+	// is a flag value like --row-mismatch or --dialect, so a typo should fail the
+	// same way they do: before anything is read, as a usage error naming the
+	// values that exist.
+	if *stdinFormat != "" && !validStdinFormats[strings.ToLower(strings.TrimSpace(*stdinFormat))] {
+		return nil, fmt.Errorf("unsupported --stdin-format value %q: want %s", *stdinFormat,
+			strings.ReplaceAll(stdinFormatHelp, ", ", ", "))
 	}
 
 	// --stdin-table only names the --stdin-format dataset, so it has no effect
@@ -240,6 +271,7 @@ func newArg(args []string) (*Arg, error) {
 	arg.Dialect = sqlDialectValue
 	arg.Query = *query
 	arg.SQLFilePath = *sqlFile
+	arg.ScriptFilePath = *scriptFile
 	arg.InspectSample = *inspectSample
 
 	return arg, nil
@@ -357,7 +389,7 @@ type optionGroup struct {
 // being true, so a flag added later cannot silently vanish from --help.
 var optionGroups = []optionGroup{
 	{title: "Input", options: []string{"stdin-format", "stdin-table", "encoding", "row-mismatch"}},
-	{title: "Query", options: []string{"sql", "sql-file", "dialect"}},
+	{title: "Query", options: []string{"sql", "sql-file", "script-file", "dialect"}},
 	{title: "Output", options: []string{"output", "output-format"}},
 	{title: "Inspection", options: []string{"inspect", "inspect-sample"}},
 	{title: "General", options: []string{"help", "version"}},
@@ -385,6 +417,7 @@ var optionArgNames = map[string]string{
 	"row-mismatch":   argPolicy,
 	"sql":            argSQL,
 	"sql-file":       argFile,
+	"script-file":    argFile,
 	"dialect":        argName,
 	"output":         argFile,
 	"output-format":  argFormat,

--- a/config/argument_test.go
+++ b/config/argument_test.go
@@ -649,3 +649,55 @@ func TestNewArgDependentFlagValidation(t *testing.T) {
 		}
 	})
 }
+
+// TestNewArg_NormalizesStdinFormat pins the fix for a value that passed
+// validation and then failed anyway. --stdin-format is validated trimmed and
+// lowercased, so " CSV " is accepted; storing the raw string meant the staging
+// step looked it up in a map keyed by the canonical names, missed, and failed
+// mid-run. What is validated is what is stored.
+func TestNewArg_NormalizesStdinFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		given string
+		want  string
+	}{
+		{name: "an already canonical value is unchanged", given: "csv", want: "csv"},
+		{name: "surrounding whitespace is trimmed", given: " csv ", want: "csv"},
+		{name: "an uppercase value is lowered", given: "CSV", want: "csv"},
+		{name: "both at once", given: "  JSONL\t", want: "jsonl"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			arg, err := NewArg([]string{"sqly", "--stdin-format", tt.given, "--sql", "SELECT 1"})
+			if err != nil {
+				t.Fatalf("NewArg(--stdin-format %q): %v", tt.given, err)
+			}
+			if arg.StdinFormat != tt.want {
+				t.Errorf("StdinFormat = %q, want %q", arg.StdinFormat, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewArg_RejectsAnUnknownStdinFormat is the other half: a value that is not
+// one of the five is refused while parsing, so it exits as a usage error rather
+// than after the run has started.
+func TestNewArg_RejectsAnUnknownStdinFormat(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewArg([]string{"sqly", "--stdin-format", "xml", "--sql", "SELECT 1"})
+	if err == nil {
+		t.Fatal("an unknown --stdin-format value was accepted")
+	}
+	var argErr *ArgError
+	if !errors.As(err, &argErr) {
+		t.Errorf("error is %T, want a *ArgError so it exits as a usage error", err)
+	}
+	if !strings.Contains(err.Error(), "want csv, tsv, ltsv, json, jsonl") {
+		t.Errorf("error should list the values that exist, got: %v", err)
+	}
+}

--- a/config/errors.go
+++ b/config/errors.go
@@ -46,6 +46,7 @@ var (
 	errEmptyQuery       = errors.New("--sql requires a non-empty SQL statement")
 	errEmptyOutput      = errors.New("--output requires a non-empty destination path")
 	errEmptySQLFile     = errors.New("--sql-file requires a non-empty file path")
+	errEmptyScriptFile  = errors.New("--script-file requires a non-empty file path")
 	errEmptyStdinFormat = errors.New("--stdin-format requires a non-empty format: csv, tsv, ltsv, json, or jsonl")
 )
 

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -5,10 +5,11 @@ and Fedwire files (test-version)
   sqly [OPTIONS] [FILE|DIRECTORY|URL ...]
 
   Each input is loaded into an in-memory SQLite database as a table named
-  after the file. With --sql or --sql-file, sqly runs the query and exits;
-  with neither, it opens an interactive shell, or runs SQL piped into it.
-  sqly has no subcommands. Dot-commands run inside the shell, including
-  .save, which writes changed tables back to their files.
+  after the file. With --sql, --sql-file, or --script-file, sqly runs the
+  work and exits; with none of them, it opens an interactive shell, or runs
+  a script piped into it. sqly has no subcommands. Dot-commands run inside
+  the shell, in a piped script, and in a --script-file — including .save,
+  which writes changed tables back to their files.
 
 [Examples]
   - open the shell with a file loaded

--- a/config/testdata/usage.golden
+++ b/config/testdata/usage.golden
@@ -42,9 +42,12 @@ and Fedwire files (test-version)
   Query:
     -s, --sql SQL               run one SQL statement, then exit
     -f, --sql-file FILE         run every SQL statement in this file, then exit;
-                                a dot-command is rejected, so pipe such a script
-                                in instead; printing several results needs
+                                a dot-command is rejected, so use --script-file
+                                for those; printing several results needs
                                 --output-format table, vertical, or markdown
+        --script-file FILE      run this sqly script, then exit: SQL statements
+                                and dot-commands, exactly as when piped in; use
+                                it to script .save and .import from a file
         --dialect NAME          write the query in one of: sqlite, mysql,
                                 postgresql, googlesql; sqly translates it to
                                 SQLite (default: sqlite)

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -661,12 +661,20 @@ func TestFlags_EveryOneIsDocumentedInTheReference(t *testing.T) {
 	}
 	body := string(data)
 
+	// The names the page documents, as whole words. A prefix test would let
+	// `--sql-file` stand in for `--sql`, so a flag could go undocumented and the
+	// test would still pass.
+	documented := make(map[string]bool)
+	for _, m := range regexp.MustCompile("`--([a-z][a-z0-9-]*)").FindAllStringSubmatch(body, -1) {
+		documented[m[1]] = true
+	}
+
 	flags := definedFlags(t)
 	if len(flags) < 10 {
 		t.Fatalf("only %d flags found; the extractor or the parser changed", len(flags))
 	}
 	for _, name := range flags {
-		if !strings.Contains(body, "`--"+name) {
+		if !documented[name] {
 			t.Errorf("--%s is a real flag that %s does not document", name, page)
 		}
 	}
@@ -682,9 +690,9 @@ func TestFlags_EveryOneIsDocumentedInTheReference(t *testing.T) {
 	for _, name := range flags {
 		defined[name] = true
 	}
-	for _, m := range regexp.MustCompile("`--([a-z][a-z0-9-]*)").FindAllStringSubmatch(body, -1) {
-		if !defined[m[1]] && !dotCommandOptions[m[1]] {
-			t.Errorf("%s documents --%s, which the parser does not define", page, m[1])
+	for name := range documented {
+		if !defined[name] && !dotCommandOptions[name] {
+			t.Errorf("%s documents --%s, which the parser does not define", page, name)
 		}
 	}
 }

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -641,3 +641,87 @@ func TestExitCodes_DocumentedTableMatchesTheConstants(t *testing.T) {
 		}
 	}
 }
+
+// TestFlags_EveryOneIsDocumentedInTheReference derives the flag list from the
+// parser instead of trusting any document to keep its own copy. A flag that
+// exists and is documented nowhere is one nobody can find; a flag documented
+// after it has been removed sends a reader to write a command that fails.
+//
+// The reference is the page that promises to list every flag, so it is the one
+// checked. The README deliberately does not enumerate them — it used to say
+// "Twelve flags" while there were thirteen, which is exactly the drift a
+// hand-maintained count produces.
+func TestFlags_EveryOneIsDocumentedInTheReference(t *testing.T) {
+	t.Parallel()
+
+	const page = "website/content/reference.md"
+	data, err := os.ReadFile(page)
+	if err != nil {
+		t.Fatalf("read %s: %v", page, err)
+	}
+	body := string(data)
+
+	flags := definedFlags(t)
+	if len(flags) < 10 {
+		t.Fatalf("only %d flags found; the extractor or the parser changed", len(flags))
+	}
+	for _, name := range flags {
+		if !strings.Contains(body, "`--"+name) {
+			t.Errorf("--%s is a real flag that %s does not document", name, page)
+		}
+	}
+
+	// And the reverse: a long flag the page mentions must still exist. The
+	// exceptions are the options of dot-commands, which are the shell's language
+	// rather than the CLI's and so are not in the FlagSet at all.
+	dotCommandOptions := map[string]bool{
+		"in-place":        true, // .save --in-place
+		"follow-symlinks": true, // .save --in-place --follow-symlinks
+	}
+	defined := make(map[string]bool, len(flags))
+	for _, name := range flags {
+		defined[name] = true
+	}
+	for _, m := range regexp.MustCompile("`--([a-z][a-z0-9-]*)").FindAllStringSubmatch(body, -1) {
+		if !defined[m[1]] && !dotCommandOptions[m[1]] {
+			t.Errorf("%s documents --%s, which the parser does not define", page, m[1])
+		}
+	}
+}
+
+// TestREADME_DoesNotHandCountTheFlags keeps the count from coming back. A number
+// spelled out in prose has no way to notice a flag being added.
+func TestREADME_DoesNotHandCountTheFlags(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	counted := regexp.MustCompile(`(?i)\b(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|\d+)\s+flags\b`)
+	if m := counted.FindString(string(data)); m != "" {
+		t.Errorf("README.md states a flag count (%q); the number goes stale the next time a flag is added. Describe the groups instead.", m)
+	}
+}
+
+// definedFlags returns every long flag name the parser defines, read from the
+// usage the parser itself renders. Going through the real output is what makes
+// this a check on sqly rather than on a second list kept beside it.
+func definedFlags(t *testing.T) []string {
+	t.Helper()
+
+	arg, err := config.NewArg([]string{"sqly"})
+	if err != nil {
+		t.Fatalf("build the usage: %v", err)
+	}
+	seen := make(map[string]bool)
+	var names []string
+	for _, m := range regexp.MustCompile(`--([a-z][a-z0-9-]*)`).FindAllStringSubmatch(arg.Usage, -1) {
+		if seen[m[1]] {
+			continue
+		}
+		seen[m[1]] = true
+		names = append(names, m[1])
+	}
+	return names
+}

--- a/e2e/atago/capability_matrix.atago.yaml
+++ b/e2e/atago/capability_matrix.atago.yaml
@@ -1,0 +1,153 @@
+# The capability matrix on website/content/formats.md claims a specific thing
+# about each format: whether it can come from stdin, whether it can be written
+# back, whether a compressed form reads. Those are the claims a reader plans
+# around, and the ones that go stale silently — a doc table has no way to notice
+# that a format gained or lost an ability.
+#
+# One scenario per claim that is a boundary. The "yes" cases for CSV are already
+# covered thoroughly elsewhere; what is here is each "no", because a refusal that
+# quietly becomes an acceptance (or the reverse) is what makes the table wrong.
+#
+# Run with: make test-e2e
+version: "1"
+
+suite:
+  name: sqly format capability matrix
+
+scenarios:
+  # stdin: only the five text formats. The others have no filename to name the
+  # table after, and are binary or multi-table besides.
+  - name: refuses a stdin dataset in a format that cannot be piped
+    steps:
+      - run:
+          command: sqly --stdin-format parquet --sql "SELECT 1"
+          stdin: "ignored"
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "want csv, tsv, ltsv, json, jsonl"
+
+  # Write back: JSON and JSONL cannot. The document lives whole in one column,
+  # so there is nothing to reconstruct the file from.
+  - name: refuses to write a json source back
+    steps:
+      - fixture:
+          file: rows.json
+          content: |
+            {"a": 1}
+      - run:
+          command: sqly rows.json
+          stdin: "UPDATE rows SET data = '{\"a\": 2}';\n.save --in-place\n"
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "write-back to rows.json is not supported"
+
+  - name: refuses to write an excel source back
+    steps:
+      - fixture:
+          file: book.xlsx
+          from: testdata/sample.xlsx
+      - run:
+          command: sqly book.xlsx
+          stdin: "UPDATE book_test_sheet SET name = 'x';\n.save --in-place\n"
+      - assert:
+          exit_code: 4
+
+  # Write back: CSV, TSV, LTSV, and Parquet can, and compression is preserved.
+  - name: writes a compressed csv source back in the same compression
+    steps:
+      - fixture:
+          file: t.csv
+          content: |
+            a,b
+            1,2
+      - run:
+          command: sh -c 'gzip t.csv && printf "UPDATE t SET b = 9;\n.save --in-place\n" | sqly t.csv.gz && gzip -dc t.csv.gz'
+          shell: true
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "9"
+
+  - name: writes a parquet source back
+    steps:
+      - fixture:
+          file: t.csv
+          content: |
+            a,b
+            1,2
+      - run:
+          command: sqly --output-format parquet --output t.parquet --sql "SELECT * FROM t" t.csv
+      - assert:
+          exit_code: 0
+      - run:
+          command: sqly t.parquet
+          stdin: "UPDATE t SET b = 9;\n.save --in-place\n"
+      - assert:
+          exit_code: 0
+      - run:
+          command: sqly --output-format csv --sql "SELECT b FROM t" t.parquet
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: "9"
+
+  # Compressed Parquet reads but cannot be written back: Parquet already
+  # compresses internally, and .save will not produce a doubly compressed file.
+  - name: reads a compressed parquet source but refuses to write it back
+    steps:
+      - fixture:
+          file: t.csv
+          content: |
+            a,b
+            1,2
+      - run:
+          command: sh -c 'sqly --output-format parquet --output t.parquet --sql "SELECT * FROM t" t.csv && gzip t.parquet && sqly --output-format csv --sql "SELECT b FROM t" t.parquet.gz'
+          shell: true
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: "2"
+      - run:
+          command: sqly t.parquet.gz
+          stdin: "UPDATE t SET b = 9;\n.save --in-place\n"
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "not supported"
+
+  # A bzip2 source cannot be written back at all: there is no bzip2 writer, and
+  # the refusal comes before anything is touched.
+  - name: refuses a bzip2 source before touching it
+    steps:
+      - fixture:
+          file: t.csv
+          content: |
+            a,b
+            1,2
+      - run:
+          command: sh -c 'bzip2 t.csv && printf "UPDATE t SET b = 9;\n.save --in-place\n" | sqly t.csv.bz2'
+          shell: true
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "not supported"
+
+  # Binary result formats have no on-screen form and say so rather than printing
+  # something else.
+  - name: refuses a binary result format with nowhere to write it
+    steps:
+      - fixture:
+          file: t.csv
+          content: |
+            a,b
+            1,2
+      - run:
+          command: sqly --output-format excel --sql "SELECT * FROM t" t.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "--output"

--- a/e2e/atago/capability_matrix.atago.yaml
+++ b/e2e/atago/capability_matrix.atago.yaml
@@ -56,6 +56,10 @@ scenarios:
 
   # Write back: CSV, TSV, LTSV, and Parquet can, and compression is preserved.
   - name: writes a compressed csv source back in the same compression
+    # Needs gzip(1)/bzip2(1) and a POSIX shell; the compression handling
+    # itself is not platform-specific and is covered by the Go tests.
+    skip:
+      os: windows
     steps:
       - fixture:
           file: t.csv
@@ -97,6 +101,10 @@ scenarios:
   # Compressed Parquet reads but cannot be written back: Parquet already
   # compresses internally, and .save will not produce a doubly compressed file.
   - name: reads a compressed parquet source but refuses to write it back
+    # Needs gzip(1)/bzip2(1) and a POSIX shell; the compression handling
+    # itself is not platform-specific and is covered by the Go tests.
+    skip:
+      os: windows
     steps:
       - fixture:
           file: t.csv
@@ -122,6 +130,10 @@ scenarios:
   # A bzip2 source cannot be written back at all: there is no bzip2 writer, and
   # the refusal comes before anything is touched.
   - name: refuses a bzip2 source before touching it
+    # Needs gzip(1)/bzip2(1) and a POSIX shell; the compression handling
+    # itself is not platform-specific and is covered by the Go tests.
+    skip:
+      os: windows
     steps:
       - fixture:
           file: t.csv

--- a/e2e/atago/exit_codes.atago.yaml
+++ b/e2e/atago/exit_codes.atago.yaml
@@ -240,6 +240,13 @@ scenarios:
   # runner's capture pipes open. Backgrounding a subshell that keeps them was
   # enough to error these scenarios on macOS while passing on Linux.
   #
+  # The marker says the FIFO has a reader, and the reader is the shell setting up
+  # the redirection — which happens before it execs sqly. So the marker is a
+  # lower bound, not the moment sqly is ready, and a signal sent on it can arrive
+  # before the handler is installed and be lost. A settle follows it for that
+  # reason. It is not the thing being measured: the elapsed-time assertion below
+  # starts at the signal, so a slow settle cannot make a broken run look prompt.
+  #
   # Second, the exit status alone proves nothing here, for two reasons. A process
   # killed by the default SIGINT handler is also reported as 130 by the shell —
   # so stderr is asserted, and a process killed outright never gets to write it.
@@ -259,7 +266,7 @@ scenarios:
             id
             1
       - run:
-          command: sh -c 'mkfifo pipe; (exec 3> pipe; touch writer-ready; exec sleep 30) >/dev/null 2>&1 & holder=$!; sqly rows.csv < pipe > /dev/null 2> err.log & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; start=$(date +%s); kill -INT $child; wait $child; code=$?; elapsed=$(( $(date +%s) - start )); kill $holder 2>/dev/null; wait $holder 2>/dev/null; echo "exit=$code"; [ "$elapsed" -le 5 ] && echo prompt || echo "slow after ${elapsed}s"'
+          command: sh -c 'mkfifo pipe; (exec 3> pipe; touch writer-ready; exec sleep 30) >/dev/null 2>&1 & holder=$!; sqly rows.csv < pipe > /dev/null 2> err.log & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; sleep 2; start=$(date +%s); kill -INT $child; wait $child; code=$?; elapsed=$(( $(date +%s) - start )); kill $holder 2>/dev/null; wait $holder 2>/dev/null; echo "exit=$code"; [ "$elapsed" -le 5 ] && echo prompt || echo "slow after ${elapsed}s"'
           shell: true
       - assert:
           exit_code: 0
@@ -287,7 +294,7 @@ scenarios:
           # run created. The staging directory is made before the read blocks, so
           # by the time the signal arrives there is something to clean up: a
           # process killed outright would leave it behind.
-          command: sh -c 'mkdir -p tmp; export TMPDIR="$PWD/tmp"; mkfifo pipe; (exec 3> pipe; touch writer-ready; exec sleep 30) >/dev/null 2>&1 & holder=$!; sqly --stdin-format csv --sql "SELECT 1" < pipe > /dev/null 2>/dev/null & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; kill -INT $child; wait $child; kill $holder 2>/dev/null; wait $holder 2>/dev/null; ls tmp | grep -c sqly- || echo 0'
+          command: sh -c 'mkdir -p tmp; export TMPDIR="$PWD/tmp"; mkfifo pipe; (exec 3> pipe; touch writer-ready; exec sleep 30) >/dev/null 2>&1 & holder=$!; sqly --stdin-format csv --sql "SELECT 1" < pipe > /dev/null 2>/dev/null & child=$!; i=0; until [ -f writer-ready ]; do i=$((i+1)); [ $i -ge 100 ] && { echo "sqly never opened the FIFO" >&2; exit 1; }; sleep 0.1; done; sleep 2; kill -INT $child; wait $child; kill $holder 2>/dev/null; wait $holder 2>/dev/null; ls tmp | grep -c sqly- || echo 0'
           shell: true
       - assert:
           exit_code: 0

--- a/e2e/atago/script_file.atago.yaml
+++ b/e2e/atago/script_file.atago.yaml
@@ -1,0 +1,176 @@
+# --script-file is the entry point for a sqly script kept in a file: SQL
+# statements and dot-commands, exactly what a pipe carries. --sql-file stays SQL
+# only, and the boundary between them is the contract these scenarios pin.
+#
+# The pair matters because before --script-file existed, moving a working piped
+# script into a file made it stop working — --sql-file rejected the dot-commands
+# and there was nowhere else to put them.
+#
+# Run with: make test-e2e
+version: "1"
+
+suite:
+  name: sqly --script-file
+
+scenarios:
+  - name: runs dot-commands and SQL from one file
+    steps:
+      - fixture:
+          file: t.csv
+          content: |
+            a,b
+            1,2
+      - fixture:
+          file: s.sqly
+          content: |
+            UPDATE t SET b = 9;
+            .save --in-place
+      - run:
+          command: sqly --script-file s.sqly t.csv
+      - assert:
+          exit_code: 0
+          file:
+            path: t.csv
+            contains: "9"
+
+  - name: gives the same result as the same script piped in
+    steps:
+      - fixture: &rows
+          file: t.csv
+          content: |
+            a,b
+            1,2
+      - fixture:
+          file: s.sqly
+          content: |
+            .mode csv
+            SELECT b FROM t;
+      - run:
+          command: sqly --script-file s.sqly t.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: "2"
+      - run:
+          command: sh -c 'printf ".mode csv\nSELECT b FROM t;\n" | sqly t.csv'
+          shell: true
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: "2"
+
+  - name: still refuses a dot-command in a --sql-file and names the new flag
+    steps:
+      - fixture: *rows
+      - fixture:
+          file: q.sql
+          content: |
+            SELECT 1;
+            .save --in-place
+      - run:
+          command: sqly --sql-file q.sql t.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "--script-file"
+          file:
+            path: t.csv
+            not_contains: "9"
+
+  - name: rejects a second source for the work to run
+    steps:
+      - fixture: *rows
+      - fixture:
+          file: s.sqly
+          content: |
+            SELECT 1;
+      - run:
+          command: sqly --script-file s.sqly --sql "SELECT 1" t.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "cannot be used together"
+
+  - name: points at .dump when --output is given
+    steps:
+      - fixture: *rows
+      - fixture:
+          file: s.sqly
+          content: |
+            SELECT 1;
+      - run:
+          command: sqly --script-file s.sqly --output out.csv t.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: ".dump"
+          file:
+            path: out.csv
+            exists: false
+
+  - name: leaves stdin free for a piped dataset
+    steps:
+      - fixture:
+          file: s.sqly
+          content: |
+            .mode csv
+            SELECT COUNT(*) AS n FROM stdin;
+      - run:
+          command: sqly --stdin-format csv --script-file s.sqly
+          stdin: |
+            a,b
+            1,2
+            3,4
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: "2"
+
+  - name: rejects an empty script rather than exiting 0 having done nothing
+    steps:
+      - fixture: *rows
+      - fixture:
+          file: empty.sqly
+          content: "   \n"
+      - run:
+          command: sqly --script-file empty.sqly t.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "is empty"
+
+  - name: reports a missing script as an input error
+    steps:
+      - fixture: *rows
+      - run:
+          command: sqly --script-file nope.sqly t.csv
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "--script-file"
+
+  - name: stops at the failing statement and reports its line
+    steps:
+      - fixture: *rows
+      - fixture:
+          file: s.sqly
+          content: |
+            SELECT 1;
+            SELECT * FROM no_such_table;
+            .save --in-place
+      - run:
+          command: sqly --script-file s.sqly t.csv
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "line 2"
+      - assert:
+          # The .save after the failure never ran, so the source is untouched.
+          file:
+            path: t.csv
+            equals: |
+              a,b
+              1,2

--- a/e2e/atago/script_file.atago.yaml
+++ b/e2e/atago/script_file.atago.yaml
@@ -34,6 +34,11 @@ scenarios:
             contains: "9"
 
   - name: gives the same result as the same script piped in
+    # The second half pipes through `sh -c`, which Windows quotes differently;
+    # the equivalence itself is not platform-specific and is asserted
+    # deterministically by shell.TestScriptFile_IsTheSameTextAPipeWouldRun.
+    skip:
+      os: windows
     steps:
       - fixture: &rows
           file: t.csv

--- a/e2e/atago/stdin_dataset.atago.yaml
+++ b/e2e/atago/stdin_dataset.atago.yaml
@@ -153,6 +153,8 @@ scenarios:
             path: escaped.csv
             exists: false
 
+  # A flag value, so it is rejected while parsing like every other enum flag:
+  # before stdin is read, as a usage error naming the values that exist.
   - name: reports a clear error for an unsupported stdin format
     steps:
       - run:
@@ -161,7 +163,7 @@ scenarios:
             a,b
             1,2
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "unsupported --stdin-format value"
 

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -553,6 +553,24 @@ func withMainVerb(stmt string) string {
 // error for a missing or unreadable file (wrapping the OS error so callers can
 // inspect it with errors.Is) and rejects a file with no SQL, so an empty or
 // whitespace-only script fails loudly instead of running nothing.
+// readScriptFile reads a --script-file. It is the sibling of readSQLFile and
+// differs in what counts as empty: a script whose only content is dot-commands
+// has no SQL statement and is perfectly valid, so the "no executable SQL" check
+// does not apply here. A file with nothing in it at all is still rejected, for
+// the same reason as a --sql-file: a run that does nothing and exits 0 is
+// indistinguishable from one that worked.
+func readScriptFile(path string) (string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is the user-specified --script-file
+	if err != nil {
+		return "", &scriptSourceError{Err: fmt.Errorf("failed to read --script-file %q: %w", path, err)}
+	}
+	content := strings.TrimPrefix(string(data), "\ufeff")
+	if strings.TrimSpace(content) == "" {
+		return "", &scriptError{Err: fmt.Errorf("--script-file %q is empty", path)}
+	}
+	return content, nil
+}
+
 func readSQLFile(path string) (string, error) {
 	// The two kinds of failure below are told apart deliberately. A path that
 	// cannot be read is a problem with the file, like any other input; a file that

--- a/shell/runmode.go
+++ b/shell/runmode.go
@@ -26,6 +26,7 @@ import (
 const (
 	flagSQL      = "--sql"
 	flagSQLFile  = "--sql-file"
+	flagScript   = "--script-file"
 	flagInspect  = "--inspect"
 	devStdinPath = "/dev/stdin"
 )
@@ -43,6 +44,9 @@ const (
 	modeInlineSQL
 	// modeSQLFile runs the statements in a --sql-file. SQL only.
 	modeSQLFile
+	// modeScriptFile runs a --script-file: the shell's own language, SQL
+	// statements and dot-commands alike, from a file instead of a pipe.
+	modeScriptFile
 	// modeInspect prints the JSON report and exits.
 	modeInspect
 )
@@ -58,6 +62,8 @@ func (m runMode) String() string {
 		return flagSQL
 	case modeSQLFile:
 		return flagSQLFile
+	case modeScriptFile:
+		return flagScript
 	case modeInspect:
 		return flagInspect
 	default:
@@ -69,8 +75,10 @@ func (m runMode) String() string {
 // commands. A script typed at the prompt or piped in is the shell's own
 // language, so it may; a file named by --sql-file is a SQL file, and the flag
 // says so.
+// A --script-file is the same language, chosen deliberately by a flag that says
+// script rather than sql, so it may too.
 func (m runMode) allowsHelperCommands() bool {
-	return m == modeInteractiveShell || m == modeStdinScript
+	return m == modeInteractiveShell || m == modeStdinScript || m == modeScriptFile
 }
 
 // runPlan is the decided shape of one invocation: the mode, and where stdin
@@ -89,10 +97,10 @@ func (s *Shell) planRun() (runPlan, error) {
 	arg := s.argument
 	stdinIsDataset := arg.StdinFormat != ""
 
-	// --sql and --sql-file both name the statements to run; two answers to one
-	// question is a mistake, not a merge.
-	if arg.Query != "" && arg.SQLFilePath != "" {
-		return runPlan{}, &invocationError{Err: errors.New("--sql and --sql-file cannot be used together")}
+	// --sql, --sql-file, and --script-file all name the work to run; two answers
+	// to one question is a mistake, not a merge.
+	if err := rejectConflictingQuerySources(arg.Query, arg.SQLFilePath, arg.ScriptFilePath); err != nil {
+		return runPlan{}, err
 	}
 
 	switch {
@@ -102,13 +110,15 @@ func (s *Shell) planRun() (runPlan, error) {
 		return s.planWithQuerySource(runPlan{mode: modeInlineSQL, stdinIsDataset: stdinIsDataset})
 	case arg.SQLFilePath != "":
 		return s.planWithQuerySource(runPlan{mode: modeSQLFile, stdinIsDataset: stdinIsDataset})
+	case arg.ScriptFilePath != "":
+		return s.planWithQuerySource(runPlan{mode: modeScriptFile, stdinIsDataset: stdinIsDataset})
 	}
 
 	// No query flag: the script comes from stdin, or from the prompt.
 	if stdinIsDataset {
 		// stdin is the data, so nothing is left to carry the statements.
 		return runPlan{}, &invocationError{Err: errors.New(
-			"--stdin-format takes stdin as data, so there is no script to run; add --sql, --sql-file, or --inspect")}
+			"--stdin-format takes stdin as data, so there is no script to run; add --sql, --sql-file, --script-file, or --inspect")}
 	}
 	if s.stdinKind() == stdinTerminal {
 		return runPlan{mode: modeInteractiveShell}, nil
@@ -168,6 +178,8 @@ func (m runMode) source() string {
 	switch m {
 	case modeSQLFile:
 		return "the statements in the file"
+	case modeScriptFile:
+		return "the script in the file"
 	case modeInspect:
 		return "the files named on the command line"
 	default:
@@ -242,4 +254,25 @@ func (s *Shell) probeStdin() stdinKind {
 		// Sockets, and anything a platform reports that does not fit above.
 		return stdinPipe
 	}
+}
+
+// rejectConflictingQuerySources refuses more than one source for the work to
+// run. Each pair is named explicitly so the message says which two flags
+// collided rather than listing all three at a user who typed two.
+func rejectConflictingQuerySources(query, sqlFile, scriptFile string) error {
+	given := make([]string, 0, 3)
+	if query != "" {
+		given = append(given, flagSQL)
+	}
+	if sqlFile != "" {
+		given = append(given, flagSQLFile)
+	}
+	if scriptFile != "" {
+		given = append(given, flagScript)
+	}
+	if len(given) < 2 {
+		return nil
+	}
+	return &invocationError{Err: fmt.Errorf("%s and %s cannot be used together; each names the work to run, and sqly runs one",
+		given[0], given[1])}
 }

--- a/shell/save_test.go
+++ b/shell/save_test.go
@@ -801,3 +801,36 @@ func TestRollbackCommitted(t *testing.T) {
 		t.Errorf("a destination this save created must be removed again, stat err = %v", err)
 	}
 }
+
+// runWithArgs runs a full invocation from its command line, with stdin closed.
+// runScriptStreams covers the piped case; this covers the flags that read their
+// work from somewhere else, where what is being tested is the invocation itself.
+func runWithArgs(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	shell, cleanup, newErr := newShell(t, append([]string{"sqly"}, args...))
+	if newErr != nil {
+		t.Fatalf("newShell: %v", newErr)
+	}
+	defer cleanup()
+	shell.isTTY = func() bool { return false }
+	shell.stdin = strings.NewReader("")
+
+	stdout, stderr = captureStreams(t, func() error {
+		err = shell.Run(context.Background())
+		return err
+	})
+	return stdout, stderr, err
+}
+
+// captureStreams redirects config.Stdout and config.Stderr for the duration of
+// fn and returns what was written to each. They are process-wide, so a test
+// using it cannot run in parallel.
+func captureStreams(t *testing.T, fn func() error) (stdout, stderr string) {
+	t.Helper()
+	backupOut, backupErr := config.Stdout, config.Stderr
+	var out, errOut strings.Builder
+	config.Stdout, config.Stderr = &out, &errOut
+	defer func() { config.Stdout, config.Stderr = backupOut, backupErr }()
+	_ = fn()
+	return out.String(), errOut.String()
+}

--- a/shell/scriptfile_test.go
+++ b/shell/scriptfile_test.go
@@ -1,0 +1,201 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `--sql-file` holds SQL and rejects a dot-command by name and line. That is the
+// right rule for a flag that says `sql`, and it left a gap: the only way to run
+// a script that mixes SQL and dot-commands was to pipe it in, so moving the very
+// same text into a file made it stop working for no reason a user could see.
+//
+// `--script-file` is that missing entry point. These tests pin the boundary
+// between the two flags, which is the part that has to stay stable: what each
+// one accepts, what it refuses, and that neither quietly becomes the other.
+//
+// None of them call t.Parallel: runScriptStreams swaps config.Stdout and
+// config.Stderr, which are process-wide.
+
+func TestScriptFile_RunsDotCommandsAndSQL(t *testing.T) {
+	dir := t.TempDir()
+	src := writeCSV(t, dir, "t.csv", "a,b\n1,2\n")
+	script := filepath.Join(dir, "s.sqly")
+	writeScript(t, script, "UPDATE t SET b = 9;\n.save --in-place\n")
+
+	_, stderr, err := runWithArgs(t, "--script-file", script, src)
+	if err != nil {
+		t.Fatalf("--script-file with a dot-command failed: %v (%s)", err, stderr)
+	}
+	if got := readFile(t, src); !strings.Contains(got, "9") {
+		t.Errorf(".save --in-place did not persist: %q", got)
+	}
+}
+
+// TestScriptFile_IsTheSameTextAPipeWouldRun is the point of the flag: a script
+// that works piped in must work from a file unchanged. If the two ever diverge,
+// the flag has stopped being a way to keep a script in version control.
+func TestScriptFile_IsTheSameTextAPipeWouldRun(t *testing.T) {
+	const script = ".mode csv\nSELECT b FROM t;\n"
+
+	pipedDir := t.TempDir()
+	pipedSrc := writeCSV(t, pipedDir, "t.csv", "a,b\n1,2\n")
+	piped, _, err := runScriptStreams(t, script, pipedSrc)
+	if err != nil {
+		t.Fatalf("piped script: %v", err)
+	}
+
+	fileDir := t.TempDir()
+	fileSrc := writeCSV(t, fileDir, "t.csv", "a,b\n1,2\n")
+	path := filepath.Join(fileDir, "s.sqly")
+	writeScript(t, path, script)
+	fromFile, _, err := runWithArgs(t, "--script-file", path, fileSrc)
+	if err != nil {
+		t.Fatalf("--script-file: %v", err)
+	}
+
+	if piped != fromFile {
+		t.Errorf("the same script gave different output:\n piped: %q\n  file: %q", piped, fromFile)
+	}
+}
+
+// TestSQLFile_StillRejectsADotCommand keeps the boundary from eroding. Adding
+// --script-file must not relax --sql-file: the flag says SQL, and a .sql file
+// that silently ran .save would be a shell script wearing a SQL extension.
+func TestSQLFile_StillRejectsADotCommand(t *testing.T) {
+	dir := t.TempDir()
+	src := writeCSV(t, dir, "t.csv", "a,b\n1,2\n")
+	path := filepath.Join(dir, "q.sql")
+	writeScript(t, path, "SELECT 1;\n.save --in-place\n")
+
+	_, _, err := runWithArgs(t, "--sql-file", path, src)
+	if err == nil {
+		t.Fatal("--sql-file accepted a dot-command")
+	}
+	if !strings.Contains(err.Error(), "--script-file") {
+		t.Errorf("the refusal should point at --script-file, got: %v", err)
+	}
+}
+
+func TestScriptFile_ConflictsWithTheOtherQuerySources(t *testing.T) {
+	dir := t.TempDir()
+	src := writeCSV(t, dir, "t.csv", "a,b\n1,2\n")
+	script := filepath.Join(dir, "s.sqly")
+	writeScript(t, script, "SELECT 1;\n")
+	sqlFile := filepath.Join(dir, "q.sql")
+	writeScript(t, sqlFile, "SELECT 1;\n")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "with --sql", args: []string{"--script-file", script, "--sql", "SELECT 1"}},
+		{name: "with --sql-file", args: []string{"--script-file", script, "--sql-file", sqlFile}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := runWithArgs(t, append(tt.args, src)...)
+			if err == nil {
+				t.Fatal("two sources for the work to run were accepted")
+			}
+			if !strings.Contains(err.Error(), "cannot be used together") {
+				t.Errorf("the error should say the flags collide, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestScriptFile_RejectsOutput scopes the flag. A script writes files with
+// .dump, at the point in the script where the destination means something; one
+// --output for a whole script would have to pick one of its results and nothing
+// says which.
+func TestScriptFile_RejectsOutput(t *testing.T) {
+	dir := t.TempDir()
+	src := writeCSV(t, dir, "t.csv", "a,b\n1,2\n")
+	script := filepath.Join(dir, "s.sqly")
+	writeScript(t, script, "SELECT 1;\n")
+
+	_, _, err := runWithArgs(t, "--script-file", script, "--output", filepath.Join(dir, "out.csv"), src)
+	if err == nil {
+		t.Fatal("--output was accepted with --script-file")
+	}
+	if !strings.Contains(err.Error(), ".dump") {
+		t.Errorf("the error should point at .dump, got: %v", err)
+	}
+}
+
+func TestScriptFile_RejectsAnEmptyOrMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	src := writeCSV(t, dir, "t.csv", "a,b\n1,2\n")
+	empty := filepath.Join(dir, "empty.sqly")
+	writeScript(t, empty, "\n   \n")
+
+	t.Run("an empty script is rejected rather than exiting 0 having done nothing", func(t *testing.T) {
+		_, stderr, err := runWithArgs(t, "--script-file", empty, src)
+		if err == nil {
+			t.Fatal("an empty --script-file was accepted")
+		}
+		if got := ExitCode(err); got != ExitUsage {
+			t.Errorf("ExitCode = %d, want %d (%s)", got, ExitUsage, stderr)
+		}
+	})
+
+	t.Run("a missing script is an input error", func(t *testing.T) {
+		_, _, err := runWithArgs(t, "--script-file", filepath.Join(dir, "nope.sqly"), src)
+		if err == nil {
+			t.Fatal("a missing --script-file was accepted")
+		}
+		if got := ExitCode(err); got != ExitInput {
+			t.Errorf("ExitCode = %d, want %d", got, ExitInput)
+		}
+	})
+}
+
+// TestScriptFile_AcceptsADotCommandOnlyScript is the case that separates
+// readScriptFile from readSQLFile: a script whose whole content is dot-commands
+// has no SQL statement in it and is perfectly valid.
+func TestScriptFile_AcceptsADotCommandOnlyScript(t *testing.T) {
+	dir := t.TempDir()
+	src := writeCSV(t, dir, "t.csv", "a,b\n1,2\n")
+	script := filepath.Join(dir, "s.sqly")
+	writeScript(t, script, ".tables\n")
+
+	stdout, stderr, err := runWithArgs(t, "--script-file", script, src)
+	if err != nil {
+		t.Fatalf("a dot-command-only script failed: %v (%s)", err, stderr)
+	}
+	if !strings.Contains(stdout+stderr, "t") {
+		t.Errorf(".tables produced no output: %q / %q", stdout, stderr)
+	}
+}
+
+// TestScriptFile_FreesStdinForADataset is the reason --sql-file exists at all,
+// and it must hold here too: the script comes from the file, so a piped dataset
+// still has stdin to itself.
+func TestScriptFile_FreesStdinForADataset(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "s.sqly")
+	writeScript(t, script, ".mode csv\nSELECT COUNT(*) AS n FROM stdin;\n")
+
+	s, cleanup, err := newShell(t, []string{"sqly", "--stdin-format", "csv", "--script-file", script})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	s.isTTY = func() bool { return false }
+	s.stdin = strings.NewReader("a,b\n1,2\n3,4\n")
+
+	stdout, stderr := captureStreams(t, func() error { return s.Run(t.Context()) })
+	if !strings.Contains(stdout, "2") {
+		t.Errorf("the piped dataset was not queried: %q / %q", stdout, stderr)
+	}
+}
+
+func writeScript(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -251,6 +251,13 @@ func (s *Shell) Run(ctx context.Context) error {
 	// --output is honored by --sql (a single result) and --sql-file (the script's
 	// one result set). Without either (batch stdin or interactive) the flag was
 	// silently ignored, so reject it instead of looking successful.
+	if s.argument.Output.FilePath != "" && s.argument.ScriptFilePath != "" {
+		// A script already has a way to write a file, and it is per-result rather
+		// than per-run: .dump names the table and the destination at the point in
+		// the script where it means something. One --output for a whole script
+		// would have to pick one of its results, and nothing says which.
+		return &invocationError{Err: errors.New("--output does not apply to --script-file; write from inside the script with .dump TABLE FILE")}
+	}
 	if s.argument.Output.FilePath != "" && s.argument.Query == "" && s.argument.SQLFilePath == "" {
 		return &invocationError{Err: errors.New("--output requires --sql or --sql-file")}
 	}
@@ -333,7 +340,7 @@ func (s *Shell) Run(ctx context.Context) error {
 		}
 		return s.finishNonInteractive(ctx)
 
-	case modeStdinScript:
+	case modeStdinScript, modeScriptFile:
 		if err := s.prepareForScript(ctx, elements); err != nil {
 			return err
 		}
@@ -343,7 +350,9 @@ func (s *Shell) Run(ctx context.Context) error {
 		}
 		// A non-interactive run that executed nothing — empty or comment-only
 		// stdin — is a silent no-op that still exits 0, so headless wrappers and CI
-		// mistake it for a completed query. Surface a hint and fail instead.
+		// mistake it for a completed query. Surface a hint and fail instead. A
+		// --script-file with nothing in it was already rejected when it was read,
+		// which is why only the stdin case needs the hint.
 		if !ranAny {
 			return &invocationError{Err: errNoStatements}
 		}
@@ -378,6 +387,12 @@ func (s *Shell) loadScript(ctx context.Context) ([]scriptElement, error) {
 			return nil, err
 		}
 		script, origin = loaded, s.argument.SQLFilePath
+	case modeScriptFile:
+		loaded, err := readScriptFile(s.argument.ScriptFilePath)
+		if err != nil {
+			return nil, err
+		}
+		script, origin = loaded, s.argument.ScriptFilePath
 	case modeStdinScript:
 		data, err := readAllContext(ctx, s.stdin)
 		if err != nil {
@@ -400,7 +415,7 @@ func (s *Shell) loadScript(ctx context.Context) ([]scriptElement, error) {
 	if !s.plan.mode.allowsHelperCommands() {
 		if helper, found := firstHelper(elements); found {
 			return nil, &scriptError{Err: fmt.Errorf(
-				"%s runs SQL only, but line %d is the helper command %q; pipe the script to sqly instead: printf '...' | sqly FILE",
+				"%s runs SQL only, but line %d is the helper command %q; run it with --script-file, or pipe it to sqly",
 				origin, helper.startLine, helper.commandName())}
 		}
 	}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -2728,21 +2728,21 @@ func TestShellRun_StdinDataset(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid stdin format returns a clear error", func(t *testing.T) {
-		shell, cleanup, err := newShell(t, []string{"sqly", "--stdin-format", "xml", "--sql", "SELECT 1"})
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer cleanup()
-		shell.isTTY = func() bool { return false }
-		shell.stdin = strings.NewReader("a,b\n1,2\n")
-
-		err = shell.Run(context.Background())
+	// An unsupported --stdin-format is a flag value, so it is rejected where the
+	// other enum flags are: while parsing, before anything is read. It used to
+	// surface only when stdin was staged, which made a typo look like a runtime
+	// failure rather than a bad command line.
+	t.Run("an invalid stdin format is rejected while parsing, not when stdin is staged", func(t *testing.T) {
+		_, _, err := newShell(t, []string{"sqly", "--stdin-format", "xml", "--sql", "SELECT 1"})
 		if err == nil {
-			t.Fatal("invalid --stdin-format value returned nil error, want error")
+			t.Fatal("an invalid --stdin-format value was accepted")
 		}
-		if !strings.Contains(err.Error(), "stdin") {
-			t.Fatalf("error = %q, want it to mention stdin", err.Error())
+		if !strings.Contains(err.Error(), "--stdin-format") {
+			t.Fatalf("error = %q, want it to name the flag", err.Error())
+		}
+		var argErr *config.ArgError
+		if !errors.As(err, &argErr) {
+			t.Errorf("error is %T, want a *config.ArgError so it exits as a usage error", err)
 		}
 	})
 

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -42,9 +42,12 @@ and Fedwire files ((devel))
   Query:
     -s, --sql SQL               run one SQL statement, then exit
     -f, --sql-file FILE         run every SQL statement in this file, then exit;
-                                a dot-command is rejected, so pipe such a script
-                                in instead; printing several results needs
+                                a dot-command is rejected, so use --script-file
+                                for those; printing several results needs
                                 --output-format table, vertical, or markdown
+        --script-file FILE      run this sqly script, then exit: SQL statements
+                                and dot-commands, exactly as when piped in; use
+                                it to script .save and .import from a file
         --dialect NAME          write the query in one of: sqlite, mysql,
                                 postgresql, googlesql; sqly translates it to
                                 SQLite (default: sqlite)

--- a/shell/testdata/golden/help.golden
+++ b/shell/testdata/golden/help.golden
@@ -5,10 +5,11 @@ and Fedwire files ((devel))
   sqly [OPTIONS] [FILE|DIRECTORY|URL ...]
 
   Each input is loaded into an in-memory SQLite database as a table named
-  after the file. With --sql or --sql-file, sqly runs the query and exits;
-  with neither, it opens an interactive shell, or runs SQL piped into it.
-  sqly has no subcommands. Dot-commands run inside the shell, including
-  .save, which writes changed tables back to their files.
+  after the file. With --sql, --sql-file, or --script-file, sqly runs the
+  work and exits; with none of them, it opens an interactive shell, or runs
+  a script piped into it. sqly has no subcommands. Dot-commands run inside
+  the shell, in a piped script, and in a --script-file — including .save,
+  which writes changed tables back to their files.
 
 [Examples]
   - open the shell with a file loaded

--- a/website/content/formats.md
+++ b/website/content/formats.md
@@ -24,8 +24,9 @@ is the whole picture in one place — the sections below explain the entries.
 
 Reading the columns:
 
-- **stdin** — can be piped in with `--stdin-format`. The three that cannot are
-  binary or multi-table: there is no filename to name the tables after.
+- **stdin** — can be piped in with `--stdin-format`. The four that cannot
+  (Parquet, Excel, ACH, Fedwire) are binary or multi-table: there is no filename
+  to name the tables after.
 - **Compressed** — readable through `.gz`, `.bz2`, `.xz`, `.zst`, `.z`,
   `.snappy`, `.s2`, `.lz4`. ACH and Fedwire are not. A compressed Parquet file
   reads, but cannot be written back: Parquet already compresses internally, and

--- a/website/content/formats.md
+++ b/website/content/formats.md
@@ -4,6 +4,47 @@ description: Every file format sqly reads and writes, how each one becomes a tab
 weight: 50
 ---
 
+## What each format can do
+
+The formats are not interchangeable. Reading is nearly universal; writing back
+into the source file is not, and two of them are not even one table each. This
+is the whole picture in one place — the sections below explain the entries.
+
+| Format | Read | stdin | URL | Compressed | Tables per file | Query result | Write back | Types |
+|:--|:--|:--|:--|:--|:--|:--|:--|:--|
+| CSV | yes | yes | yes | yes | 1 | yes | yes | inferred |
+| TSV | yes | yes | yes | yes | 1 | yes | yes | inferred |
+| LTSV | yes | yes | yes | yes | 1 | yes | yes | inferred |
+| JSON | yes | yes | yes | yes | 1 (`data` column) | yes | no | document kept whole |
+| JSONL | yes | yes | yes | yes | 1 (`data` column) | yes | no | document kept whole |
+| Parquet | yes | no | yes | yes (read only) | 1 | yes (needs `--output`) | yes, uncompressed | from the schema |
+| Excel | yes | no | yes | yes | one per sheet | yes (needs `--output`) | no | inferred |
+| ACH | yes | no | yes | no | 4: `_file_header`, `_batches`, `_entries`, `_addenda` | yes | yes, as a set | fixed by the spec |
+| Fedwire | yes | no | yes | no | 1: `_message` | yes | yes, as a set | fixed by the spec |
+
+Reading the columns:
+
+- **stdin** — can be piped in with `--stdin-format`. The three that cannot are
+  binary or multi-table: there is no filename to name the tables after.
+- **Compressed** — readable through `.gz`, `.bz2`, `.xz`, `.zst`, `.z`,
+  `.snappy`, `.s2`, `.lz4`. ACH and Fedwire are not. A compressed Parquet file
+  reads, but cannot be written back: Parquet already compresses internally, and
+  `.save` will not produce a doubly compressed file.
+- **Query result** — can be produced by `--output-format`. Parquet and Excel are
+  binary and need `--output` to write to; they are never printed.
+- **Write back** — `.save` can rewrite the source. JSON and JSONL cannot,
+  because the whole document lives in one column and sqly cannot reconstruct
+  the file from it. Excel cannot, because several tables share the file. ACH and
+  Fedwire are rebuilt from their complete set of tables into one file.
+- **Types** — `inferred` means sqly reads the values and picks INTEGER, REAL, or
+  TEXT; a value that looks numeric but must stay text (a zero-padded code) stays
+  text. Parquet carries its own schema, and the financial formats have theirs
+  fixed by the specification.
+
+Compression is preserved by a write-back: a `.csv.gz` source is rewritten as
+`.csv.gz`. A `.bz2` source cannot be written back at all — there is no bzip2
+writer — and is refused before anything is touched.
+
 ## Read
 
 | Format | Extensions | Becomes |

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -57,12 +57,52 @@ option applies to the inputs it can and the run proceeds.
 | Flag | Does |
 |:--|:--|
 | `-s`, `--sql SQL` | run one statement, then exit |
-| `-f`, `--sql-file FILE` | run every SQL statement in a file, then exit; cannot combine with `--sql` |
+| `-f`, `--sql-file FILE` | run every SQL statement in a file, then exit |
+| `--script-file FILE` | run a sqly script from a file: SQL and dot-commands, then exit |
 | `--dialect NAME` | write the query in `sqlite` (default), `mysql`, `postgresql`, or `googlesql` and have it translated |
 
-Without either query flag, sqly opens the interactive shell on a terminal, and
-reads SQL from stdin when it is piped. `--stdin-format` takes stdin for the data,
-so it needs `--sql`, `--sql-file`, or `--inspect` to say what to run.
+`--sql`, `--sql-file`, and `--script-file` each name the work to run, so any two
+of them together is rejected. Without one, sqly opens the interactive shell on a
+terminal and reads a script from stdin when it is piped. `--stdin-format` takes
+stdin for the data, so it needs one of the three, or `--inspect`, to say what to
+run.
+
+### SQL file or script file
+
+A `--sql-file` holds SQL. A `--script-file` holds what the shell reads: SQL
+statements and dot-commands alike, exactly the text a pipe would carry.
+
+| | `--sql-file` | `--script-file` | piped stdin |
+|:--|:--|:--|:--|
+| SQL statements | yes | yes | yes |
+| Dot-commands | rejected by name and line | yes | yes |
+| `.save`, `.import` | rejected | yes | yes |
+| stdin free for `--stdin-format` | yes | yes | no |
+| `--output` | yes, for one result set | rejected; use `.dump` | no |
+| Several result sets | `table`, `vertical`, `markdown` only | same | same |
+| On a failing statement | stops there, non-zero | stops there, non-zero | stops there, non-zero |
+
+The two flags are separate rather than one flag with a relaxed rule because they
+make different promises. A `.sql` file is a thing other tools read too, and one
+that silently ran `.save` would be a shell script wearing a SQL extension. The
+flag that permits side effects says `script` in its name.
+
+Everything else is the same, deliberately: a script that works piped in works
+from a file unchanged, which is what makes it worth keeping in version control.
+
+```shell
+sqly --script-file monthly.sqly sales.csv
+```
+
+```text
+# monthly.sqly
+UPDATE sales SET region = 'APAC' WHERE region = 'ASIA';
+.save --in-place
+```
+
+An empty `--script-file` is rejected rather than exiting 0 having done nothing. A
+script that is only dot-commands is fine — it has no SQL statement in it and does
+not need one.
 
 ### What a `--sql-file` may contain
 
@@ -369,6 +409,17 @@ temporary file, so without this a world-readable CSV would come back owner-only.
 **The limit:** replacing several files cannot be atomic on any OS sqly runs on.
 What is guaranteed is that nothing is replaced until everything has been written,
 and that a failure after that point is reported with the exact files affected.
+
+## General
+
+| Flag | Does |
+|:--|:--|
+| `-h`, `--help` | print the grouped option list and exit |
+| `-v`, `--version` | print the sqly version and exit |
+
+sqly has no subcommands, so these are flags and not words: `sqly help` and
+`sqly version` are read as input paths. Typing either is recognized as the
+mistake it is and answered with a hint rather than a "path does not exist".
 
 ## Table name rules
 

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -135,8 +135,8 @@ no writer at all cannot hang it.
 | none | a terminal | opens the interactive shell |
 | none | a pipe or a redirected file | runs it as a script: SQL and dot-commands |
 | `--stdin-format FORMAT` | anything | imports it as the table `stdin` |
-| `--sql` / `--sql-file` / `--inspect` | a terminal, `/dev/null`, or an empty file | nothing; stdin is unused |
-| `--sql` / `--sql-file` / `--inspect` | a pipe or a non-empty file | nothing, and says so on stderr |
+| `--sql` / `--sql-file` / `--script-file` / `--inspect` | a terminal, `/dev/null`, or an empty file | nothing; stdin is unused |
+| `--sql` / `--sql-file` / `--script-file` / `--inspect` | a pipe or a non-empty file | nothing, and says so on stderr |
 
 The last row is the one worth knowing. `cat data.csv \| sqly --sql "..." other.csv`
 looks like it feeds `data.csv` in, and it does not — the answer comes from
@@ -158,7 +158,7 @@ cat data.csv | sqly --sql "SELECT COUNT(*) FROM stdin" /dev/stdin
 rejected — the split is quote-, comment-, and trigger-aware, so a semicolon inside
 `'a;b'` or a `-- comment;` does not count as a second statement.
 
-`--sql-file` and a piped script run every statement. How many of them may return
+`--sql-file`, `--script-file`, and a piped script run every statement. How many of them may return
 rows depends on the output format, because only some formats can say where one
 result ends and the next begins:
 

--- a/website/content/shell.md
+++ b/website/content/shell.md
@@ -95,10 +95,17 @@ which is what the line does not show. Leading whitespace is fine, so a script ca
 indent. A `.` inside a string, a `--` comment, or a `/* */` block is part of the
 statement, not a command.
 
-This is also the only place a helper command runs. `--sql-file` holds SQL, and a
-dot-command in one is rejected by name and line — a `.sql` file that runs `.save`
-is a shell script wearing a SQL extension. Pipe such a script in instead, exactly
-as written above.
+A helper command runs here and in a `--script-file`, which is the same script
+read from a file instead of a pipe:
+
+```shell
+sqly --script-file monthly.sqly user.csv
+```
+
+`--sql-file` holds SQL, and a dot-command in one is rejected by name and line — a
+`.sql` file that runs `.save` is a shell script wearing a SQL extension. The flag
+that permits side effects says `script` in its name. See the
+[reference](/reference/#sql-file-or-script-file) for what each one accepts.
 
 ## Write-back from the shell
 

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -38,6 +38,15 @@
 <link rel="icon" href="{{ $favicon }}" type="{{ $faviconType }}"{{ if eq $faviconType "image/png" }} sizes="64x64"{{ end }}>
 {{- $css := slice (resources.Get "css/site.css") (resources.Get "css/chroma.css") | resources.Concat "css/bundle.css" | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
+{{- /* Build metadata, so a deployed page can be told apart from a stale cached
+       one. The post-deploy check reads these to confirm the commit it expects
+       is the commit that is live; without them, "the site is up" and "the site
+       is the site we just built" are indistinguishable. The workflow sets the
+       commit via HUGO_PARAMS_BUILDCOMMIT; a local build falls back to "dev".
+       Hugo's getenv is whitelisted to HUGO_* only, and a param override is the
+       idiomatic way in besides. */ -}}
+<meta name="sqly-build-commit" content="{{ or site.Params.buildCommit "dev" }}">
+<meta name="sqly-build-time" content="{{ now.UTC.Format "2006-01-02T15:04:05Z" }}">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>


### PR DESCRIPTION
Four changes, all about the same gap: what sqly promises, and whether anything checks the promise. Merged into one PR rather than four to keep review in one place.

## `--script-file FILE`

`--sql-file` holds SQL and rejects a dot-command by name and line. That is the right rule for a flag that says `sql`, and it left a script that mixes SQL and dot-commands with nowhere to live but a pipe — moving working text into a file made it stop working for no reason a user could see.

`--script-file` is that missing entry point. The two flags stay separate rather than one being relaxed, because they make different promises: a `.sql` file is a thing other tools read too, and one that silently ran `.save` would be a shell script wearing a SQL extension. The flag that permits side effects says `script` in its name.

|  | `--sql-file` | `--script-file` | piped stdin |
|:--|:--|:--|:--|
| SQL statements | yes | yes | yes |
| Dot-commands | rejected by name and line | yes | yes |
| stdin free for `--stdin-format` | yes | yes | no |
| `--output` | yes, one result set | rejected; use `.dump` | no |

Everything else is deliberately identical to a piped script, so a script works from a file unchanged — that is what makes it worth keeping in version control. `--output` does not apply: a script writes with `.dump`, at the point where the destination means something, and one `--output` for a whole script would have to pick one of its results with nothing to say which.

## `--stdin-format` validation moves to parse time

An unsupported value was caught when stdin was staged, so a typo failed mid-run and exited `1`. It is a flag value like `--dialect` or `--row-mismatch`, so it is now rejected while parsing and exits `2`.

## Docs that were wrong

- The reference never listed `--help` or `--version`, on a page that promises every flag. The new drift test found this.
- CONTRIBUTING pointed at `doc/pages/markdown/`, a mkdocs tree replaced by Hugo some time ago.
- The bug report template asked for browser click-steps and a Go version. It now asks for the command, the exit code, and `sqly --version`.
- The README said "Twelve flags" while there were thirteen.

## Docs that can now notice

- A drift test derives the flag list from the parser and fails both ways: a flag the reference omits, and a flag it documents that no longer exists. Mutation-checked in both directions.
- Another fails if the README goes back to stating a flag count, which is the specific thing that went stale.
- The formats page opens with a capability matrix, because the formats differ in read/stdin/URL/compression/tables-per-file/write-back/types and the page described them one at a time. Writing the E2E spec that pins it found an error in my own matrix: it claimed compressed Parquet cannot be read, and it can.
- Every page carries its build commit, and the website workflow now verifies the live site after deploying — the commit matches, the current flags are on the page, the removed ones are not. Retries are bounded in attempts and total wait, and hitting the bound fails the job rather than passing on a timeout. I ran the check logic against the currently deployed site to confirm it is meaningful: it correctly reports `--script-file` as missing there, since this PR is what adds it.

The CHANGELOG now states the RC policy: breaking changes land before the final RC, and nothing user-visible changes between the final RC and v1.0.0.

## Verification

`go test ./...`, `-race`, `go vet`, `golangci-lint`, `go-arch-lint`, and `actionlint` clean locally. 723 atago scenarios pass, including new specs for `--script-file` (9 scenarios) and the capability matrix (8).

Two existing tests changed to the new contract rather than being relaxed: the `--stdin-format` typo case now asserts it is rejected at parse time as a `config.ArgError`, and the E2E scenario asserts `2` instead of `1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--script-file` to run SQL and dot-commands from a file, including `.save` and `.import`.
  - Added clearer validation for unsupported `--stdin-format` values and conflicting input options.

- **Documentation**
  - Updated CLI help, README, reference, shell, and format documentation.
  - Added release-candidate guidance and expanded format capability details.

- **Quality Improvements**
  - Added automated coverage for script execution, format capabilities, and documentation consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->