### PR TITLE
docs: prepare the v1.0.0-rc3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Release candidates and what v1.0.0 freezes
 
-`v1.0.0-rc3` is the next release candidate, and it is not the final contract either. Breaking changes are
-still being made, and they are being made now rather than after v1.0.0.
+`v1.0.0-rc3` is the current release candidate, and it is not the final contract
+either. Breaking changes are still being made, and they are being made now
+rather than after v1.0.0.
 
 * Breaking changes land before the final release candidate.
 * From the final RC onward, only bug fixes and documentation changes.
@@ -19,11 +20,10 @@ Upgrading between candidates: [doc/migration.md](doc/migration.md).
 
 ## [Unreleased]
 
-## [v1.0.0-rc3](https://github.com/nao1215/sqly/compare/v1.0.0-rc2...v1.0.0-rc3) (unreleased)
+## [v1.0.0-rc3](https://github.com/nao1215/sqly/compare/v1.0.0-rc2...v1.0.0-rc3) (2026-08-05)
 
 A release candidate for v1.0.0, not the final one. Everything below is a change
-from rc2. **This tag has not been published yet**; the documentation on `main`
-describes it as the next candidate.
+from rc2.
 
 Upgrading from rc2: [doc/migration.md](doc/migration.md).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedw
 
 Documentation: **https://nao1215.github.io/sqly/**
 
-This documentation describes `v1.0.0-rc3`, the next release candidate, which has not been tagged yet; the latest published candidate is `v1.0.0-rc2`. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, and now a schema-only `--inspect` and default-deny remote input — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) and the [migration guide](./doc/migration.md) before upgrading.
+This documentation describes `v1.0.0-rc3`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, and now a schema-only `--inspect` and default-deny remote input — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) and the [migration guide](./doc/migration.md) before upgrading.
 
 ![demo](./doc/img/demo.gif)
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -4,7 +4,7 @@ title: sqly
 
 sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedwire files. It loads them into an in-memory SQLite database, so joins, CTEs, window functions, and aggregates all work — across formats, in one query.
 
-This site describes `v1.0.0-rc3`, the next release candidate, which has not been tagged yet; the latest published candidate is `v1.0.0-rc2`. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, and now a schema-only `--inspect` and default-deny remote input — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) and the [migration guide](https://github.com/nao1215/sqly/blob/main/doc/migration.md) before upgrading.
+This site describes `v1.0.0-rc3`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, and now a schema-only `--inspect` and default-deny remote input — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) and the [migration guide](https://github.com/nao1215/sqly/blob/main/doc/migration.md) before upgrading.
 
 ![sqly running a query against a CSV file](/img/demo.gif)
 


### PR DESCRIPTION
Release prep for `v1.0.0-rc3`. Documentation only — no code changes.

## Changes

| File | Change |
|:--|:--|
| `CHANGELOG.md` | rc3 heading dated `2026-08-05`; dropped "**This tag has not been published yet**" |
| `CHANGELOG.md` | preamble now calls rc3 the *current* candidate rather than the next one |
| `README.md:18` | banner reduced to "describes `v1.0.0-rc3`, a release candidate" |
| `website/content/_index.md:7` | same banner on the site |

Both banners previously said rc3 "has not been tagged yet; the latest published candidate is `v1.0.0-rc2`", which stops being true the moment the tag is pushed.

What is deliberately unchanged: the preamble still says rc3 is **not** the final contract, still says breaking changes land before the final RC, and still points at [`doc/migration.md`](doc/migration.md). Tagging rc3 does not make it the version to pin against — the final RC is announced as final in its own release notes.

## Gate

The Pages `verify` job passed on `main` at [`224c2ae`](https://github.com/nao1215/sqly/commit/224c2ae074b86aacbb2d5c5709f525bd2240539d) after [#815](https://github.com/nao1215/sqly/pull/815), including all three checking steps:

```
success  Wait for the deployed commit to go live
success  Check the reference page shows the current flags
success  Check the deployed pages state the contracts a wrong page would break
success  Check the deployed site serves the inspect JSON Schema
```

That last step had never executed before — the job used to exit on the earlier failure. The published site now demonstrably serves the `--inspect` JSON Schema with draft 2020-12, `schema_version.const = 1`, the three required top-level fields, and `sample_rows` required.

## After this merges

`git tag v1.0.0-rc3 && git push origin v1.0.0-rc3`, which triggers the release workflow. `prerelease: auto` publishes rc3 as a pre-release, so it will not displace `v0.31.0` as *Latest*. `v1.0.0-rc2` is not touched.