### PR TITLE
test(e2e): stop tolerating a flaky pty pass

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+# The suite only reads the repository and runs the binary it builds.
+permissions:
+  contents: read
+
 jobs:
   atago:
     name: atago (binary e2e)

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -50,8 +50,12 @@ jobs:
   # has open, which is every in-place save, and no Unix run can show that.
   #
   # The pty specs run as a second, serialized pass. atago >= v0.7.0 drives a
-  # ConPTY on Windows, and the concurrent sessions starve each other otherwise;
-  # --retry-failed is a safety net against CPU-starvation flakes.
+  # ConPTY on Windows, and the concurrent sessions starve each other otherwise.
+  # That pass does not retry: a keystroke this platform loses is a bug to fix.
+  # It used to, because ConPTY dropped input delivered while the prompt was being
+  # redrawn — the prompt library spent up to 100ms of every redraw reading the
+  # input handle for a terminal size reply, and swallowed what was typed into it.
+  # prompt v0.0.14 stopped doing that.
   atago-windows:
     name: atago (binary e2e) (windows-latest)
     runs-on: windows-latest
@@ -97,4 +101,4 @@ jobs:
           export USERPROFILE="$HOME"
           export SQLY_HISTORY_DB_PATH="$RUNNER_TEMP/history.db"
           mkdir -p "$HOME"
-          atago run --ci --parallel 1 --retry-failed 5 ./e2e/atago/pty.atago.yaml
+          atago run --ci --parallel 1 --retry-failed 0 ./e2e/atago/pty.atago.yaml

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -74,21 +74,21 @@ export PATH
 # either pass surfaces; the last successful run's exit status is the script's.
 #
 # The interactive-shell pty specs (e2e/atago/pty.atago.yaml drives sqly's readline
-# REPL over a pty) are split from the rest of the suite. The prompt is re-rendered a
-# beat before its read loop is ready, so a keystroke sent right after can be lost
-# when the pty sessions are starved of CPU by the other scenarios running in
-# parallel. The rest of the suite runs in parallel; the pty specs then run on their
-# own with --parallel 1 so each session gets uncontended CPU, and with extra
-# retries.
+# REPL over a pty) run on their own, serially, so each session has the terminal to
+# itself. Nothing here retries: a lost keystroke is a bug to fix, not a verdict to
+# tolerate.
 #
-# Only the pty pass retries, and only it accepts a flaky verdict. As of atago
-# v0.18.0 a recovered scenario fails the run unless --allow-flaky says the
-# instability is expected, which is exactly the split wanted here: the pty
-# sessions lose keystrokes under CPU starvation and that is known, while the
-# non-pty specs assert fixed output from a subprocess and have no timing to lose.
+# They used to run with five retries and --allow-flaky, because a keystroke sent
+# right after the prompt appeared could be lost when the sessions were starved of
+# CPU. The cause was in the prompt library, not in the timing: measuring the
+# terminal went through go-tty's Size, which asks the terminal for its pixel size
+# by writing an escape sequence and reading the reply back out of the input
+# handle. Every redraw spent up to 100ms in that read and swallowed whatever was
+# typed while it waited. prompt v0.0.14 measures with an ioctl instead, and the
+# suite went from 74 seconds to under one — the seconds were the lost keystrokes.
 #
-# Before that split, one --retry-failed covered the whole suite and quietly
-# extended tolerance to every spec: filesql built an LTSV table's column list by
+# A retry budget hides the next such bug. One --retry-failed once covered the
+# whole suite and did exactly that: filesql built an LTSV table's column list by
 # ranging over a map, so `SELECT *` answered in a different order on every run,
 # and the retries turned that into "flaky, PASSED" instead of a failure.
 PTY_SPEC="$ROOT/e2e/atago/pty.atago.yaml"
@@ -174,11 +174,11 @@ if spec_group_matches_filter $NON_PTY_SPECS; then
 fi
 if spec_group_matches_filter "$PTY_SPEC"; then
 	ran_any=true
-	atago run --ci --parallel 1 --retry-failed 5 --allow-flaky "$@" "$PTY_SPEC"
+	atago run --ci --parallel 1 --retry-failed 0 "$@" "$PTY_SPEC"
 fi
 if [ "$ran_any" = false ]; then
 	# Neither group matched, so nothing was selected; run everything and let atago
-	# report the empty selection. The pty retry count applies because this pass
-	# includes the pty spec.
-	atago run --ci --parallel 1 --retry-failed 5 --allow-flaky "$@" $NON_PTY_SPECS "$PTY_SPEC"
+	# report the empty selection. It runs serially because this pass includes the
+	# pty spec.
+	atago run --ci --parallel 1 --retry-failed 0 "$@" $NON_PTY_SPECS "$PTY_SPEC"
 fi


### PR DESCRIPTION
The measurement behind [prompt#13](https://github.com/nao1215/prompt/issues/13), which describes interactive input being lost between a render and the read that should have received it.

The pty specs have carried a flakiness budget since they were written: five retries, `--allow-flaky` locally, and a serialized pass so the sessions were not starved of CPU. The starvation was real but it was not the cause. Measuring the terminal went through go-tty's `Size`, which falls back to asking the terminal for its size in pixels — it writes `\x1b[14t` and reads the reply back **from the input handle** — whenever the kernel reports no pixel dimensions, which is the normal case under a pty. Every redraw therefore spent up to 100ms reading input and throwing away whatever was typed into that window. A keystroke sent right after the prompt appeared landed in exactly that window.

prompt v0.0.14 measures with an ioctl on the terminal's own descriptor instead. sqly's pty suite went from 74s to 0.9s on that change alone: the seconds were the lost keystrokes.

So this drops the tolerance and lets CI answer whether anything is left:

- `scripts/run_e2e.sh`: the pty pass runs `--retry-failed 0` with no `--allow-flaky`.
- `.github/workflows/e2e_test.yml`: the Windows ConPTY pty pass runs `--retry-failed 0`.

Both keep `--parallel 1` for the pty specs. Serializing is not a masking device — a terminal session deserves the terminal to itself — while a retry budget that absorbs nothing only hides the next bug. That is not hypothetical here: before the pty split existed, one blanket `--retry-failed` turned a filesql map-ordering defect into "flaky, PASSED", which is recorded in the runner's own comments.

Windows is the platform prompt#13 said reproduced near-deterministically, so the `atago (binary e2e) (windows-latest)` job is the result that matters. Locally, 95 pty sessions (19 scenarios × 5 repeats, run in parallel) pass in 385ms with no retries.

The behavior specs keep `--retry-failed 3` on Windows. That is a different failure mode — process startup on a slow runner, not keystroke loss — and it deserves its own measurement rather than being folded into this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Windows interactive-shell PTY tests now run serially without retries, making lost keystrokes fail immediately.
  * End-to-end test documentation now explains the non-retry policy and terminal input handling improvements.
  * PTY and fallback test runs consistently use non-retry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->