### PR TITLE
docs: prepare the v1.0.0-rc5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Release candidates and what v1.0.0 freezes
 
-`v1.0.0-rc4` is the current release candidate, and it is not the final contract
+`v1.0.0-rc5` is the current release candidate, and it is not the final contract
 either. Breaking changes are still being made, and they are being made now
 rather than after v1.0.0.
 
@@ -14,16 +14,33 @@ rather than after v1.0.0.
   Changes below.
 
 The final RC is announced as the final one in its release notes. That is the
-point to pin a version against; none of rc1 through rc4 is it.
+point to pin a version against; none of rc1 through rc5 is it.
 
 Upgrading between candidates: [doc/migration.md](doc/migration.md).
 
-## [Unreleased]
+## [v1.0.0-rc5](https://github.com/nao1215/sqly/compare/v1.0.0-rc4...v1.0.0-rc5) (2026-08-06)
+
+A release candidate for v1.0.0, not the final one. Everything below is a change
+from rc4.
+
+Upgrading from rc4: [doc/migration.md](doc/migration.md).
+
+The theme of this one is the interactive shell, and what an export does with a
+value it cannot write. Ctrl-C could not reach a running statement and ended the
+session instead of the line; a ";" was a terminator wherever it appeared, so a
+trigger could not be typed and a trailing comment was never submitted; a line
+holding several statements printed one of their results. Two exports answered an
+unwritable value by failing with a parser error nobody could act on, or by
+changing the value and saying nothing. And a URL's password was printed back on
+both streams.
+
+### Breaking Changes
+
+* Exporting to Excel refuses a value XLSX cannot carry, where it used to change it. XLSX is XML, and XML 1.0 has no way to write a control character other than tab, newline, and carriage return, nor the noncharacters `U+FFFE` and `U+FFFF`; the writer substituted `U+FFFD` for the rest, so the export succeeded, the file appeared, and the byte was gone. It now exits `4`, names the character, and leaves the destination exactly as it was — the contract every other format already followed, and the one the exit-code table already documented. A pipeline that exported such data and got a file now gets a failure; csv, tsv, and json carry the same values unchanged.
+* A password carried in a remote URL is redacted in everything sqly prints. `--inspect` wrote it into the `source` field on stdout — the document people commit, attach, and paste — and every message about a download repeated the URL as given on stderr, alongside Go's own error, which redacts it. All of them now show `user:xxxxx@`. A program that read `source` and re-fetched from it has to keep the URL it passed in; the redaction is a display of the source, not a handle to it. Command history still records the line as typed, so the up-arrow returns something runnable.
 
 ### Bug Fixes
 
-* A password carried in a remote URL is no longer printed back. Every message about a download repeated the URL as given, so a failed import wrote the secret to stderr — undoing the redaction Go's own transport error performs — and the `--inspect` report wrote it to stdout, the document people attach and paste. Messages, the `--allow-remote` refusal, and the report now show `user:xxxxx@`. Command history still records the line as typed, which the shell page now says.
-* Exporting to Excel refuses a value XLSX cannot carry instead of changing it. XLSX is XML, and XML 1.0 has no way to write most control characters, so the writer substituted `U+FFFD`: the export succeeded, the file appeared, and the byte was gone. It now fails with exit code 4, names the character, and leaves the destination exactly as it was — the contract every other format already followed, and the one the reference documents. Tab, newline, and carriage return are the three XML keeps, so a value holding them still exports.
 * Exporting to Parquet no longer fails on a value SQLite cannot parse as a literal. The export stages the result in a temporary database, and it built that INSERT as SQL text with every value quoted into it, so a NUL byte — which ends a statement as far as SQLite's tokenizer is concerned — left the literal unclosed: a CSV carrying one exported to every other format and failed Parquet with `unrecognized token`, naming a token nobody typed. Values are bound now, which also parses the statement once for the export instead of once per row.
 * A result printed for a statement typed across a continuation line keeps its last line. The prompt that followed it erased one row per row the entry had occupied, so a two-line statement ate the last line of its own result — a table lost its bottom border, while the same query typed on one line kept it. Fixed in prompt v0.0.17.
 * Ctrl-C now stops a statement that is already running. The prompt holds the terminal in raw mode, where Ctrl-C is a byte rather than a signal, and between prompts nothing was reading it: the key could not reach a running statement at all. It waited in the input buffer while the query ran to completion, however long that took, and was then read as the next line. A canceled statement rolls back and the session carries on, so canceling is not a failure and the session still exits 0. Needs prompt v0.0.16.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedw
 
 Documentation: **https://nao1215.github.io/sqly/**
 
