### PR TITLE
fix(shell): classify four failures off the SQL exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Upgrading between candidates: [doc/migration.md](doc/migration.md).
 
 ## [Unreleased]
 
+### Breaking Changes
+
+* Four kinds of failure that exited `1` now exit `2` or `4`. `1` means a statement ran and failed, so it told a wrapper to fix the SQL; none of these four is a SQL problem. An `--output` or `.dump` destination that is one of the run's source files exits `4` (the collision the exit-code table already named). A value or column set the chosen output format cannot represent — a tab inside an LTSV field, two result columns of the same name in JSON — exits `4`, whether the result was going to a file or to stdout, because what has to change is the format or the destination. An `--output-format` that contradicts the destination's extension exits `2`, and is now decided from the command line before any input is read, so a run with a missing input still reports the conflict rather than the missing file; the same contradiction inside a script, where `.mode` is session state, exits `2` at the statement that hits it. `--inspect` with nothing to inspect exits `2`, which is where an agent expanding an empty file list into `sqly --inspect $FILES` lands. A wrapper that branched on `1` for any of these has to branch on the new code.
+
 ## [v1.0.0-rc3](https://github.com/nao1215/sqly/compare/v1.0.0-rc2...v1.0.0-rc3) (2026-08-05)
 
 A release candidate for v1.0.0, not the final one. Everything below is a change

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -7,6 +7,43 @@ The [CHANGELOG](../CHANGELOG.md) records every change. This file records the one
 that require an edit to a command line, a script, or a program that reads sqly's
 output.
 
+## v1.0.0-rc3 → v1.0.0-rc4
+
+### Four failures moved off exit code `1`
+
+`1` means a statement ran and failed, so a wrapper reading it goes back to the
+SQL. Four failures that had nothing to do with SQL were reported that way and now
+carry the code that says what to fix.
+
+| Failure | Before | Now |
+|:--|:--|:--|
+| `--output` or `.dump` names one of the run's source files | `1` | `4` |
+| the output format cannot represent a value or a column set, to a file or to stdout | `1` | `4` |
+| `--output-format` contradicts the destination's extension | `1` | `2` |
+| `--inspect` with no input files | `1` | `2` |
+
+**What to change:** a wrapper that branched on `1` for any of these branches on
+the new code. Nothing about the messages changed, so one matching on stderr text
+needs nothing.
+
+The format conflict also moved earlier. It is decided from the command line
+before any input is read, so a run that names both a contradiction and a missing
+file now reports the contradiction:
+
+```text
+Before rc4:
+  sqly --output-format csv --output m.json --sql "SELECT 1" nosuch.csv
+  # exit 3, "Import failed" on stderr
+
+From rc4:
+  sqly --output-format csv --output m.json --sql "SELECT 1" nosuch.csv
+  # exit 2, nothing imported
+```
+
+The same contradiction inside a script — a `.mode` that disagrees with a `.dump`
+destination — stays a runtime check, because the mode is session state. It exits
+`2` at the statement that hits it.
+
 ## v1.0.0-rc2 → v1.0.0-rc3
 
 Two defaults changed, in the same direction and for the same reason: sqly is run

--- a/e2e/atago/exit_codes.atago.yaml
+++ b/e2e/atago/exit_codes.atago.yaml
@@ -181,6 +181,155 @@ scenarios:
       - assert:
           exit_code: 4
 
