### PR TITLE
fix: stop the prompt from walking up the screen when an earlier line is edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Upgrading between candidates: [doc/migration.md](doc/migration.md).
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* Editing an earlier line of a buffered statement no longer walks the prompt up the screen. Pressing the left arrow across a line break, and every keystroke after it, redrew the prompt one row too high and took a line of scrollback with it: after a dozen keystrokes sqly's own banner was gone. The prompt library erased the block it had drawn by moving up its height, which is where the cursor is only while it sits on the last line. Fixed in prompt v0.0.14, which also stopped measuring the terminal by writing to it and reading the reply back out of the input stream — a keystroke typed during a redraw could be consumed with that reply, and a terminal that did not answer cost 100ms of every redraw. sqly's interactive pty suite runs in a second where it took over a minute.
+
 ## [v1.0.0-rc4](https://github.com/nao1215/sqly/compare/v1.0.0-rc3...v1.0.0-rc4) (2026-08-05)
 
 A release candidate for v1.0.0, not the final one. Everything below is a change

--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -450,3 +450,63 @@ scenarios:
             - send: { key: ctrl-d }
       - assert:
           exit_code: 0
+
+  # Editing an earlier line of a buffered statement leaves the screen alone. The
+  # renderer erased the block it had drawn by moving up its height, which is
+  # where the cursor is only while it sits on the last line; a left arrow
+  # crossing the line break put it on the first, so every keystroke after that
+  # erased one row too high and the prompt walked up the screen, taking a line of
+  # scrollback with it each time. Fixed in prompt v0.0.14.
+  #
+  # The banner sqly prints at startup is what the climb ate, so it is what the
+  # screen is checked for: after sixteen left arrows it is still there, above a
+  # prompt still holding both lines of the statement.
+  - name: editing an earlier line leaves the lines above the prompt alone
+    steps:
+      - fixture: *capability_people
+      - pty:
+          command: sqly people.csv
+          rows: 12
+          cols: 80
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: "SELECT name\r"
+            - expect: '\.\.\.>'
+            - send: "FROM people"
+            - expect: "FROM people"
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            - send: { key: left }
+            # Typing here is the barrier: the character lands where the sixteen
+            # arrows left the cursor, so seeing it proves every one of them has
+            # been processed and the screen below is the settled one.
+            - send: "X"
+            - expect: "SELECT Xname"
+            # The screen is checked while the statement is still being edited:
+            # after the exit below it holds neither line.
+            - expect_screen:
+                contains: 'enter "SQL query" or "sqly command that begins with a dot".'
+            - expect_screen:
+                contains: ".help print usage, .exit exit sqly."
+            - expect_screen:
+                contains: "...> FROM people"
+            # Ctrl-U clears the line so Ctrl-D is read as end of input rather
+            # than as a delete.
+            - send: { key: ctrl-u }
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.27
 	github.com/nao1215/filesql v0.34.0
-	github.com/nao1215/prompt v0.0.13
+	github.com/nao1215/prompt v0.0.14
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/nao1215/fileparser v0.5.2 h1:IXhH5m3UJf/TMidfTcVen8CSlZ4KEFEgBz6+2o+5
 github.com/nao1215/fileparser v0.5.2/go.mod h1:Jb16QbtYfgzQ2BR+UOVNSa1WeKMP2o+xnwBYFUNAG2Y=
 github.com/nao1215/filesql v0.34.0 h1:Z2u2jU+q+d3Fc4V3rNsurxIm5xiKoc47vGBAqRzyUX8=
 github.com/nao1215/filesql v0.34.0/go.mod h1:eL54cR7WUkLU8uskeLy5xFCp3PywFyDghAfGhCJU6R4=
-github.com/nao1215/prompt v0.0.13 h1:a94GZTfuz+f9Z2AXmMh5ediOPM5j25nS646gyeC+ofM=
-github.com/nao1215/prompt v0.0.13/go.mod h1:jcU0SPfCTCBHDQ4Uu0n7ZLrV/+hGXVJ64YRV2aKnqxA=
+github.com/nao1215/prompt v0.0.14 h1:/Lrnw0z9juWaXRJlqF5RleE4+llJABiPksBxdn1j2QE=
+github.com/nao1215/prompt v0.0.14/go.mod h1:jcU0SPfCTCBHDQ4Uu0n7ZLrV/+hGXVJ64YRV2aKnqxA=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=


### PR DESCRIPTION
Reported against the shell: write a `SELECT`, press the left arrow, and the prompt line moves up, taking the line above it with it. Every keystroke after that moves it up again — sixteen arrows ate the banner and two more lines of scrollback.

The cause is in the prompt library and is fixed in [prompt v0.0.14](https://github.com/nao1215/prompt/pull/23). A redraw erased the block it had drawn by moving up the block's height, which is where the cursor is only while it sits on the block's last row. A left arrow crossing a line break puts it on an earlier row, so the erase started above the block and the redraw landed a row high.

That release carries a second fix found while chasing this one. The terminal was measured with go-tty's `Size`, which asks the terminal for its size in pixels — it writes `\x1b[14t` and reads the reply back from the input handle — whenever the kernel reports no pixel dimensions, the normal case under tmux and most terminals. A keystroke typed while that read was waiting was consumed with the reply and never arrived, and a terminal that does not answer cost the full 100ms read timeout on every redraw. sqly's interactive pty suite went from 74s to 0.9s, and `make smoke` from 128s to 8s.

## The regression scenario

`e2e/atago/pty.atago.yaml` gains one scenario: buffer a two-line statement, walk the cursor back onto the first line with sixteen left arrows, and check that the banner sqly printed at startup is still on the screen with both lines of the statement below it.

It types a character after the arrows and waits for it in the transcript before looking at the screen. Without that barrier the screen check races the keystrokes — it passed against the broken library by reading a frame from before the climb.

Verified both ways: the scenario fails against prompt v0.0.13 and passes against v0.0.14.

## Follow-up, not in this PR

`scripts/run_e2e.sh` runs the pty specs serially with five retries and `--allow-flaky`, a workaround for interactive input being lost. The swallowed-keystroke half of the prompt fix is a plausible cause of that, so the tolerance may no longer be needed — but the platform it was added for is Windows ConPTY ([prompt#13](https://github.com/nao1215/prompt/issues/13)), and dropping the net is worth its own change with its own Windows CI evidence.

`make test`, `make smoke`, `sh scripts/run_e2e.sh`, and `make lint` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multiline editing so earlier buffered lines no longer shift the prompt upward or remove scrollback.
  * Improved terminal redraw behavior to prevent lost keystrokes and unnecessary delays on unresponsive terminals.

* **Tests**
  * Added end-to-end coverage for editing multiline SQL statements while preserving screen content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->