### PR TITLE
docs: prepare the v1.0.0-rc6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Release candidates and what v1.0.0 freezes
 
-`v1.0.0-rc5` is the current release candidate, and it is not the final contract
+`v1.0.0-rc6` is the current release candidate, and it is not the final contract
 either. Breaking changes are still being made, and they are being made now
 rather than after v1.0.0.
 
@@ -14,11 +14,24 @@ rather than after v1.0.0.
   Changes below.
 
 The final RC is announced as the final one in its release notes. That is the
-point to pin a version against; none of rc1 through rc5 is it.
+point to pin a version against; none of rc1 through rc6 is it.
 
 Upgrading between candidates: [doc/migration.md](doc/migration.md).
 
-## [Unreleased]
+## [v1.0.0-rc6](https://github.com/nao1215/sqly/compare/v1.0.0-rc5...v1.0.0-rc6) (2026-08-06)
+
+A release candidate for v1.0.0, not the final one. Everything below is a change
+from rc5.
+
+Upgrading from rc5: [doc/migration.md](doc/migration.md).
+
+The theme of this one is what sqly writes and what it says about it, found by
+running the rc5 binary rather than by reading it. Two paths lost rows and said
+nothing: a one-column CSV or TSV result piped to a file, and an Excel export
+whose last row was empty. A column could be declared a type its own values were
+not stored as. Three refusals reported an exit code that named the wrong thing
+to fix, and four messages described sqly's insides rather than the query.
+
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedw
 
 Documentation: **https://nao1215.github.io/sqly/**
 
-This documentation describes `v1.0.0-rc5`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, and now an export that refuses a value it cannot write rather than changing it — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) and the [migration guide](./doc/migration.md) before upgrading.
+This documentation describes `v1.0.0-rc6`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, and now an export that refuses a value it cannot write rather than changing it — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) and the [migration guide](./doc/migration.md) before upgrading.
 
 ![demo](./doc/img/demo.gif)
 