+  # A destination that is also one of the run's inputs is the collision the
+  # contract names under 4. It used to exit 1, which told a wrapper to fix the
+  # SQL when the SQL was fine and the destination was the problem.
+  - name: an --output destination that is a source file exits 4
+    steps:
+      - fixture:
+          file: staff.csv
+          content: |
+            name,dept
+            alice,eng
+      - run:
+          command: sqly --output staff.csv --sql "SELECT 1" staff.csv
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: 'is the source file for table "staff"'
+
+  - name: a .dump destination that is a source file exits 4
+    steps:
+      - fixture:
+          file: staff.csv
+          content: |
+            name,dept
+            alice,eng
+      - run:
+          command: sqly staff.csv
+          stdin: ".dump staff staff.csv\n"
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: 'is the source file for table "staff"'
+
+  # A format the results cannot be carried in is not a SQL error: the fix is a
+  # different --output-format or a different destination, so it belongs with the
+  # other output failures rather than with the statements that ran and failed.
+  - name: a value LTSV cannot represent exits 4 on stdout
+    steps:
+      - fixture:
+          file: staff.csv
+          content: |
+            name,dept
+            alice,eng
+      - run:
+          command: sqly --output-format ltsv --sql "SELECT 'a' || char(9) || 'b' AS x" staff.csv
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "contains a tab or newline"
+
+  - name: a value LTSV cannot represent exits 4 when writing a file
+    steps:
+      - fixture:
+          file: staff.csv
+          content: |
+            name,dept
+            alice,eng
+      - run:
+          command: sqly --output-format ltsv --output bad.ltsv --sql "SELECT 'a' || char(9) || 'b' AS x" staff.csv
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "contains a tab or newline"
+
+  - name: a column set JSON cannot represent exits 4
+    steps:
+      - fixture:
+          file: staff.csv
+          content: |
+            name,dept
+            alice,eng
+      - run:
+          command: sqly --output-format json --sql "SELECT name AS c, dept AS c FROM staff" staff.csv
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "json output requires unique column names"
+
+  - name: a column set LTSV cannot represent exits 4
+    steps:
+      - fixture:
+          file: staff.csv
+          content: |
+            name,dept
+            alice,eng
+      - run:
+          command: sqly --output-format ltsv --sql "SELECT name AS c, dept AS c FROM staff" staff.csv
+      - assert:
+          exit_code: 4
+
+  # --output-format against the destination extension is decided from argv
+  # alone, so it is a usage error and it is settled before anything is read.
+  - name: an --output-format that contradicts the destination extension exits 2
+    steps:
+      - fixture:
+          file: staff.csv
+          content: |
+            name,dept
+            alice,eng
+      - run:
+          command: sqly --output-format csv --output m.json --sql "SELECT 1" staff.csv
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "does not match destination extension"
+
+  # The decisive case: with an input that does not exist, a run that still
+  # reports 2 proved it decided before the import. A 3 here means the conflict
+  # is being evaluated after the files are read.
+  - name: an --output-format conflict is decided before any input is read
+    steps:
+      - run:
+          command: sqly --output-format csv --output m.json --sql "SELECT 1" nosuch.csv
+      - assert:
+          exit_code: 2
+          stdout:
+            empty: true
+          stderr:
+            not_contains: "Import failed"
+
+  # The same conflict inside a script depends on session state (.mode), so it
+  # can only be seen when the statement runs. It is still a script sqly will not
+  # accept, which is 2.
+  - name: a .mode that contradicts a .dump destination exits 2
+    steps:
+      - fixture:
+          file: staff.csv
+          content: |
+            name,dept
+            alice,eng
+      - run:
+          command: sqly staff.csv
+          stdin: ".mode csv\n.dump staff z.json\n"
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "does not match destination extension"
+
+  # --inspect with nothing to inspect ran no statement at all, so 1 would send a
+  # wrapper looking for a SQL error. An agent expanding an empty file list into
+  # `sqly --inspect $FILES` lands here.
+  - name: --inspect with no inputs exits 2
+    steps:
+      - run:
+          command: sqly --inspect
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "no tables to inspect"
+
   # 1: the invocation and the data were both fine and a statement failed. This
   # is the only class where the SQL itself is what needs changing.
   - name: a query against a table that does not exist exits 1

--- a/e2e/atago/export_inference.atago.yaml
+++ b/e2e/atago/export_inference.atago.yaml
@@ -117,7 +117,7 @@ scenarios:
       - run:
           command: sqly --output-format json --sql "SELECT user_name FROM user LIMIT 1" user.csv --output result.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "conflicts with destination path"
 

--- a/e2e/atago/file_write_contract.atago.yaml
+++ b/e2e/atago/file_write_contract.atago.yaml
@@ -36,7 +36,7 @@ scenarios:
       - run:
           command: sqly --output-format ltsv --output keep.ltsv --sql "SELECT a FROM tabbed" tabbed.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           file:
             path: keep.ltsv
             equals: |
