### PR TITLE
docs: say which version the documentation describes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedw
 
 Documentation: **https://nao1215.github.io/sqly/**
 
+This documentation describes `v1.0.0-rc2`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, and multiple inputs as one atomic import — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) before upgrading.
+
 ![demo](./doc/img/demo.gif)
 
 ## Try it in 30 seconds

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -4,6 +4,8 @@ title: sqly
 
 sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedwire files. It loads them into an in-memory SQLite database, so joins, CTEs, window functions, and aggregates all work — across formats, in one query.
 
+This site describes `v1.0.0-rc2`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, and multiple inputs as one atomic import — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) before upgrading.
+
 ![sqly running a query against a CSV file](/img/demo.gif)
 
 ## Try it in 30 seconds


### PR DESCRIPTION
Two lines, on the README and on the website landing page:

> This documentation describes `v1.0.0-rc2`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, and multiple inputs as one atomic import — and more can land before v1.0.0, so read the CHANGELOG before upgrading.

## Why

A reader arriving from a search result cannot tell which version a page describes. That mattered little while releases were incremental; it matters now, because the v0.x → rc2 changes are the kind that leave a command still working while doing something different:

- exit codes are classified (`2` usage, `3` input, `4` output) where everything used to be `1`, so a wrapper checking for `1` silently stops catching failures;
- an Excel workbook contributes only its visible sheets, so a table that used to appear no longer does;
- SIGTERM exits `143`, not `130`;
- several inputs are one atomic import, so a partial load is no longer a state the caller can land in.

The note also says rc2 is a candidate and that more can change before v1.0.0, which matches what CHANGELOG.md's intro says — and keeps a reader from pinning to an RC on the assumption the surface is settled.

Placed on both front doors rather than one: the README is the GitHub entry point, the landing page is the site's, and neither reader necessarily sees the other.

## Verification

```
go test ./...   ok
make lint       golangci-lint 0 issues; go-arch-lint OK - No warnings found
make website    ok, no tracked-file diff
```

## Note

The version string is not covered by a drift test. `TestREADMEVersionMatchesChangelog` matches `sqly vX.Y.Z` and does not recognise a pre-release suffix, so nothing fails if this line still says rc2 after rc3 is cut. Say the word and I will add a check that ties it to the newest CHANGELOG heading.