### PR TITLE
docs: repair comments that lost their referents

### DIFF
--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -584,7 +584,7 @@ func (t *Table) printTable(out io.Writer) error {
 
 // markdownCell renders a cell for a Markdown table. A "|" is escaped so it does
 // not start a new column, and an embedded newline is replaced with "<br>" so a
-// multi-line value stays on one physical row instead of breaking the table. Ref
+// multi-line value stays on one physical row instead of breaking the table.
 func markdownCell(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.ReplaceAll(s, "\r", "\n")
@@ -676,8 +676,7 @@ func (t *Table) writeDelimited(out io.Writer, comma rune) error {
 // printLTSV print all record with header; output format is ltsv. LTSV has no
 // escaping mechanism: a tab separates fields and a newline ends a record, so a
 // value containing either cannot be represented losslessly. Reject such a value
-// up front instead of emitting output that no longer round-trips as LTSV. Ref
-// ,.
+// up front instead of emitting output that no longer round-trips as LTSV.
 func (t *Table) printLTSV(out io.Writer) error {
 	if err := EnsureLTSVHeaderWritable(t.Header()); err != nil {
 		return err

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -37,11 +37,11 @@ var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 //
 // Execution is fail-fast: the first failed statement or helper command stops
 // the run and returns an error, so later statements never execute and their
-// output cannot leak into a pipeline that the process then reports as failed
-// (). A ".exit" command stops early with success, mirroring the
-// interactive shell. ranAny reports whether at least one statement or command
-// was executed, so callers can skip post-run side effects (e.g. a .save
-// write-back) for an empty batch ().
+// output cannot leak into a pipeline that the process then reports as failed.
+// A ".exit" command stops early with success, mirroring the interactive shell.
+// ranAny reports whether at least one statement or command was executed, so
+// callers can skip post-run side effects (e.g. a .save write-back) for an empty
+// batch.
 func (s *Shell) runScriptElements(ctx context.Context, elements []scriptElement) (ranAny bool, err error) {
 	var failErr error
 	for i, element := range elements {
@@ -549,10 +549,6 @@ func withMainVerb(stmt string) string {
 	return ""
 }
 
-// readSQLFile reads the SQL script at path for --sql-file. It returns a clear
-// error for a missing or unreadable file (wrapping the OS error so callers can
-// inspect it with errors.Is) and rejects a file with no SQL, so an empty or
-// whitespace-only script fails loudly instead of running nothing.
 // readScriptFile reads a --script-file. It is the sibling of readSQLFile and
 // differs in what counts as empty: a script whose only content is dot-commands
 // has no SQL statement and is perfectly valid, so the "no executable SQL" check
@@ -571,6 +567,10 @@ func readScriptFile(path string) (string, error) {
 	return content, nil
 }
 
+// readSQLFile reads the SQL script at path for --sql-file. It returns a clear
+// error for a missing or unreadable file (wrapping the OS error so callers can
+// inspect it with errors.Is) and rejects a file with no SQL, so an empty or
+// whitespace-only script fails loudly instead of running nothing.
 func readSQLFile(path string) (string, error) {
 	// The two kinds of failure below are told apart deliberately. A path that
 	// cannot be read is a problem with the file, like any other input; a file that

--- a/shell/import.go
+++ b/shell/import.go
@@ -593,12 +593,12 @@ func validatePath(path string) (string, error) {
 	cleanPath := filepath.Clean(path)
 
 	// No directory-depth limit: sqly is a local CLI run with the user's own
-	// permissions, so legitimate deeply nested workspace paths must import. Ref
+	// permissions, so legitimate deeply nested workspace paths must import.
 
 	// Check for dangerous patterns that could indicate path traversal attacks.
 	// URL-encoded sequences (..%2f, ..%5c) are intentionally NOT matched: the
 	// filesystem never URL-decodes a path, so those bytes only ever appear in a
-	// legitimate literal filename, and matching them rejected real files. Ref
+	// legitimate literal filename, and matching them rejected real files.
 	dangerousPatterns := []string{
 		"../../../",    // Multiple levels up
 		"..\\..\\..\\", // Windows path traversal

--- a/shell/save.go
+++ b/shell/save.go
@@ -275,8 +275,8 @@ func (s *Shell) applySymlinkPolicy(destDir string, targets []writeTarget, follow
 // planWriteBack validates that every current table can be written and returns the
 // resolved write targets. It reports all problems at once and writes nothing, so
 // a session is never partially saved. For .save DIR it also rejects a
-// destination that resolves to the source file () and a destination that
-// already exists ().
+// destination that resolves to the source file, and one that already exists.
+//
 // skipUnchanged selects whether an unchanged table is dropped from the plan. An
 // actual save passes true (persist only real changes); preflight passes false
 // (validate every file-backed table up front, before any change has happened).

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -117,8 +117,7 @@ type Shell struct {
 	// dataChanged is set when an executed statement actually changed table data
 	// (a DML that affected at least one row, or a DML RETURNING that returned at
 	// least one row). A non-interactive run only writes back when data changed, so
-	// an EXPLAIN or a zero-row DML leaves source files untouched.,
-	//,.
+	// an EXPLAIN or a zero-row DML leaves source files untouched.
 	dataChanged bool
 	// importBaseline maps an imported file-backed table name to a fingerprint of
 	// its content as loaded, and never moves. It answers "has this session changed
@@ -1237,8 +1236,7 @@ func (s *Shell) execSQL(ctx context.Context, req string) error {
 		return s.withMissingNameHint(ctx, err)
 	}
 	// Track whether this statement actually changed data, so write-back runs only
-	// for a run that modified a table (not an EXPLAIN or a zero-row DML).,
-	//,,.
+	// for a run that modified a table (not an EXPLAIN or a zero-row DML).
 	if statementModifiesData(req) {
 		if table != nil {
 			if table.RowCount() > 0 {


### PR DESCRIPTION
## What

Six comments in the codebase referred to something that is no longer there. Stripping the issue references out of them left the surrounding sentence broken rather than shorter, so what a reader now meets is punctuation with nothing behind it.

- `shell/shell.go`: two comment lines had decayed to `//,.` and `//,,.`
- `shell/import.go`, `domain/model/table.go`: sentences ending in a bare `Ref`
- `shell/batch.go`, `shell/save.go`: an empty `()` where a number used to sit

`readSQLFile`'s doc comment had also drifted onto `readScriptFile`. godoc therefore described the wrong function, and `readSQLFile` — the one with the more surprising contract, since it rejects a comment-only file — had no comment at all. It is moved back onto the function it describes.

## Why

A comment that trails off is worse than no comment: it tells a reader that something was meant to be said and does not say it, and nothing in the build or the tests will ever notice. These are the first thing anyone reads when they open the write-back and batch paths, which are the two most intricate parts of the shell.

## Testing

`go build ./...`, `go vet ./...`, `gofmt -l .`, and `go test ./...` all pass. Comments only; no statement changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comments for batch execution, SQL file handling, import validation, write-back planning, and shell behavior.
  * Removed stray text and punctuation from internal documentation.
  * No user-visible functionality or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->