@@ -53,7 +53,7 @@ scenarios:
       - run:
           command: sqly --output-format ltsv --output keep.ltsv --sql "SELECT a FROM tabbed" tabbed.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: '"keep.ltsv"'
             not_contains: "sqly-out-"
@@ -184,7 +184,7 @@ scenarios:
       - run:
           command: sqly --output-format csv --output rows.csv --sql "SELECT a FROM rows" rows.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           file:
             path: rows.csv
             contains: "a"

--- a/e2e/atago/inspect.atago.yaml
+++ b/e2e/atago/inspect.atago.yaml
@@ -76,7 +76,7 @@ scenarios:
       - run:
           command: sqly --inspect
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "no tables to inspect"
 

--- a/e2e/atago/parquet_export.atago.yaml
+++ b/e2e/atago/parquet_export.atago.yaml
@@ -92,6 +92,6 @@ scenarios:
       - run:
           command: sqly --output-format parquet --output empty.parquet --sql "SELECT user_name FROM user WHERE 1=0" user.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "empty result"

--- a/e2e/atago/v0_18_bugs.atago.yaml
+++ b/e2e/atago/v0_18_bugs.atago.yaml
@@ -202,7 +202,7 @@ scenarios:
       - run:
           command: sqly --output-format csv --sql "SELECT * FROM user WHERE identifier=1" --output user.csv user.csv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "--output"
 

--- a/e2e/atago/v0_19_bugs.atago.yaml
+++ b/e2e/atago/v0_19_bugs.atago.yaml
@@ -31,7 +31,7 @@ scenarios:
       - run:
           command: sqly --output-format ltsv --sql "SELECT 'a' || char(9) || 'b' AS c"
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: LTSV
 
@@ -40,7 +40,7 @@ scenarios:
       - run:
           command: sqly --output-format json --sql "SELECT 1 AS x, 2 AS x"
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "unique column names"
 
@@ -49,7 +49,7 @@ scenarios:
       - run:
           command: sqly --output-format jsonl --sql "SELECT 1 AS x, 2 AS x"
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             contains: "unique column names"
 

--- a/e2e/atago/v0_20_bugs.atago.yaml
+++ b/e2e/atago/v0_20_bugs.atago.yaml
@@ -434,7 +434,7 @@ scenarios:
       - run:
           command: sqly --output-format ltsv --sql 'SELECT 1 AS "foo:bar"' --output out.ltsv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             empty: false
 
@@ -444,7 +444,7 @@ scenarios:
       - run:
           command: sqly --output-format ltsv --sql "SELECT 1 AS x, 2 AS x" --output out.ltsv
       - assert:
-          exit_code: 1
+          exit_code: 4
           stderr:
             empty: false
 

--- a/shell/dump.go
+++ b/shell/dump.go
@@ -71,7 +71,7 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 	// vertical); otherwise the format (and any compression) is inferred from the
 	// destination path.
 	mode := s.state.mode.PrintMode
-	exportFmt, compression, err := model.ResolveOutputTarget(userPath, model.ExportFormatFromPrintMode(mode), !mode.IsDisplayOnly())
+	exportFmt, compression, err := resolveOutputTarget(userPath, model.ExportFormatFromPrintMode(mode), !mode.IsDisplayOnly())
 	if err != nil {
 		return err
 	}
@@ -81,10 +81,10 @@ func (c CommandList) dumpCommand(ctx context.Context, s *Shell, argv []string) e
 	// .dump, so a stray .dump cannot silently rewrite the dataset in another
 	// format.
 	if name, aliased := s.outputAliasesImportedSource(filePath); aliased {
-		return fmt.Errorf(".dump destination %s is the source file for table %q; use .save --in-place to overwrite a source", filePath, name)
+		return &outputPathError{Path: filePath, Err: fmt.Errorf(".dump destination %s is the source file for table %q; use .save --in-place to overwrite a source", filePath, name)}
 	}
 	if err := s.usecases.export.DumpTable(filePath, table, exportFmt, compression); err != nil {
-		return err
+		return &outputPathError{Path: filePath, Err: err}
 	}
 	// .dump writes data to a file, so its status line is control-plane output
 	// and goes to stderr, keeping stdout free of non-data noise.