@@ -91,7 +91,7 @@ sqly --inspect user.csv
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc5",
+  "sqly_version": "v1.0.0-rc6",
   "tables": [
     {
       "name": "user",

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -7,6 +7,90 @@ The [CHANGELOG](../CHANGELOG.md) records every change. This file records the one
 that require an edit to a command line, a script, or a program that reads sqly's
 output.
 
+## v1.0.0-rc5 → v1.0.0-rc6
+
+### A one-column CSV or TSV result writes `""` for an empty value
+
+The rule already applied to `--output`; stdout wrote a blank line, and a blank
+line is not a record, so the row vanished when the stream was read back.
+
+```text
+Before rc6:
+  sqly --output-format csv --sql "SELECT v FROM t" data.csv > out.csv
+  # a row whose v is empty became a blank line
+  sqly --sql "SELECT COUNT(*) FROM out" out.csv   # 2, from 3 rows
+
+From rc6:
+  # the row is written ""
+  sqly --sql "SELECT COUNT(*) FROM out" out.csv   # 3
+```
+
+**What to change:** nothing, unless a consumer matched the blank line. A row of
+several columns is unaffected; only a result of exactly one column changes.
+
+### An Excel export refuses a result whose last row is empty in every column
+
+A workbook stores cells, not rows, so such a row leaves nothing behind to say it
+was there and a reader stops at the last row with a value.
+
+```text
+Before rc6:
+  # 3 rows exported, 2 rows read back, exit 0
+
+From rc6:
+  # excel: the last row is empty in every column, and a workbook has no way to
+  # store it: the file would read back one row short
+  # exit 4, and no file is written
+```
+
+**What to change:** export to csv, tsv, json, or parquet, which carry the row, or
+add a column that is not empty (`SELECT *, 1 AS n`). An empty row anywhere but
+last is unaffected.
+
+### Three refusals exit `4` or `2` where they exited `1`
+
+`1` means a statement ran and failed. None of these ran anything.
+
+```text
+--output out.csv.bz2, out.parquet.gz, out.xlsx.gz   1 → 4
+.dialect oracle, .dialect a b                       1 → 2
+```
+
+**What to change:** a wrapper that read `1` as "the SQL was wrong" now sees `4`
+for a destination it cannot write and `2` for a command line it cannot accept.
+`--dialect oracle` on the command line already exited `2`.
+
+### A non-finite number is spelled `Infinity` in every format
+
+`--output-format json` already wrote `"Infinity"`; the text formats wrote Go's
+`+Inf`.
+
+```text
+Before rc6:
+  sqly --output-format csv --sql "SELECT 1e400 AS v"   # +Inf
+From rc6:
+  # Infinity
+```
+
+**What to change:** a consumer matching `+Inf` matches `Infinity`, `-Infinity`,
+or `NaN` instead.
+
+### A column's declared type matches what is stored in it
+
+`1_000` and `0x1p4` are numbers to Go's parser and not to SQLite's numeric
+affinity, and a datetime beside a number used to lose to it. Either way the
+column was reported as `INTEGER` or `REAL` while its values were stored as text.
+
+```text
+Before rc6:
+  # a column of "1_000" reported "type": "REAL", typeof() said text
+From rc6:
+  # "type": "TEXT", which is what the storage always was
+```
+
+**What to change:** nothing, unless a program depended on the wrong type. The
+values themselves never changed.
+
 ## v1.0.0-rc4 → v1.0.0-rc5
 
 ### An Excel export refuses a value XLSX cannot carry

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -1880,6 +1880,57 @@ func TestMigrationGuide_ExplainsRc2ToRc3(t *testing.T) {
 	}
 }
 
+// TestMigrationGuide_ExplainsRc5ToRc6 holds the guide to the changes an rc5
+// command line or wrapper has to absorb. A breaking change recorded only in the
+// CHANGELOG leaves the person upgrading to work out the edit themselves.
+func TestMigrationGuide_ExplainsRc5ToRc6(t *testing.T) {
+	t.Parallel()
+
+	guide := readDoc(t, migrationGuideFile)
+	if !strings.Contains(guide, "## v1.0.0-rc5 → v1.0.0-rc6") {
+		t.Fatalf("%s has no rc5 to rc6 section", migrationGuideFile)
+	}
+	flat := flatten(section(guide, "## v1.0.0-rc5 → v1.0.0-rc6"))
+
+	for _, claim := range []string{
+		"one column",
+		"last row is empty in every column",
+		"1 → 4",
+		"1 → 2",
+		"Infinity",
+		"declared type",
+	} {
+		if !strings.Contains(flat, claim) {
+			t.Errorf("%s does not state: %s", migrationGuideFile, claim)
+		}
+	}
+}
+
+// TestCHANGELOG_ListsTheRc6BreakingChanges is the rc5 check for the release
+// after it: what the guide tells someone to change, the release notes have to
+// record.
+func TestCHANGELOG_ListsTheRc6BreakingChanges(t *testing.T) {
+	t.Parallel()
+
+	body := readDoc(t, "CHANGELOG.md")
+	rc6 := section(body, "## [v1.0.0-rc6]")
+	if rc6 == "" {
+		t.Fatal("CHANGELOG.md has no v1.0.0-rc6 section")
+	}
+	breaking := flatten(section(rc6, "### Breaking Changes"))
+	if breaking == "" {
+		t.Fatal("the v1.0.0-rc6 CHANGELOG entry has no Breaking Changes section")
+	}
+	for _, claim := range []string{"out.csv.bz2", "last row is empty", "Infinity", "`4`"} {
+		if !strings.Contains(breaking, claim) {
+			t.Errorf("the rc6 Breaking Changes section does not mention %s", claim)
+		}
+	}
+	if !strings.Contains(flatten(rc6), migrationGuideLink) {
+		t.Errorf("the rc6 CHANGELOG entry does not link the migration guide (%s)", migrationGuideLink)
+	}
+}
+
 // TestMigrationGuide_ExplainsRc4ToRc5 holds the guide to the changes an rc4
 // command line or wrapper has to absorb. A breaking change recorded only in the
 // CHANGELOG leaves the person upgrading to work out the edit themselves.

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -4,7 +4,7 @@ title: sqly
 
 sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedwire files. It loads them into an in-memory SQLite database, so joins, CTEs, window functions, and aggregates all work — across formats, in one query.
 
-This site describes `v1.0.0-rc5`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, and now an export that refuses a value it cannot write rather than changing it — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) and the [migration guide](https://github.com/nao1215/sqly/blob/main/doc/migration.md) before upgrading.
+This site describes `v1.0.0-rc6`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, and now an export that refuses a value it cannot write rather than changing it — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) and the [migration guide](https://github.com/nao1215/sqly/blob/main/doc/migration.md) before upgrading.
 
 ![sqly running a query against a CSV file](/img/demo.gif)
 

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -479,7 +479,7 @@ Every report opens with two fields that answer different questions:
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc5",
+  "sqly_version": "v1.0.0-rc6",
   "tables": []
 }
 ```
@@ -529,7 +529,7 @@ it has sheets, and nothing in `tables` says what is missing.
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc5",
+  "sqly_version": "v1.0.0-rc6",
   "tables": [],
   "excel_sheets": [
     {


### PR DESCRIPTION
## Summary

Cuts v1.0.0-rc6 from the Unreleased section. The changes it releases were all found by exercising the rc5 binary: two silent row losses, a column type that did not match its own storage, three refusals reporting the wrong exit code, and four messages describing sqly's insides rather than the query.

## Changes

- `CHANGELOG.md`: the Unreleased section becomes the rc6 entry, and the release-candidate preamble names rc6.
- `doc/migration.md`: an rc5 to rc6 section covering the five changes that need an edit — the `""` a one-column CSV or TSV result now writes, the Excel export that refuses a last row empty in every column, the three refusals moving off exit `1`, the `Infinity` spelling, and the corrected column types.
- `docs_drift_test.go`: the rc6 pair of the checks each release adds, so the guide and the release notes cannot drift apart.
- `README.md`, `website/content/_index.md`, `website/content/reference.md`: the documented version.

## Design Decisions

The migration guide states what each change costs a caller rather than repeating the CHANGELOG's account of the bug. The three exit-code moves share one section, since a wrapper absorbs them the same way: `1` had meant "a statement ran and failed" for cases where nothing ran.