### PR TITLE
fix(ci): compare deployed pages with whitespace normalized

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Check the reference page shows the current flags
         run: |
-          page=$(curl -fsSL --max-time 30 "${SITE}reference/?cachebust=${GITHUB_RUN_ID}")
+          page=$(curl -fsSL --max-time 30 "${SITE}reference/?cachebust=${GITHUB_RUN_ID}" | tr -s '[:space:]' ' ')
 
           # Present: flags v1.0.0 commits to. A page that lost one is a page a
           # reader cannot use to write a working command.
@@ -160,8 +160,19 @@ jobs:
           # name check cannot see, and the one that misleads a reader worst: a
           # wrapper written against the wrong exit code, or an untrusted URL run
           # on the belief that 2 GiB bounds what it can cost.
-          reference=$(curl -fsSL --max-time 30 "${SITE}reference/?cachebust=${GITHUB_RUN_ID}")
-          formats=$(curl -fsSL --max-time 30 "${SITE}formats/?cachebust=${GITHUB_RUN_ID}")
+          # Every run of whitespace is collapsed to one space before matching.
+          # Hugo keeps a Markdown paragraph's source newlines in the HTML, so a
+          # claim that wraps in the source — "not a sandbox or an SSRF\ndefense"
+          # — is not the string this step looks for, and the check failed while
+          # the page was right. The Go drift tests already flatten for exactly
+          # this reason (see flatten() in docs_drift_test.go); this makes both
+          # readers of the same claim agree.
+          fetch() {
+            curl -fsSL --max-time 30 "$1" | tr -s '[:space:]' ' '
+          }
+
+          reference=$(fetch "${SITE}reference/?cachebust=${GITHUB_RUN_ID}")
+          formats=$(fetch "${SITE}formats/?cachebust=${GITHUB_RUN_ID}")
 
           require() {
             haystack=$1
@@ -195,11 +206,11 @@ jobs:
           require "${formats}" "not a sandbox or an SSRF defense" "formats"
           require "${formats}" "--allow-remote" "formats"
 
-          dialects=$(curl -fsSL --max-time 30 "${SITE}dialects/?cachebust=${GITHUB_RUN_ID}")
+          dialects=$(fetch "${SITE}dialects/?cachebust=${GITHUB_RUN_ID}")
           require "${dialects}" "translation, not emulation" "dialects"
           require "${dialects}" "SQLite semantics" "dialects"
 
-          about=$(curl -fsSL --max-time 30 "${SITE}about/?cachebust=${GITHUB_RUN_ID}")
+          about=$(fetch "${SITE}about/?cachebust=${GITHUB_RUN_ID}")
           require "${about}" "Historical measurement" "about"
           require "${about}" "not a performance guarantee" "about"
           echo "the deployed pages state the v1.0.0 contracts"

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -1900,6 +1900,106 @@ func TestCHANGELOG_ListsTheRc3BreakingChanges(t *testing.T) {
 	}
 }
 