--- a/shell/errorpath_test.go
+++ b/shell/errorpath_test.go
@@ -167,6 +167,11 @@ func TestShell_runInspect_reportsNoTables(t *testing.T) {
 	if err == nil {
 		t.Fatal("want error when there are no tables to inspect, got nil")
 	}
+	// Nothing ran, so this is a command line to fix rather than a statement that
+	// failed. A wrapper reading exit 1 here would look for SQL that never existed.
+	if got := ExitCode(err); got != ExitUsage {
+		t.Errorf("ExitCode(%v) = %d, want %d", err, got, ExitUsage)
+	}
 }
 
 // TestShell_negativeInspectSample_isRejectedBeforeTheRun records where the

--- a/shell/inspect.go
+++ b/shell/inspect.go
@@ -130,7 +130,11 @@ func (s *Shell) runInspect(ctx context.Context) error {
 		return fmt.Errorf("failed to list tables: %w", err)
 	}
 	if len(tables) == 0 {
-		return errors.New("no tables to inspect: provide input files or directories")
+		// Nothing was inspected because nothing was given to inspect, so the fix is
+		// on the command line. Reporting this as a failed statement told a wrapper
+		// to look at SQL that never ran — the case an agent lands in when it
+		// expands an empty file list into `sqly --inspect $FILES`.
+		return &invocationError{Err: errors.New("no tables to inspect: provide input files or directories")}
 	}
 
 	names := make([]string, 0, len(tables))

--- a/shell/output_safety_test.go
+++ b/shell/output_safety_test.go
@@ -1,9 +1,14 @@
 package shell
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/nao1215/sqly/config"
+	"github.com/nao1215/sqly/domain/model"
 )
 
 // TestEnsureNotDirectory covers rejecting directory-like output destinations:
@@ -32,6 +37,82 @@ func TestEnsureNotDirectory(t *testing.T) {
 			t.Errorf("want nil for plain file path, got %v", err)
 		}
 	})
