### PR TITLE
docs: prepare the v1.0.0-rc2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,24 @@
 
 ## Release candidates and what v1.0.0 freezes
 
-`v1.0.0-rc1` is a broad candidate, not the final contract. Breaking changes are
-still being made, and they are being made now rather than after v1.0.0.
+`v1.0.0-rc2` is the final release candidate. The CLI surface it ships is the one
+v1.0.0 commits to, and this is the version to pin against.
 
-* Breaking changes land before the final release candidate.
-* From the final RC onward, only bug fixes and documentation changes.
-* Nothing user-visible changes between the final RC and v1.0.0 — same flags,
-  same output, same exit codes.
-* Every change to what rc1 promised is listed under Breaking Changes below.
+`v1.0.0-rc1` was the broad candidate: breaking changes were still being made,
+deliberately before v1.0.0 rather than after it. Everything rc1 promised and rc2
+changed is listed under Breaking Changes below.
 
-The final RC is announced as the final one in its release notes. That is the
-point to pin a version against.
+* Breaking changes landed before this candidate. There are no more.
+* From here to v1.0.0, only bug fixes and documentation changes.
+* Nothing user-visible changes between rc2 and v1.0.0 — same flags, same output,
+  same exit codes.
 
 ## [Unreleased]
+
+## [v1.0.0-rc2](https://github.com/nao1215/sqly/compare/v1.0.0-rc1...v1.0.0-rc2) (2026-08-04)
+
+The final release candidate for v1.0.0. Everything below is a change from rc1;
+from here to v1.0.0 nothing user-visible moves.
 
 ### Breaking Changes
 * Added `--script-file FILE`, and `--sql-file` now points at it when it rejects a dot-command. `--sql-file` still holds SQL only; a script that mixes SQL and dot-commands has an entry point of its own instead of only working when piped. `--sql`, `--sql-file`, and `--script-file` are mutually exclusive, and `--output` does not apply to `--script-file` — a script writes files with `.dump`, where the destination means something.
@@ -51,7 +56,7 @@ point to pin a version against.
 * Drift tests cover the new claims: both script flags appear in the README with a link to `examples/`, the reference documents `--include-hidden-sheets`, the formats and cookbook pages state the visible-only default, the documented signal codes match `128+SIGINT` and `128+SIGTERM`, the download limit is described as a body limit, and the example files exist, are linked, and are run by the E2E suite. Flag names are matched as whole tokens, so `--sql-file` can no longer stand in for a missing `--sql`.
 
 ### v1.0.0 CLI Surface
-This supersedes the list under v1.0.0-rc1, which is left as the record of what that tag promised.
+This is the frozen surface: v1.0.0 ships it unchanged. It supersedes the list under v1.0.0-rc1, which is left as the record of what that tag promised.
 
 * Input: positional paths (files, directories, `http(s)` URLs), `--stdin-format FORMAT`, `--stdin-table NAME`, `--encoding ENCODING`, `--row-mismatch error|skip|pad`, `--include-hidden-sheets`.
 * Query: `--sql/-s SQL`, `--sql-file/-f FILE`, `--script-file FILE`, `--dialect sqlite|mysql|postgresql|googlesql`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,25 @@
 
 ## Release candidates and what v1.0.0 freezes
 
-`v1.0.0-rc2` is the final release candidate. The CLI surface it ships is the one
-v1.0.0 commits to, and this is the version to pin against.
+`v1.0.0-rc2` is a release candidate, not the final contract. Breaking changes are
+still being made, and they are being made now rather than after v1.0.0.
 
-`v1.0.0-rc1` was the broad candidate: breaking changes were still being made,
-deliberately before v1.0.0 rather than after it. Everything rc1 promised and rc2
-changed is listed under Breaking Changes below.
+* Breaking changes land before the final release candidate.
+* From the final RC onward, only bug fixes and documentation changes.
+* Nothing user-visible changes between the final RC and v1.0.0 — same flags,
+  same output, same exit codes.
+* Every change to what the previous candidate promised is listed under Breaking
+  Changes below.
 
-* Breaking changes landed before this candidate. There are no more.
-* From here to v1.0.0, only bug fixes and documentation changes.
-* Nothing user-visible changes between rc2 and v1.0.0 — same flags, same output,
-  same exit codes.
+The final RC is announced as the final one in its release notes. That is the
+point to pin a version against; rc2 is not it.
 
 ## [Unreleased]
 
 ## [v1.0.0-rc2](https://github.com/nao1215/sqly/compare/v1.0.0-rc1...v1.0.0-rc2) (2026-08-04)
 