+// pagesVerifyRequire matches the `require "${page}" "claim" "where"` lines the
+// website workflow checks the live site with.
+var pagesVerifyRequire = regexp.MustCompile(`(?m)^\s*require "\$\{(\w+)\}" "([^"]*)" "(\w+)"`)
+
+// pagesVerifySources maps the page name the workflow uses to the Markdown it is
+// rendered from, so a claim can be checked against the source before a deploy
+// has to check it against the live site.
+var pagesVerifySources = map[string]string{
+	"reference": "website/content/reference.md",
+	"formats":   "website/content/formats.md",
+	"dialects":  "website/content/dialects.md",
+	"about":     "website/content/about.md",
+}
+
+// TestPagesVerification_EveryClaimIsInTheSourceItChecks runs the deploy check's
+// own claim list against the Markdown those pages are built from.
+//
+// It exists because the deploy check is the one test that cannot run before a
+// deploy: a claim reworded out of a page, or a needle typed slightly wrong,
+// only fails after the site is already live. Comparing the list to the source
+// moves that failure to `go test`.
+func TestPagesVerification_EveryClaimIsInTheSourceItChecks(t *testing.T) {
+	t.Parallel()
+
+	workflow := readDoc(t, ".github/workflows/website.yml")
+	matches := pagesVerifyRequire.FindAllStringSubmatch(workflow, -1)
+	if len(matches) == 0 {
+		t.Fatal("no require lines parsed from the website workflow; the parser or the workflow changed")
+	}
+
+	flattened := make(map[string]string, len(pagesVerifySources))
+	for page, path := range pagesVerifySources {
+		flattened[page] = flatten(readDoc(t, path))
+	}
+
+	for _, m := range matches {
+		page, claim := m[1], m[2]
+		source, known := flattened[page]
+		if !known {
+			t.Errorf("the workflow checks a page %q this test cannot map to a Markdown source; add it to pagesVerifySources", page)
+			continue
+		}
+		if !strings.Contains(source, claim) {
+			t.Errorf("%s no longer states %q, which the Pages verification requires of the deployed page",
+				pagesVerifySources[page], claim)
+		}
+	}
+}
+
+// TestPagesVerification_NormalizesWhitespaceBeforeMatching keeps the workflow
+// from going back to a raw substring match on the fetched HTML.
+//
+// Every step that searches a page for prose must squeeze whitespace first.
+// Without it, a claim that happens to wrap in the Markdown source is absent
+// from the string being searched, and the deploy fails on a page that says
+// exactly the right thing — which is what happened the first time this check
+// ran.
+//
+// The steps are named rather than every curl being matched, because the
+// workflow fetches for two other reasons that are unaffected: the homepage is
+// read to pull a 40-hex build commit out of a meta tag, and the schema is
+// fetched to a file and parsed as JSON. Neither searches prose.
+func TestPagesVerification_NormalizesWhitespaceBeforeMatching(t *testing.T) {
+	t.Parallel()
+
+	const squeeze = `tr -s '[:space:]' ' '`
+	workflow := readDoc(t, ".github/workflows/website.yml")
+
+	for _, step := range []string{
+		"Check the reference page shows the current flags",
+		"Check the deployed pages state the contracts a wrong page would break",
+	} {
+		body := workflowStep(t, workflow, step)
+		if body == "" {
+			t.Errorf("the website workflow has no step named %q", step)
+			continue
+		}
+		if !strings.Contains(body, squeeze) {
+			t.Errorf("the %q step does not normalize whitespace with %s, so a claim that wraps in the source would not match",
+				step, squeeze)
+		}
+	}
+}
+
+// workflowStep returns the body of a named workflow step, or "" when there is
+// none. A step ends where the next one begins.
+func workflowStep(t *testing.T, workflow, name string) string {
+	t.Helper()
+
+	start := strings.Index(workflow, "- name: "+name)
+	if start < 0 {
+		return ""
+	}
+	rest := workflow[start+len("- name: "+name):]
+	if end := strings.Index(rest, "\n      - name: "); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
 // TestPagesVerification_ChecksTheRc3Contracts guards the deploy check itself.
 // The website workflow verifies the live site against a list of claims; a
 // contract added without being added there is a contract the deploy cannot


### PR DESCRIPTION
## What broke

The Pages verification failed on its first real run — [`Website` on `80aab1e`](https://github.com/nao1215/sqly/actions/runs/30927636795/job/92054185705):

```
##[error]the deployed formats page does not state: not a sandbox or an SSRF defense
```

The page says it. The check could not see it.

`formats.md` wraps the sentence:

```markdown
`--allow-remote` is an explicit network capability, not a sandbox or an SSRF
defense.
```

Hugo keeps a paragraph's source newlines in the rendered HTML, so what is served is `...an SSRF\ndefense.` and the workflow's plain `case "${haystack}" in *"${needle}"*)` never matches the space-separated needle.

Confirmed against the live site — zero hits raw, one hit once whitespace is squeezed:

```
ode> is an explicit network capability, not a sandbox or an SSRF defense.</p><p>It decides ...
```

`build` and `deploy` both succeeded. The deployed commit is `80aab1e`, and the schema is served correctly (draft 2020-12, `schema_version.const = 1`, three required top-level fields, `sample_rows` required) — that step never ran, because `verify` exits on the first failure.

## The fix

Every step that searches a page for prose squeezes whitespace first, which is what the Go drift tests have always done via `flatten()`. Having one reader normalize and the other not is what let this through.

The two other fetches are untouched and unaffected: the homepage is read to pull a 40-hex build commit out of a meta tag, and the schema is fetched to a file and parsed as JSON. Neither searches prose.

## Guards

I wrote the fragile check *and* a comment in `docs_drift_test.go` warning against exactly this ("a check that breaks when a paragraph is rewrapped teaches contributors to reflow around the test rather than to keep the claim"), so a fix without a guard is not worth much. Two new tests, both of which fail today without the fix:

| Test | Mutation | Result |
|:--|:--|:--|
| `TestPagesVerification_NormalizesWhitespaceBeforeMatching` | remove the squeeze (the original bug) | fails |
| `TestPagesVerification_EveryClaimIsInTheSourceItChecks` | reword a claim out of `formats.md` while the workflow still requires it | fails, alongside `TestDocs_StateTheRemoteDefaultDeny` |

The second one matters most: it runs the workflow's own `require` list against the Markdown those pages are built from. That check could previously only fail *after* a deploy; now it fails in `go test`.

## Verified

`go test ./...` green. The `verify` job itself can only be exercised by a push to `main`, so this PR's own run does not prove it — that is the next thing to watch after merge, and it is what gates cutting `v1.0.0-rc3`.