+}
+
+// TestResolveOutputTarget_ClassifiesAFormatConflictAsUsage pins which of
+// ResolveOutputTarget's refusals is a command-line problem. A mode that
+// contradicts the destination extension is two things the user typed
+// disagreeing, so it exits 2; a destination that cannot carry the compression it
+// was given describes the file, and keeps the class it had.
+func TestResolveOutputTarget_ClassifiesAFormatConflictAsUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		path        string
+		explicit    model.ExportFormat
+		explicitSet bool
+		want        int
+	}{
+		{
+			name:        "a mode that contradicts the extension is a usage error",
+			path:        "m.json",
+			explicit:    model.ExportCSV,
+			explicitSet: true,
+			want:        ExitUsage,
+		},
+		{
+			name:        "compression a format cannot carry keeps its own class",
+			path:        "out.parquet.gz",
+			explicit:    model.ExportParquet,
+			explicitSet: true,
+			want:        ExitFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := resolveOutputTarget(tt.path, tt.explicit, tt.explicitSet)
+			if err == nil {
+				t.Fatalf("resolveOutputTarget(%q) = nil error, want one", tt.path)
+			}
+			if got := ExitCode(err); got != tt.want {
+				t.Errorf("ExitCode(%v) = %d, want %d", err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPrintResultTable_ReportsAnUnrepresentableValueAsOutput checks the class of
+// a result stdout cannot carry. The statement ran and produced its rows, so the
+// fix is another --output-format, not another query.
+func TestPrintResultTable_ReportsAnUnrepresentableValueAsOutput(t *testing.T) {
+	table := model.NewTable(
+		"t",
+		model.Header{"x"},
+		[]model.Record{{"a\tb"}},
+	)
+
+	var buf bytes.Buffer
+	stdout := config.Stdout
+	config.Stdout = &buf
+	t.Cleanup(func() { config.Stdout = stdout })
+
+	err := printResultTable(table, model.PrintModeLTSV)
+	if err == nil {
+		t.Fatal("want an error for a tab inside an LTSV value, got nil")
+	}
+	if got := ExitCode(err); got != ExitOutput {
+		t.Errorf("ExitCode(%v) = %d, want %d", err, got, ExitOutput)
+	}
+	var pathErr *outputPathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("want an *outputPathError, got %T", err)
+	}
+	if pathErr.Path != stdoutDestination {
+		t.Errorf("Path = %q, want %q", pathErr.Path, stdoutDestination)
+	}
 }
 
 // TestSameFilePathSymlink verifies that a symlink alias to a file is recognized

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -292,6 +292,16 @@ func (s *Shell) Run(ctx context.Context) error {
 		return err
 	}
 
+	// An --output-format that contradicts the destination's extension is decided
+	// from the command line alone, so it is settled here rather than after the
+	// import: a caller whose invocation cannot mean anything should not have to
+	// read past import diagnostics for a message about two flags, and a missing
+	// input must not change the answer from "fix the command line" to "fix the
+	// file".
+	if err := s.validateOutputFormatAgainstDestination(); err != nil {
+		return err
+	}
+
 	// Excel and Parquet are binary container formats with no on-screen rendering,
 	// so a query run that selects one without a destination used to print CSV to
 	// stdout instead: the user asked for one format and silently received another.
@@ -587,6 +597,27 @@ func (s *Shell) validateBinaryOutputFormat() error {
 	default:
 		return nil
 	}
+}
+
+// validateOutputFormatAgainstDestination rejects an --output-format that
+// contradicts the extension of the --output path.
+//
+// The check runs before the import because both halves of it are on the command
+// line: no file changes the answer, so a run this rejects should read nothing.
+// Only the conflict is reported here. What else the resolution can reject —
+// compression a format cannot carry, stacked codecs — describes the destination
+// rather than the invocation, and is left to the write that would produce it.
+func (s *Shell) validateOutputFormatAgainstDestination() error {
+	if s.argument.Output.FilePath == "" {
+		return nil
+	}
+	mode := s.state.mode.PrintMode
+	_, _, err := resolveOutputTarget(s.argument.Output.FilePath, model.ExportFormatFromPrintMode(mode), !mode.IsDisplayOnly())
+	var invocationErr *invocationError
+	if errors.As(err, &invocationErr) {
+		return err
+	}
+	return nil
 }
 
 // positionalSubcommandHint reports whether the first positional argument is the
@@ -1140,8 +1171,8 @@ func (s *Shell) runScript(ctx context.Context, elements []scriptElement) (bool, 
 			s.state.mode, len(s.capturedRowsets), multiResultAdvice)}
 	}
 	for _, table := range s.capturedRowsets {
-		if err := table.Print(config.Stdout, s.state.mode.PrintMode); err != nil {
-			return ranAny, fmt.Errorf("failed to print table: %w", err)
+		if err := printResultTable(table, s.state.mode.PrintMode); err != nil {
+			return ranAny, err
 		}
 	}
 	return ranAny, nil
@@ -1250,11 +1281,48 @@ func (s *Shell) execSQL(ctx context.Context, req string) error {
 	if s.printedResults > 0 {
 		fmt.Fprintln(config.Stdout)
 	}
-	if err := table.Print(config.Stdout, s.state.mode.PrintMode); err != nil {
-		return fmt.Errorf("failed to print table: %w", err)
+	if err := printResultTable(table, s.state.mode.PrintMode); err != nil {
+		return err
 	}
 	s.printedResults++
 	return nil
+}
+
+// stdoutDestination is the Path an outputPathError carries when the destination
+// was stdout rather than a file, so a caller reading Path always finds where the
+// result was going.
+const stdoutDestination = "stdout"
+
+// printResultTable writes table to stdout and reports a rendering failure as an
+// output failure.
+//
+// A format that cannot represent a value (a tab inside an LTSV field) or a
+// column set (two columns of the same name in JSON) is not a SQL error: the
+// statement ran and produced the rows it was asked for. What has to change is
+// the chosen --output-format or where the result goes, which is what the output
+// class tells a caller. Reporting it as a failed statement sent them back to the
+// query instead.
+func printResultTable(table *model.Table, mode model.PrintMode) error {
+	if err := table.Print(config.Stdout, mode); err != nil {
+		return &outputPathError{Path: stdoutDestination, Err: fmt.Errorf("failed to print table: %w", err)}
+	}
+	return nil
+}
+
+// resolveOutputTarget resolves path against the run's format and reports a
+// conflict between the two as a usage error.
+//
+// The conflict is a contradiction between two things the user typed — an output
+// mode and a destination extension — so nothing about the data can settle it and
+// the fix is on the command line or in the script. The rest of what
+// ResolveOutputTarget rejects is about what the destination itself can hold, and
+// keeps the class it already had.
+func resolveOutputTarget(path string, explicit model.ExportFormat, explicitSet bool) (model.ExportFormat, model.Compression, error) {
+	format, compression, err := model.ResolveOutputTarget(path, explicit, explicitSet)
+	if errors.Is(err, model.ErrOutputFormatConflict) {
+		return 0, model.CompressionNone, &invocationError{Err: err}
+	}
+	return format, compression, err
 }
 
 // outputToFile output table data to file. The export format and compression are
@@ -1269,7 +1337,7 @@ func (s *Shell) outputToFile(table *model.Table) error {
 	}
 	mode := s.state.mode.PrintMode
 	explicit := model.ExportFormatFromPrintMode(mode)
-	exportFmt, compression, err := model.ResolveOutputTarget(s.argument.Output.FilePath, explicit, !mode.IsDisplayOnly())
+	exportFmt, compression, err := resolveOutputTarget(s.argument.Output.FilePath, explicit, !mode.IsDisplayOnly())
 	if err != nil {
 		return err
 	}
@@ -1278,15 +1346,20 @@ func (s *Shell) outputToFile(table *model.Table) error {
 	// destructive source write must go through .save --in-place, not a one-off
 	// export, so a stray --output cannot silently destroy the dataset.
 	if name, aliased := s.outputAliasesImportedSource(filePath); aliased {
-		return fmt.Errorf("--output destination %s is the source file for table %q; use .save --in-place to overwrite a source", filePath, name)
+		return &outputPathError{Path: filePath, Err: fmt.Errorf("--output destination %s is the source file for table %q; use .save --in-place to overwrite a source", filePath, name)}
 	}
 	// The result is serialized beside the destination and moved onto it, so a
 	// format that rejects a value part-way — or a full disk — leaves an existing
 	// file whole rather than truncated. .save writes through the same steps.
+	//
+	// Everything this can fail at is about the destination: a value the format
+	// cannot hold, a staging file that could not be written, a commit that did
+	// not land. The wrapper carries no text of its own, so the message stays the
+	// one the failing step produced.
 	if err := s.writeFileAtomically(filePath, func(staging string) error {
 		return s.usecases.export.DumpTable(staging, table, exportFmt, compression)
 	}); err != nil {
-		return err
+		return &outputPathError{Path: filePath, Err: err}
 	}
 	// Status for a file-output operation is control-plane information; the data
 	// went to the file, so keep stdout empty and report progress on stderr.

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -305,10 +305,15 @@ destination exactly as it was — never truncated, half-written, or removed.
 
 The checks that can run before the import do: a destination that is a directory,
 ends in a path separator, or whose parent directory does not exist is rejected
-before any input is read. A destination that resolves to one of the input files is
-rejected too — overwriting a source is `.save --in-place`'s job, not a side effect
-of `--output`. Symlinks are resolved before that comparison, so an alias cannot
-get around it.
+before any input is read, as is an `--output-format` that contradicts the
+destination's extension.
+
+A destination that resolves to one of the input files is rejected too —
+overwriting a source is `.save --in-place`'s job, not a side effect of
+`--output`. Symlinks are resolved before that comparison, so an alias cannot get
+around it. This one is not a pre-import check: which files became which tables is
+only known once they have been imported, so the inputs are read before the
+destination is refused. It exits `4` either way.
 
 An existing destination is **overwritten**. `--output` is how you name the file you
 want; it does not ask. The file's permissions are preserved when it already exists,
@@ -655,14 +660,16 @@ wrong" from "that file would not load" without reading stderr.
 | `1` | a statement ran and failed: a SQL error, a missing table, a constraint | the SQL |
 | `2` | the command line or the script was not accepted: an unknown flag, two flags that contradict, a dot-command in a `--sql-file`, a format that cannot carry the results | the invocation |
 | `3` | an input could not be read: a missing path, an unsupported format, a download that failed or hit a limit, a malformed row under `--row-mismatch error` | the input |
-| `4` | a destination could not be written: a missing parent directory, a source with no writable form, a collision, a failed commit or rollback | the destination |
+| `4` | a destination could not be written: a missing parent directory, a source with no writable form, a collision, a failed commit or rollback, a value or column set the chosen output format cannot represent — including when the destination is stdout | the destination |
 | `130` | SIGINT stopped the run — someone pressed Ctrl-C | — |
 | `143` | SIGTERM stopped the run — something else asked it to stop | — |
 
-Most code-`2` failures are decided before anything is read or written. The
-exception is a script whose result sets the chosen format cannot separate: that
-is only known once the script has run, so the inputs were read even though
-nothing was printed. A `4` means the query may already have produced results.
+Most code-`2` failures are decided before anything is read or written. Two are
+not. A script whose result sets the chosen format cannot separate is only known
+once the script has run, so the inputs were read even though nothing was
+printed. A script whose `.mode` contradicts a `.dump` destination is the same
+case: the mode is session state, so the contradiction only exists at the
+statement that hits it. A `4` means the query may already have produced results.
 
 The class is the same whether a failure happens at the top level or inside a
 script: a `.save` that cannot write exits `4` as line 9 of a piped script exactly

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -658,7 +658,7 @@ wrong" from "that file would not load" without reading stderr.
 |:--|:--|:--|
 | `0` | success | — |
 | `1` | a statement ran and failed: a SQL error, a missing table, a constraint | the SQL |
-| `2` | the command line or the script was not accepted: an unknown flag, two flags that contradict, a dot-command in a `--sql-file`, a format that cannot carry the results | the invocation |
+| `2` | the command line or the script was not accepted: an unknown flag, two flags that contradict, a dot-command in a `--sql-file`, a script whose several result sets the chosen format cannot separate | the invocation |
 | `3` | an input could not be read: a missing path, an unsupported format, a download that failed or hit a limit, a malformed row under `--row-mismatch error` | the input |
 | `4` | a destination could not be written: a missing parent directory, a source with no writable form, a collision, a failed commit or rollback, a value or column set the chosen output format cannot represent — including when the destination is stdout | the destination |
 | `130` | SIGINT stopped the run — someone pressed Ctrl-C | — |


### PR DESCRIPTION
## What

Exit code `1` means a statement ran and failed, so a wrapper that reads it goes back to the SQL. `shell/exitcode.go` promises the classification comes from error types rather than message text, but four failures were returning plain `fmt.Errorf`/`errors.New` values and falling through `ExitCode` to `ExitFailure`.

| Failure | Before | Now |
|:--|:--|:--|
| `--output` or `.dump` names one of the run's source files | 1 | 4 |
| the output format cannot represent a value or a column set, to a file or to stdout | 1 | 4 |
| `--output-format` contradicts the destination's extension | 1 | 2 |
| `--inspect` with no input files | 1 | 2 |

No message text changed; only the type each failure is reported as.

## The format conflict also moved earlier

Both halves of it are on the command line, so nothing about the data can settle it. It is now checked before the import, which makes the answer stable when an input is also missing.

```
sqly --output-format csv --output m.json --sql "SELECT 1" nosuch.csv
# before: exit 3, "Import failed" on stderr
# now:    exit 2, nothing imported
```

The same contradiction inside a script depends on `.mode`, which is session state, so it stays a runtime check and is wrapped to exit 2 at the statement that hits it.

The other refusals `ResolveOutputTarget` makes — compression a format cannot carry, stacked codecs — describe the destination rather than the invocation, so they keep the class and the timing they had.

## Tests

Ten scenarios were added to `e2e/atago/exit_codes.atago.yaml`, each asserting the code numerically; this cluster had no exit-code assertions at all, which is why the misclassification survived. The decisive one is the missing-input case above: a 3 there would prove the check is still running after the import. Twelve existing scenarios that pinned the old codes were updated. Unit tests cover the classifier for the resolution path and the stdout print path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved validation for output formats and destination extensions before inputs are read.
  * Added clearer handling of output-source collisions and unsupported output values.
* **Bug Fixes**
  * Corrected exit codes for usage errors and output failures, including `--inspect` without inputs.
  * Improved diagnostics for output conflicts in commands and scripts.
* **Documentation**
  * Added migration guidance and updated reference documentation for validation behavior and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->