### PR TITLE
fix(ci): match the build commit tag as Hugo actually renders it

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -109,9 +109,13 @@ jobs:
         run: |
           attempt=1
           while [ "${attempt}" -le "${MAX_ATTEMPTS}" ]; do
+            # Quote-agnostic on purpose: Hugo's minifier renders the tag as
+            # `name=sqly-build-commit content="..."`, dropping the quotes around
+            # any attribute value that does not need them. Matching the tag and
+            # then pulling the 40-hex commit out of it does not care either way.
             live=$(curl -fsSL --max-time 30 "${SITE}?cachebust=${GITHUB_RUN_ID}-${attempt}" \
-              | grep -o 'name="sqly-build-commit" content="[0-9a-f]*"' \
-              | sed 's/.*content="//; s/"//') || live=""
+              | grep -o 'sqly-build-commit[^>]*' \
+              | grep -o '[0-9a-f]\{40\}') || live=""
             if [ "${live}" = "${EXPECTED_SHA}" ]; then
               echo "the live site is ${live}"
               exit 0


### PR DESCRIPTION
The post-deploy verification added in #807 failed on its first real run, and the failure was in the check rather than in the deploy.

It extracted the commit with a pattern requiring quotes around the `name` attribute. Hugo's minifier drops quotes from any attribute value that does not need them, so the tag is rendered:

```html
<meta name=sqly-build-commit content="7251c8cedf6f0ae9a3cea58fa8409e028cb5c52a">
```

The match returned nothing, and the job spent its full retry budget reporting an empty live commit against a correct one. The site was deployed correctly the whole time — I confirmed the metadata was live and matched `7251c8ce` while the job was still retrying.

Matching the tag and then pulling the 40-hex commit out of it does not care how the attributes are quoted.

## Verification

I ran both steps of the job as written against the deployed site: the commit match succeeds, and the reference page carries all twelve current flags and none of the seven removed ones.

This is also the check working as intended in one respect — it is meant to catch a difference between what was built and what is live, and the first thing it caught was that nobody had verified the extraction against minified output.