-This documentation describes `v1.0.0-rc4`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, and now stdout carrying nothing but data in every machine-readable format — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) and the [migration guide](./doc/migration.md) before upgrading.
+This documentation describes `v1.0.0-rc5`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, and now an export that refuses a value it cannot write rather than changing it — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) and the [migration guide](./doc/migration.md) before upgrading.
 
 ![demo](./doc/img/demo.gif)
 
@@ -91,7 +91,7 @@ sqly --inspect user.csv
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc4",
+  "sqly_version": "v1.0.0-rc5",
   "tables": [
     {
       "name": "user",

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -7,6 +7,58 @@ The [CHANGELOG](../CHANGELOG.md) records every change. This file records the one
 that require an edit to a command line, a script, or a program that reads sqly's
 output.
 
+## v1.0.0-rc4 → v1.0.0-rc5
+
+### An Excel export refuses a value XLSX cannot carry
+
+XLSX is XML, and XML 1.0 has no way to write a control character other than tab,
+newline, and carriage return, nor the noncharacters `U+FFFE` and `U+FFFF`. The
+writer used to substitute `U+FFFD` for them, so the export succeeded and the byte
+was gone.
+
+```text
+Before rc5:
+  printf 'id,v\n1,A\x01B\n' > ctl.csv
+  sqly --output-format excel --output out.xlsx --sql "SELECT * FROM ctl" ctl.csv
+  # exit 0, and out.xlsx holds "A\uFFFDB"
+
+From rc5:
+  # excel: value for column "v" contains the character U+0001,
+  # which XLSX cannot represent; remove it or export to csv/tsv/json
+  # exit 4, and out.xlsx is untouched
+```
+
+**What to change:** a pipeline that exported such data and got a file now has to
+handle a failure. Strip the character in SQL — `replace(v, char(1), '')` — or
+export to csv, tsv, or json, which carry it unchanged. Tab, newline, and carriage
+return still export.
+
+### A password in a remote URL is redacted in what sqly prints
+
+`--inspect` wrote the URL as given into `tables[].source`, and every message about
+a download repeated it. Both now show what `url.Redacted` gives.
+
+```text
+Before rc5:
+  sqly --allow-remote --inspect "https://user:secret@host/data.csv"
+  # "source": "https://user:secret@host/data.csv"
+
+From rc5:
+  # "source": "https://user:xxxxx@host/data.csv"
+```
+
+**What to change:** a program that read `source` and fetched from it keeps the URL
+it passed in instead. The field is a display of where a table came from, not a
+handle to re-open it. A local path is unaffected — only `http` and `https` are
+rewritten, so a Windows path keeps its drive letter.
+
+### Ctrl-C in the interactive shell
+
+Not a change to a command line, but to what the key does. It used to end the
+session with exit code `1`; it now discards the line being typed, and stops a
+statement that is already running. A canceled statement rolls back and the
+session carries on, so a session that ends normally afterward still exits `0`.
+
 ## v1.0.0-rc3 → v1.0.0-rc4
 
 ### `excel_sheets[].source` is an absolute path

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -1880,6 +1880,57 @@ func TestMigrationGuide_ExplainsRc2ToRc3(t *testing.T) {
 	}
 }
 
+// TestMigrationGuide_ExplainsRc4ToRc5 holds the guide to the changes an rc4
+// command line or wrapper has to absorb. A breaking change recorded only in the
+// CHANGELOG leaves the person upgrading to work out the edit themselves.
+func TestMigrationGuide_ExplainsRc4ToRc5(t *testing.T) {
+	t.Parallel()
+
+	guide := readDoc(t, migrationGuideFile)
+	if !strings.Contains(guide, "## v1.0.0-rc4 → v1.0.0-rc5") {
+		t.Fatalf("%s has no rc4 to rc5 section", migrationGuideFile)
+	}
+	flat := flatten(section(guide, "## v1.0.0-rc4 → v1.0.0-rc5"))
+
+	for _, claim := range []string{
+		"XLSX cannot represent",
+		"exit 4",
+		"csv, tsv, or json",
+		"tables[].source",
+		"user:xxxxx@",
+		"Ctrl-C",
+	} {
+		if !strings.Contains(flat, claim) {
+			t.Errorf("%s does not state: %s", migrationGuideFile, claim)
+		}
+	}
+}
+
+// TestCHANGELOG_ListsTheRc5BreakingChanges is the rc4 check for the release
+// after it: what the guide tells someone to change, the release notes have to
+// record.
+func TestCHANGELOG_ListsTheRc5BreakingChanges(t *testing.T) {
+	t.Parallel()
+
+	body := readDoc(t, "CHANGELOG.md")
+	rc5 := section(body, "## [v1.0.0-rc5]")
+	if rc5 == "" {
+		t.Fatal("CHANGELOG.md has no v1.0.0-rc5 section")
+	}
+	breaking := flatten(section(rc5, "### Breaking Changes"))
+	if breaking == "" {
+		t.Fatal("the v1.0.0-rc5 CHANGELOG entry has no Breaking Changes section")
+	}
+	for _, claim := range []string{"Excel", "U+FFFE", "source", "user:xxxxx@"} {
+		if !strings.Contains(breaking, claim) {
+			t.Errorf("the rc5 Breaking Changes section does not mention %s", claim)
+		}
+	}
+	if !strings.Contains(flatten(rc5), migrationGuideLink) {
+		t.Errorf("the rc5 CHANGELOG entry does not link the migration guide (%s)", migrationGuideLink)
+	}
+}
+
 // TestMigrationGuide_ExplainsRc3ToRc4 holds the guide to the changes an rc3
 // command line or wrapper has to absorb. A breaking change recorded only in the
 // CHANGELOG leaves the person upgrading to work out the edit themselves.

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -4,7 +4,7 @@ title: sqly
 
 sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedwire files. It loads them into an in-memory SQLite database, so joins, CTEs, window functions, and aggregates all work — across formats, in one query.
 
-This site describes `v1.0.0-rc4`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, and now stdout carrying nothing but data in every machine-readable format — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) and the [migration guide](https://github.com/nao1215/sqly/blob/main/doc/migration.md) before upgrading.
+This site describes `v1.0.0-rc5`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, and now an export that refuses a value it cannot write rather than changing it — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) and the [migration guide](https://github.com/nao1215/sqly/blob/main/doc/migration.md) before upgrading.
 
 ![sqly running a query against a CSV file](/img/demo.gif)
 

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -479,7 +479,7 @@ Every report opens with two fields that answer different questions:
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc4",
+  "sqly_version": "v1.0.0-rc5",
   "tables": []
 }
 ```
@@ -529,7 +529,7 @@ it has sheets, and nothing in `tables` says what is missing.
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc4",
+  "sqly_version": "v1.0.0-rc5",
   "tables": [],
   "excel_sheets": [
     {


### PR DESCRIPTION
Stamps everything the Unreleased section collected since rc4 was tagged as `v1.0.0-rc5`, dated, with the entries ordered the way a release reads: what breaks first.

## What rc5 is

The interactive shell, and what an export does with a value it cannot write.

Ctrl-C could not reach a running statement — raw mode makes it a byte, and between prompts nothing was reading it — so it waited in the buffer while the query ran to completion and then ended the session with exit 1. A `;` was a terminator wherever it appeared, so a trigger body could not be typed and a statement carrying a trailing comment was never submitted. A line holding several statements printed one of their results. A statement typed across a continuation line lost the last line of its own output. Pasting lost a TAB, doubled a CRLF, and Escape ate the next three characters typed.

Two exports answered a value they could not write badly: Parquet failed with a SQLite parser error naming a token nobody typed, and Excel changed the value and said nothing. And a password in a remote URL was printed back on both streams.

## Breaking changes, and the guide

Two entries moved up into Breaking Changes, because both change what a program downstream receives:

- an Excel export that used to return a file for data holding a control character now exits `4` and leaves the destination alone;
- `--inspect` reports a credentialed URL's `source` redacted, so a program that re-fetched from that field has to keep the URL it passed in.

`doc/migration.md` gains the rc4 → rc5 section: both of those with before/after commands and what to change, plus what Ctrl-C does now — not a command-line change, but a change to what the key does. `TestMigrationGuide_ExplainsRc4ToRc5` and `TestCHANGELOG_ListsTheRc5BreakingChanges` hold the guide and the release notes to each other, the way the rc3 and rc4 pairs already do.

## The rest

The README and site banners name rc5 and the contract it adds; the sample `--inspect` reports carry the version that writes them, which `TestREADMEVersionMatchesChangelog` checks against the CHANGELOG headings.

Tagging `v1.0.0-rc5` after this merges is what publishes the release.