-The final release candidate for v1.0.0. Everything below is a change from rc1;
-from here to v1.0.0 nothing user-visible moves.
+A release candidate for v1.0.0, not the final one. Everything below is a change
+from rc1.
 
 ### Breaking Changes
 * Added `--script-file FILE`, and `--sql-file` now points at it when it rejects a dot-command. `--sql-file` still holds SQL only; a script that mixes SQL and dot-commands has an entry point of its own instead of only working when piped. `--sql`, `--sql-file`, and `--script-file` are mutually exclusive, and `--output` does not apply to `--script-file` — a script writes files with `.dump`, where the destination means something.
@@ -56,7 +57,7 @@ from here to v1.0.0 nothing user-visible moves.
 * Drift tests cover the new claims: both script flags appear in the README with a link to `examples/`, the reference documents `--include-hidden-sheets`, the formats and cookbook pages state the visible-only default, the documented signal codes match `128+SIGINT` and `128+SIGTERM`, the download limit is described as a body limit, and the example files exist, are linked, and are run by the E2E suite. Flag names are matched as whole tokens, so `--sql-file` can no longer stand in for a missing `--sql`.
 
 ### v1.0.0 CLI Surface
-This is the frozen surface: v1.0.0 ships it unchanged. It supersedes the list under v1.0.0-rc1, which is left as the record of what that tag promised.
+The surface as of this candidate. It is not frozen yet — the final RC freezes it. This supersedes the list under v1.0.0-rc1, which is left as the record of what that tag promised.
 
 * Input: positional paths (files, directories, `http(s)` URLs), `--stdin-format FORMAT`, `--stdin-table NAME`, `--encoding ENCODING`, `--row-mismatch error|skip|pad`, `--include-hidden-sheets`.
 * Query: `--sql/-s SQL`, `--sql-file/-f FILE`, `--script-file FILE`, `--dialect sqlite|mysql|postgresql|googlesql`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/sqly/coverage.svg)
 [![Build](https://github.com/nao1215/sqly/actions/workflows/build.yml/badge.svg)](https://github.com/nao1215/sqly/actions/workflows/build.yml)
 [![reviewdog](https://github.com/nao1215/sqly/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/sqly/actions/workflows/reviewdog.yml)
-![GitHub](https://img.shields.io/github/license/nao1215/sqly)  
+![GitHub](https://img.shields.io/github/license/nao1215/sqly)
 [![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/nao1215/sqly/total)](https://github.com/nao1215/sqly/releases)
 
 


### PR DESCRIPTION
Release preparation for `v1.0.0-rc2`. No code changes.

`v1.0.0-rc2` is **not** the final release candidate — more candidates follow, and breaking changes can still land in them. The CLI surface is not frozen yet.

## CHANGELOG

`[Unreleased]` is closed as `[v1.0.0-rc2]` with a compare link against `v1.0.0-rc1`. A fresh empty `[Unreleased]` sits above it.

The "Release candidates and what v1.0.0 freezes" intro was written naming rc1 specifically, so it read as stale as soon as rc2 existed. It now names rc2 while keeping the same forward-pointing contract: breaking changes still land before the final RC, the final RC announces itself in its own release notes, and that is the point to pin against — explicitly noting rc2 is not it.

The `v1.0.0 CLI Surface` list is labelled as the surface *as of this candidate*, not frozen. The rc1 section is untouched and stays as the record of what that tag promised.

## README

Dropped the two trailing spaces after the license badge. They were a Markdown hard break, so the downloads badge rendered on a line of its own instead of joining the badge row above it — the only badge line in the block that did that.

## What rc2 contains over rc1

Summarised from the section itself:

- **Breaking**: `--script-file`; `--stdin-format` validation moved to parse time; classified exit codes (`2` usage, `3` input, `4` output); `.save --in-place` symlink opt-in; Excel visible-sheets-only default; SIGTERM `143`; multiple inputs as one atomic import; table-name collisions refused up front; Unicode-aware `SanitizeForSQL`.
- **New**: SIGINT/SIGTERM cancel rather than kill; `--inspect` reports `excel_sheets`; runnable `examples/`.
- **Maintenance**: Google Wire replaced with a hand-written composition root; corrupt-fixture self-verification fixed; composition-root tests.
- **Documentation**: capability matrix, atomicity wording corrected to a commit-and-cleanup guarantee, `Libraries and tools used` crediting atago, drift tests for all of it.

## Verification

```
go test ./...   ok
make lint       golangci-lint 0 issues; go-arch-lint OK - No warnings found
make website    ok, no tracked-file diff
```

`TestREADMEVersionMatchesChangelog` passes: the benchmark captions naming `sqly v0.30.0` and `sqly v0.29.0` are deliberately not bumped, since re-measuring is what updates them.

## Not in this PR

The tag. After merge, cut it per [doc/RELEASE.md](doc/RELEASE.md):

```shell
git switch main && git pull --ff-only
git tag v1.0.0-rc2 && git push origin v1.0.0-rc2
```

The release notes should not claim this is the final RC.