### PR TITLE
refactor: leave the adapter the one job nothing else does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ point to pin a version against; none of rc1 through rc6 is it.
 
 Upgrading between candidates: [doc/migration.md](doc/migration.md).
 
+## [Unreleased]
+
+### Refactoring
+* FileSQLAdapter carries only the methods sqly calls. Its Query, Exec, GetTableHeader, and LoadFile were reached by tests alone: the session runs SQL through the memory repository and imports through LoadFiles. The adapter's Query held a second scan loop over the same rows, so the two readers could have diverged with only a user to notice.
+
 ## [v1.0.0-rc6](https://github.com/nao1215/sqly/compare/v1.0.0-rc5...v1.0.0-rc6) (2026-08-06)
 
 A release candidate for v1.0.0, not the final one. Everything below is a change

--- a/infrastructure/filesql/adapter.go
+++ b/infrastructure/filesql/adapter.go
@@ -3,9 +3,7 @@ package filesql
 
 import (
 	"context"
-	"crypto/rand"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -19,13 +17,9 @@ import (
 )
 
 const (
-	opQuery      = "query"
-	opRows       = "rows"
-	opExec       = "exec"
-	opGetTables  = "get_tables"
-	opGetHeader  = "get_header"
-	opScanTable  = "scan_table"
-	opScanHeader = "scan_header"
+	opRows      = "rows"
+	opGetTables = "get_tables"
+	opScanTable = "scan_table"
 
 	errDatabaseNotInit = "database not initialized"
 	defaultSheetName   = "sheet"
@@ -265,11 +259,6 @@ func unnamedCause(err error) error {
 	return err
 }
 
-// LoadFile loads a single file into the database
-func (f *FileSQLAdapter) LoadFile(ctx context.Context, filePath string) error {
-	return f.LoadFiles(ctx, filePath)
-}
-
 // DumpACHFile reconstructs a complete ACH file at outputPath from the table set
 // registered under baseName, reflecting any UPDATEs applied to those tables in
 // the session. It reads the current rows from the shared session database that
@@ -292,82 +281,6 @@ func (f *FileSQLAdapter) DumpFedWireFile(ctx context.Context, baseName, outputPa
 		return errors.New(errDatabaseNotInit)
 	}
 	return filesql.DumpFedWire(ctx, f.sharedDB, baseName, outputPath)
-}
-
-// Query executes SQL query and returns Table model
-func (f *FileSQLAdapter) Query(ctx context.Context, query string) (*model.Table, error) {
-	if f.sharedDB == nil {
-		return nil, &FileSQLError{Op: opQuery, Err: "shared database not initialized"}
-	}
-
-	rows, err := f.sharedDB.QueryContext(ctx, query)
-	if err != nil {
-		return nil, &FileSQLError{Op: opQuery, Err: err.Error()}
-	}
-	defer func() { _ = rows.Close() }()
-
-	// Get column names
-	columns, err := rows.Columns()
-	if err != nil {
-		return nil, &FileSQLError{Op: "columns", Err: err.Error()}
-	}
-
-	header := model.NewHeader(columns)
-	var cells [][]model.Cell
-
-	// Scan all rows, keeping the driver's native value per cell. model.Cell
-	// derives the display string from it, so this path preserves SQLite's
-	// INTEGER/REAL/TEXT types and its NULLs the same way the memory repository
-	// does instead of flattening every value to a string here.
-	for rows.Next() {
-		values := make([]any, len(columns))
-		valuePtrs := make([]any, len(columns))
-		for i := range values {
-			valuePtrs[i] = &values[i]
-		}
-
-		if err := rows.Scan(valuePtrs...); err != nil {
-			return nil, &FileSQLError{Op: "scan", Err: err.Error()}
-		}
-
-		row := make([]model.Cell, len(columns))
-		for i, val := range values {
-			row[i] = model.NewCell(val)
-		}
-		cells = append(cells, row)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, &FileSQLError{Op: opRows, Err: err.Error()}
-	}
-
-	// Generate unique table name for query results to avoid conflicts
-	tableName := "query_result_" + generateRandomName()
-
-	table, err := model.NewTableFromCells(tableName, header, cells)
-	if err != nil {
-		return nil, &FileSQLError{Op: opQuery, Err: err.Error()}
-	}
-	return table, nil
-}
-
-// Exec executes SQL statement (INSERT, UPDATE, DELETE)
-func (f *FileSQLAdapter) Exec(ctx context.Context, statement string) (int64, error) {
-	if f.sharedDB == nil {
-		return 0, &FileSQLError{Op: opExec, Err: errDatabaseNotInit}
-	}
-
-	result, err := f.sharedDB.ExecContext(ctx, statement)
-	if err != nil {
-		return 0, &FileSQLError{Op: opExec, Err: err.Error()}
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return 0, &FileSQLError{Op: "rows_affected", Err: err.Error()}
-	}
-
-	return rowsAffected, nil
 }
 
 // GetTableNames returns all table names in the database
@@ -400,50 +313,6 @@ func (f *FileSQLAdapter) GetTableNames(ctx context.Context) ([]*model.Table, err
 	}
 
 	return tables, nil
-}
-
-// GetTableHeader returns header information for a specific table.
-// The tableName is safely quoted via QuoteIdentifier, so any non-empty
-// SQLite identifier (including names with spaces, hyphens, or starting
-// with digits) is accepted.
-func (f *FileSQLAdapter) GetTableHeader(ctx context.Context, tableName string) (*model.Table, error) {
-	if f.sharedDB == nil {
-		return nil, &FileSQLError{Op: opGetHeader, Err: errDatabaseNotInit}
-	}
-	if strings.TrimSpace(tableName) == "" {
-		return nil, &FileSQLError{Op: opGetHeader, Err: "table name is empty"}
-	}
-
-	// Get column info using PRAGMA
-	// nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query, go.lang.security.audit.sqli.gosql-sqli.gosql-sqli
-	query := "PRAGMA table_info(" + QuoteIdentifier(tableName) + ")" // #nosec G202
-	rows, err := f.sharedDB.QueryContext(ctx, query)
-	if err != nil {
-		return nil, &FileSQLError{Op: opGetHeader, Err: err.Error()}
-	}
-	defer func() { _ = rows.Close() }()
-
-	var columns []string
-	for rows.Next() {
-		var cid int
-		var name string
-		var dataType string
-		var notNull int
-		var defaultValue any
-		var pk int
-
-		if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &pk); err != nil {
-			return nil, &FileSQLError{Op: opScanHeader, Err: err.Error()}
-		}
-		columns = append(columns, name)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, &FileSQLError{Op: "rows", Err: err.Error()}
-	}
-
-	header := model.NewHeader(columns)
-	return model.NewTable(tableName, header, nil), nil
 }
 
 // Close closes the database connection
@@ -608,12 +477,4 @@ func IsExcelFile(filePath string) bool {
 	}
 
 	return strings.HasSuffix(lower, ".xlsx")
-}
-
-// generateRandomName generates a random 4-byte hex string.
-func generateRandomName() string {
-	const randomBytesLen = 4
-	randomBytes := make([]byte, randomBytesLen)
-	_, _ = rand.Read(randomBytes)
-	return hex.EncodeToString(randomBytes)
 }

--- a/infrastructure/filesql/adapter_test.go
+++ b/infrastructure/filesql/adapter_test.go
@@ -10,8 +10,54 @@ import (
 	"testing"
 
 	libfilesql "github.com/nao1215/filesql"
+	"github.com/nao1215/sqly/config"
+	"github.com/nao1215/sqly/domain/model"
+	"github.com/nao1215/sqly/domain/repository"
+	"github.com/nao1215/sqly/infrastructure/memory"
 	_ "modernc.org/sqlite"
 )
+
+// testAdapter is a FileSQLAdapter plus the read helpers the tests need.
+//
+// The adapter's job is loading files; reading them back is the memory
+// repository's, and that is the path a session actually takes. The adapter used
+// to carry its own Query/Exec/GetTableHeader with a second scan loop that only
+// tests reached, so a divergence between the two readers could not have been
+// noticed by anything but a user. Keeping the helpers here reads the rows
+// through the production repository and leaves the adapter with the one job.
+type testAdapter struct {
+	*FileSQLAdapter
+	repo repository.SQLite3Repository
+}
+
+// newTestAdapter returns an adapter over db together with the repository a
+// session reads that same database with.
+func newTestAdapter(db *sql.DB) *testAdapter {
+	return &testAdapter{
+		FileSQLAdapter: NewFileSQLAdapter(db),
+		repo:           memory.NewSQLite3Repository(config.MemoryDB(db)),
+	}
+}
+
+// LoadFile loads one file, the single-path case of LoadFiles.
+func (a *testAdapter) LoadFile(ctx context.Context, filePath string) error {
+	return a.LoadFiles(ctx, filePath)
+}
+
+// Query reads rows the way the session does.
+func (a *testAdapter) Query(ctx context.Context, query string) (*model.Table, error) {
+	return a.repo.Query(ctx, query)
+}
+
+// Exec runs a statement the way the session does.
+func (a *testAdapter) Exec(ctx context.Context, statement string) (int64, error) {
+	return a.repo.Exec(ctx, statement)
+}
+
+// GetTableHeader reads a table's column names the way the session does.
+func (a *testAdapter) GetTableHeader(ctx context.Context, tableName string) (*model.Table, error) {
+	return a.repo.Header(ctx, tableName)
+}
 
 func TestFileSQLAdapter_LoadFile(t *testing.T) {
 	t.Parallel()
@@ -36,7 +82,7 @@ Jane,30,Los Angeles`
 	defer func() { _ = sharedDB.Close() }()
 
 	// Create adapter
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 
 	// Test LoadFile
 	ctx := context.Background()
@@ -101,7 +147,7 @@ func TestFileSQLAdapter_LoadFileWithReservedKeywords(t *testing.T) {
 	defer func() { _ = sharedDB.Close() }()
 
 	// Create adapter
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 
 	// Test LoadFile with reserved keywords
 	ctx := context.Background()
@@ -160,7 +206,7 @@ Jane,30,Los Angeles`
 	defer func() { _ = sharedDB.Close() }()
 
 	// Create adapter
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 
 	// Test LoadFile with empty column name - this should handle gracefully
 	ctx := context.Background()
@@ -172,60 +218,6 @@ Jane,30,Los Angeles`
 		// If it fails, the error should be informative
 		if !strings.Contains(err.Error(), "column") {
 			t.Errorf("Error should mention column issue, got: %v", err)
-		}
-	}
-}
-
-func TestFileSQLAdapter_Query(t *testing.T) {
-	t.Parallel()
-
-	// Create shared database with test data
-	sharedDB, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("Failed to create shared database: %v", err)
-	}
-	defer func() { _ = sharedDB.Close() }()
-
-	// Create test table
-	_, err = sharedDB.ExecContext(context.Background(), `CREATE TABLE test_table (id INTEGER, name TEXT, age INTEGER)`)
-	if err != nil {
-		t.Fatalf("Failed to create test table: %v", err)
-	}
-
-	// Insert test data
-	_, err = sharedDB.ExecContext(context.Background(), `INSERT INTO test_table VALUES (1, 'John', 25), (2, 'Jane', 30)`)
-	if err != nil {
-		t.Fatalf("Failed to insert test data: %v", err)
-	}
-
-	// Create adapter
-	adapter := NewFileSQLAdapter(sharedDB)
-
-	// Test Query
-	ctx := context.Background()
-	table, err := adapter.Query(ctx, "SELECT * FROM test_table ORDER BY id")
-	if err != nil {
-		t.Fatalf("Query failed: %v", err)
-	}
-
-	// Verify results
-	if len(table.Records()) != 2 {
-		t.Errorf("Expected 2 records, got %d", len(table.Records()))
-	}
-
-	expectedHeaders := []string{"id", "name", "age"}
-	actualHeaders := table.Header()
-	if len(actualHeaders) != len(expectedHeaders) {
-		t.Errorf("Expected %d headers, got %d", len(expectedHeaders), len(actualHeaders))
-	}
-
-	// Verify first record
-	if len(table.Records()) > 0 {
-		firstRecord := table.Records()[0]
-		if len(firstRecord) >= 3 {
-			if firstRecord[0] != "1" || firstRecord[1] != "John" || firstRecord[2] != "25" {
-				t.Errorf("First record data mismatch: got %v", firstRecord)
-			}
 		}
 	}
 }
@@ -252,7 +244,7 @@ func TestFileSQLAdapter_GetTableNames(t *testing.T) {
 	}
 
 	// Create adapter
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 
 	// Test GetTableNames
 	ctx := context.Background()
@@ -277,52 +269,6 @@ func TestFileSQLAdapter_GetTableNames(t *testing.T) {
 	}
 }
 
-func TestFileSQLAdapter_Exec(t *testing.T) {
-	t.Parallel()
-
-	// Create shared database
-	sharedDB, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("Failed to create shared database: %v", err)
-	}
-	defer func() { _ = sharedDB.Close() }()
-
-	// Create adapter
-	adapter := NewFileSQLAdapter(sharedDB)
-
-	// Test Exec - CREATE TABLE
-	ctx := context.Background()
-	rowsAffected, err := adapter.Exec(ctx, "CREATE TABLE test_exec (id INTEGER, name TEXT)")
-	if err != nil {
-		t.Fatalf("Exec CREATE TABLE failed: %v", err)
-	}
-
-	// CREATE TABLE typically returns 0 rows affected
-	if rowsAffected != 0 {
-		t.Logf("CREATE TABLE returned %d rows affected (expected 0, but this may vary)", rowsAffected)
-	}
-
-	// Test Exec - INSERT
-	rowsAffected, err = adapter.Exec(ctx, "INSERT INTO test_exec VALUES (1, 'test')")
-	if err != nil {
-		t.Fatalf("Exec INSERT failed: %v", err)
-	}
-
-	if rowsAffected != 1 {
-		t.Errorf("Expected 1 row affected by INSERT, got %d", rowsAffected)
-	}
-
-	// Test Exec - UPDATE
-	rowsAffected, err = adapter.Exec(ctx, "UPDATE test_exec SET name = 'updated' WHERE id = 1")
-	if err != nil {
-		t.Fatalf("Exec UPDATE failed: %v", err)
-	}
-
-	if rowsAffected != 1 {
-		t.Errorf("Expected 1 row affected by UPDATE, got %d", rowsAffected)
-	}
-}
-
 func TestNewFileSQLAdapter(t *testing.T) {
 	t.Parallel()
 
@@ -334,7 +280,7 @@ func TestNewFileSQLAdapter(t *testing.T) {
 	defer func() { _ = sharedDB.Close() }()
 
 	// Test NewFileSQLAdapter
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 
 	if adapter == nil {
 		t.Fatal("NewFileSQLAdapter returned nil")
@@ -507,7 +453,7 @@ Jane,value2,Los Angeles`
 	defer func() { _ = sharedDB.Close() }()
 
 	// Create adapter
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 
 	// Test LoadFile with quotes in column names
 	ctx := context.Background()
@@ -548,7 +494,7 @@ func TestFileSQLAdapter_Close(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 
 	// Test Close - should not return error
 	err = adapter.Close()
@@ -557,44 +503,10 @@ func TestFileSQLAdapter_Close(t *testing.T) {
 	}
 }
 
-func TestFileSQLAdapter_ExecNilDB(t *testing.T) {
-	t.Parallel()
-
-	adapter := NewFileSQLAdapter(nil)
-	ctx := context.Background()
-
-	// Test Exec with nil database
-	_, err := adapter.Exec(ctx, "SELECT 1")
-	if err == nil {
-		t.Fatal("Expected Exec to fail with nil database")
-	}
-
-	if !strings.Contains(err.Error(), "database not initialized") {
-		t.Errorf("Expected 'database not initialized' error, got: %v", err)
-	}
-}
-
-func TestFileSQLAdapter_QueryNilDB(t *testing.T) {
-	t.Parallel()
-
-	adapter := NewFileSQLAdapter(nil)
-	ctx := context.Background()
-
-	// Test Query with nil database
-	_, err := adapter.Query(ctx, "SELECT 1")
-	if err == nil {
-		t.Fatal("Expected Query to fail with nil database")
-	}
-
-	if !strings.Contains(err.Error(), "shared database not initialized") {
-		t.Errorf("Expected 'shared database not initialized' error, got: %v", err)
-	}
-}
-
 func TestFileSQLAdapter_GetTableNamesNilDB(t *testing.T) {
 	t.Parallel()
 
-	adapter := NewFileSQLAdapter(nil)
+	adapter := newTestAdapter(nil)
 	ctx := context.Background()
 
 	// Test GetTableNames with nil database
@@ -617,7 +529,7 @@ func TestFileSQLAdapter_LoadFilesEmpty(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	// Test LoadFiles with empty file list
@@ -630,7 +542,7 @@ func TestFileSQLAdapter_LoadFilesEmpty(t *testing.T) {
 func TestFileSQLAdapter_LoadFilesNilDB(t *testing.T) {
 	t.Parallel()
 
-	adapter := NewFileSQLAdapter(nil)
+	adapter := newTestAdapter(nil)
 	ctx := context.Background()
 
 	// Test LoadFiles with nil database
@@ -653,183 +565,13 @@ func TestFileSQLAdapter_LoadFileNonexistent(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	// Test LoadFile with nonexistent file
 	err = adapter.LoadFile(ctx, "/nonexistent/path/file.csv")
 	if err == nil {
 		t.Fatal("Expected LoadFile to fail with nonexistent file")
-	}
-}
-
-func TestFileSQLAdapter_GetTableHeaderNilDB(t *testing.T) {
-	t.Parallel()
-
-	adapter := NewFileSQLAdapter(nil)
-	ctx := context.Background()
-
-	// Test GetTableHeader with nil database
-	_, err := adapter.GetTableHeader(ctx, "test_table")
-	if err == nil {
-		t.Fatal("Expected GetTableHeader to fail with nil database")
-	}
-
-	if !strings.Contains(err.Error(), "database not initialized") {
-		t.Errorf("Expected 'database not initialized' error, got: %v", err)
-	}
-}
-
-func TestFileSQLAdapter_GetTableHeader(t *testing.T) {
-	t.Parallel()
-
-	sharedDB, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("Failed to create shared database: %v", err)
-	}
-	defer func() { _ = sharedDB.Close() }()
-
-	// Create test table with various column types
-	_, err = sharedDB.ExecContext(context.Background(), `CREATE TABLE test_header (id INTEGER, name TEXT, balance REAL, active BOOLEAN)`)
-	if err != nil {
-		t.Fatalf("Failed to create test table: %v", err)
-	}
-
-	adapter := NewFileSQLAdapter(sharedDB)
-	ctx := context.Background()
-
-	// Test GetTableHeader
-	table, err := adapter.GetTableHeader(ctx, "test_header")
-	if err != nil {
-		t.Fatalf("GetTableHeader failed: %v", err)
-	}
-
-	if table.Name() != "test_header" {
-		t.Errorf("Expected table name 'test_header', got %s", table.Name())
-	}
-
-	expectedHeaders := []string{"id", "name", "balance", "active"}
-	actualHeaders := table.Header()
-	if len(actualHeaders) != len(expectedHeaders) {
-		t.Errorf("Expected %d headers, got %d", len(expectedHeaders), len(actualHeaders))
-	}
-
-	for i, expected := range expectedHeaders {
-		if i < len(actualHeaders) && actualHeaders[i] != expected {
-			t.Errorf("Expected header %d to be %s, got %s", i, expected, actualHeaders[i])
-		}
-	}
-
-	// Records should be nil for header-only queries
-	if table.Records() != nil {
-		t.Errorf("Expected no records in header-only table, got %d", len(table.Records()))
-	}
-}
-
-func TestFileSQLAdapter_GetTableHeaderNonexistent(t *testing.T) {
-	t.Parallel()
-
-	sharedDB, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("Failed to create shared database: %v", err)
-	}
-	defer func() { _ = sharedDB.Close() }()
-
-	adapter := NewFileSQLAdapter(sharedDB)
-	ctx := context.Background()
-
-	// Test GetTableHeader with nonexistent table
-	table, err := adapter.GetTableHeader(ctx, "nonexistent_table")
-	if err != nil {
-		// Error is expected for nonexistent tables
-		t.Logf("Expected error for nonexistent table: %v", err)
-		return
-	}
-
-	// If no error, the table should have no columns
-	if table != nil && len(table.Header()) > 0 {
-		t.Errorf("Expected empty headers for nonexistent table, got: %v", table.Header())
-	}
-}
-
-func TestFileSQLAdapter_QueryWithDifferentDataTypes(t *testing.T) {
-	t.Parallel()
-
-	sharedDB, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("Failed to create shared database: %v", err)
-	}
-	defer func() { _ = sharedDB.Close() }()
-
-	// Create test table with various data types
-	_, err = sharedDB.ExecContext(context.Background(), `CREATE TABLE test_types (id INTEGER, name TEXT, balance REAL, data BLOB)`)
-	if err != nil {
-		t.Fatalf("Failed to create test table: %v", err)
-	}
-
-	// Insert test data with different types
-	_, err = sharedDB.ExecContext(context.Background(), `INSERT INTO test_types VALUES (1, 'test', 123.45, X'48656C6C6F')`)
-	if err != nil {
-		t.Fatalf("Failed to insert test data: %v", err)
-	}
-
-	// Insert row with NULL values
-	_, err = sharedDB.ExecContext(context.Background(), `INSERT INTO test_types VALUES (2, NULL, NULL, NULL)`)
-	if err != nil {
-		t.Fatalf("Failed to insert NULL test data: %v", err)
-	}
-
-	adapter := NewFileSQLAdapter(sharedDB)
-	ctx := context.Background()
-
-	// Test Query with different data types
-	table, err := adapter.Query(ctx, "SELECT * FROM test_types ORDER BY id")
-	if err != nil {
-		t.Fatalf("Query failed: %v", err)
-	}
-
-	if len(table.Records()) != 2 {
-		t.Errorf("Expected 2 records, got %d", len(table.Records()))
-	}
-
-	// Check first record data types conversion
-	if len(table.Records()) > 0 {
-		firstRecord := table.Records()[0]
-		if len(firstRecord) >= 4 {
-			// INTEGER -> string
-			if firstRecord[0] != "1" {
-				t.Errorf("Expected id '1', got %s", firstRecord[0])
-			}
-			// TEXT -> string
-			if firstRecord[1] != "test" {
-				t.Errorf("Expected name 'test', got %s", firstRecord[1])
-			}
-			// REAL -> string
-			if firstRecord[2] != "123.45" {
-				t.Errorf("Expected balance '123.45', got %s", firstRecord[2])
-			}
-			// BLOB -> string
-			if firstRecord[3] != "Hello" {
-				t.Errorf("Expected data 'Hello', got %s", firstRecord[3])
-			}
-		}
-	}
-
-	// Check second record with NULL values
-	if len(table.Records()) > 1 {
-		secondRecord := table.Records()[1]
-		if len(secondRecord) >= 4 {
-			// NULL values should become empty strings
-			if secondRecord[1] != "" {
-				t.Errorf("Expected NULL name to be empty string, got %s", secondRecord[1])
-			}
-			if secondRecord[2] != "" {
-				t.Errorf("Expected NULL balance to be empty string, got %s", secondRecord[2])
-			}
-			if secondRecord[3] != "" {
-				t.Errorf("Expected NULL data to be empty string, got %s", secondRecord[3])
-			}
-		}
 	}
 }
 
@@ -1024,7 +766,7 @@ func TestFileSQLAdapter_NumericPrefixFilename(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	if err := adapter.LoadFile(ctx, csvFile); err != nil {
@@ -1086,7 +828,7 @@ func TestGetTableNameFromFilePath_MatchesFilesqlNaming(t *testing.T) {
 			}
 			defer func() { _ = sharedDB.Close() }()
 
-			adapter := NewFileSQLAdapter(sharedDB)
+			adapter := newTestAdapter(sharedDB)
 			if err := adapter.LoadFile(context.Background(), csvFile); err != nil {
 				t.Fatalf("LoadFile failed: %v", err)
 			}
@@ -1128,7 +870,7 @@ func TestFileSQLAdapter_JSONFile(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	if err := adapter.LoadFile(ctx, jsonFile); err != nil {
@@ -1173,7 +915,7 @@ func TestFileSQLAdapter_JSONLFile(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	if err := adapter.LoadFile(ctx, jsonlFile); err != nil {
@@ -1212,7 +954,7 @@ func TestFileSQLAdapter_ExcelWithoutSheetName(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	if err := adapter.LoadFile(ctx, xlsxFile); err != nil {
@@ -1258,7 +1000,7 @@ func TestFileSQLAdapter_ReservedWordTableName(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	if err := adapter.LoadFile(ctx, csvFile); err != nil {
@@ -1300,7 +1042,7 @@ func TestFileSQLAdapter_ACHFile(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	if err := adapter.LoadFile(ctx, achFile); err != nil {
@@ -1355,7 +1097,7 @@ func TestFileSQLAdapter_FedWireFile(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	ctx := context.Background()
 
 	if err := adapter.LoadFile(ctx, fedFile); err != nil {
@@ -1414,7 +1156,7 @@ func TestLoadFile_ACHRegistryRetainedAfterImport(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	if err := adapter.LoadFile(context.Background(), achFile); err != nil {
 		t.Fatalf("LoadFile failed: %v", err)
 	}
@@ -1452,7 +1194,7 @@ func TestLoadFile_WireRegistryRetainedAfterImport(t *testing.T) {
 	}
 	defer func() { _ = sharedDB.Close() }()
 
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 	if err := adapter.LoadFile(context.Background(), fedFile); err != nil {
 		t.Fatalf("LoadFile failed: %v", err)
 	}
@@ -1571,7 +1313,7 @@ func BenchmarkAdapterLoadFiles(b *testing.B) {
 	// Match production: ":memory:" is private per connection, so pin the pool.
 	sharedDB.SetMaxOpenConns(1)
 	defer func() { _ = sharedDB.Close() }()
-	adapter := NewFileSQLAdapter(sharedDB)
+	adapter := newTestAdapter(sharedDB)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -1615,7 +1357,7 @@ func TestFileSQLAdapter_EmptyJSONLikeInputs(t *testing.T) {
 			}
 			defer func() { _ = sharedDB.Close() }()
 
-			adapter := NewFileSQLAdapter(sharedDB)
+			adapter := newTestAdapter(sharedDB)
 			ctx := context.Background()
 			if err := adapter.LoadFile(ctx, path); err != nil {
 				t.Fatalf("LoadFile of empty JSON input failed: %v", err)
@@ -1687,7 +1429,7 @@ func TestFileSQLAdapter_EmptyCompressedJSONLike(t *testing.T) {
 				t.Fatalf("open db: %v", err)
 			}
 			defer func() { _ = sharedDB.Close() }()
-			adapter := NewFileSQLAdapter(sharedDB)
+			adapter := newTestAdapter(sharedDB)
 
 			ctx := context.Background()
 			if err := adapter.LoadFile(ctx, path); err != nil {
@@ -1729,7 +1471,7 @@ func TestFileSQLAdapter_LTSVDuplicateLabelsRejected(t *testing.T) {
 		}
 		sharedDB, _ := sql.Open("sqlite", ":memory:")
 		defer func() { _ = sharedDB.Close() }()
-		adapter := NewFileSQLAdapter(sharedDB)
+		adapter := newTestAdapter(sharedDB)
 		if err := adapter.LoadFile(context.Background(), path); err == nil {
 			t.Error("LoadFile of duplicate-label LTSV returned nil error, want a duplicate-label rejection")
 		}
@@ -1742,7 +1484,7 @@ func TestFileSQLAdapter_LTSVDuplicateLabelsRejected(t *testing.T) {
 		gzipFile(t, path, []byte("a:1\tb:2\ta:3\n"))
 		sharedDB, _ := sql.Open("sqlite", ":memory:")
 		defer func() { _ = sharedDB.Close() }()
-		adapter := NewFileSQLAdapter(sharedDB)
+		adapter := newTestAdapter(sharedDB)
 		if err := adapter.LoadFile(context.Background(), path); err == nil {
 			t.Error("LoadFile of duplicate-label compressed LTSV returned nil error, want rejection")
 		}
@@ -1757,7 +1499,7 @@ func TestFileSQLAdapter_LTSVDuplicateLabelsRejected(t *testing.T) {
 		}
 		sharedDB, _ := sql.Open("sqlite", ":memory:")
 		defer func() { _ = sharedDB.Close() }()
-		adapter := NewFileSQLAdapter(sharedDB)
+		adapter := newTestAdapter(sharedDB)
 		if err := adapter.LoadFile(context.Background(), path); err != nil {
 			t.Errorf("LoadFile of unique-label LTSV error = %v, want nil", err)
 		}

--- a/infrastructure/filesql/atomic_import_test.go
+++ b/infrastructure/filesql/atomic_import_test.go
@@ -325,7 +325,7 @@ func TestLoadFilesRollsBackEveryEarlierInput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	adapter := NewFileSQLAdapter(db)
+	adapter := newTestAdapter(db)
 	if err := adapter.LoadFiles(t.Context(), good1, good2, broken); err == nil {
 		t.Fatal("LoadFiles with a broken last input = nil error, want an error")
 	}
@@ -386,7 +386,7 @@ func TestLoadFilesRollbackLeavesNoACHRegistryEntry(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	adapter := NewFileSQLAdapter(db)
+	adapter := newTestAdapter(db)
 	// The ACH file imports cleanly; the CSV after it does not, so the whole
 	// import rolls back.
 	if err := adapter.LoadFiles(t.Context(), achFile, broken); err == nil {

--- a/infrastructure/filesql/bench_test.go
+++ b/infrastructure/filesql/bench_test.go
@@ -91,7 +91,7 @@ func benchImport(b *testing.B, rows int) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		adapter := NewFileSQLAdapter(db)
+		adapter := newTestAdapter(db)
 		b.StartTimer()
 
 		if err := adapter.LoadFiles(ctx, csv); err != nil {
@@ -130,7 +130,7 @@ func BenchmarkImportMultiFile(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		adapter := NewFileSQLAdapter(db)
+		adapter := newTestAdapter(db)
 		b.StartTimer()
 
 		if err := adapter.LoadFiles(ctx, paths...); err != nil {
@@ -145,7 +145,7 @@ func BenchmarkImportMultiFile(b *testing.B) {
 
 // benchQueryFixture imports a CSV once and returns an adapter over it, so the
 // query and output benchmarks measure only the work they name.
-func benchQueryFixture(b *testing.B, rows int) (*FileSQLAdapter, func()) {
+func benchQueryFixture(b *testing.B, rows int) (*testAdapter, func()) {
 	b.Helper()
 
 	dir := b.TempDir()
@@ -156,7 +156,7 @@ func benchQueryFixture(b *testing.B, rows int) (*FileSQLAdapter, func()) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	adapter := NewFileSQLAdapter(db)
+	adapter := newTestAdapter(db)
 	if err := adapter.LoadFiles(context.Background(), csv); err != nil {
 		b.Fatal(err)
 	}

--- a/infrastructure/filesql/coverage_test.go
+++ b/infrastructure/filesql/coverage_test.go
@@ -19,7 +19,7 @@ import (
 // database. The pool is pinned to a single connection because a bare
 // ":memory:" database is private per connection, so every statement must run
 // against the same underlying database.
-func covFsqlNewAdapter(t *testing.T) *FileSQLAdapter {
+func covFsqlNewAdapter(t *testing.T) *testAdapter {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -27,7 +27,7 @@ func covFsqlNewAdapter(t *testing.T) *FileSQLAdapter {
 	}
 	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
-	return NewFileSQLAdapter(db)
+	return newTestAdapter(db)
 }
 
 // covFsqlWriteCSV writes a small CSV file into a temp dir and returns its path.
@@ -237,28 +237,8 @@ func TestDumpACHFile_RoundTrip(t *testing.T) {
 	}
 
 	// nil-DB guard.
-	if err := NewFileSQLAdapter(nil).DumpACHFile(ctx, baseName, out); err == nil {
+	if err := newTestAdapter(nil).DumpACHFile(ctx, baseName, out); err == nil {
 		t.Error("DumpACHFile with nil DB = nil error, want error")
-	}
-}
-
-// TestQuery_SQLError checks that an invalid query returns a FileSQLError.
-func TestQuery_SQLError(t *testing.T) {
-	t.Parallel()
-
-	a := covFsqlNewAdapter(t)
-	if _, err := a.Query(context.Background(), "SELECT * FROM no_such_table"); err == nil {
-		t.Fatal("Query on missing table = nil error, want error")
-	}
-}
-
-// TestExec_SQLError checks that an invalid statement returns a FileSQLError.
-func TestExec_SQLError(t *testing.T) {
-	t.Parallel()
-
-	a := covFsqlNewAdapter(t)
-	if _, err := a.Exec(context.Background(), "UPDATE no_such_table SET x = 1"); err == nil {
-		t.Fatal("Exec on missing table = nil error, want error")
 	}
 }
 
@@ -272,39 +252,11 @@ func TestGetTableNames_ClosedDB(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	db.SetMaxOpenConns(1)
-	a := NewFileSQLAdapter(db)
+	a := newTestAdapter(db)
 	_ = db.Close()
 
 	if _, err := a.GetTableNames(context.Background()); err == nil {
 		t.Fatal("GetTableNames on closed DB = nil error, want error")
-	}
-}
-
-// TestGetTableHeader_EmptyName checks the empty-name guard.
-func TestGetTableHeader_EmptyName(t *testing.T) {
-	t.Parallel()
-
-	a := covFsqlNewAdapter(t)
-	if _, err := a.GetTableHeader(context.Background(), "   "); err == nil {
-		t.Fatal("GetTableHeader with blank name = nil error, want error")
-	}
-}
-
-// TestGetTableHeader_ClosedDB checks the QueryContext error branch by closing the
-// database before the call.
-func TestGetTableHeader_ClosedDB(t *testing.T) {
-	t.Parallel()
-
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	db.SetMaxOpenConns(1)
-	a := NewFileSQLAdapter(db)
-	_ = db.Close()
-
-	if _, err := a.GetTableHeader(context.Background(), "some_table"); err == nil {
-		t.Fatal("GetTableHeader on closed DB = nil error, want error")
 	}
 }
 
@@ -339,7 +291,7 @@ func TestDumpFedWireFile_RoundTrip(t *testing.T) {
 	}
 
 	// nil-DB guard.
-	if err := NewFileSQLAdapter(nil).DumpFedWireFile(ctx, baseName, out); err == nil {
+	if err := newTestAdapter(nil).DumpFedWireFile(ctx, baseName, out); err == nil {
 		t.Error("DumpFedWireFile with nil DB = nil error, want error")
 	}
 }

--- a/infrastructure/filesql/errorpath_test.go
+++ b/infrastructure/filesql/errorpath_test.go
@@ -13,14 +13,14 @@ import (
 // covErrFsqlClosedAdapter returns an adapter whose shared database has already
 // been closed, so every statement it issues fails. It is the closed-DB variant of
 // covFsqlNewAdapter used to drive the error branches.
-func covErrFsqlClosedAdapter(t *testing.T) *FileSQLAdapter {
+func covErrFsqlClosedAdapter(t *testing.T) *testAdapter {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
 	db.SetMaxOpenConns(1)
-	a := NewFileSQLAdapter(db)
+	a := newTestAdapter(db)
 	if err := db.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
 	}

--- a/infrastructure/filesql/row_mismatch_test.go
+++ b/infrastructure/filesql/row_mismatch_test.go
@@ -38,7 +38,7 @@ const mismatchedCSV = "id,name,zip\n1,alice,01234\n2,bob,00123\n3,caro\n4,dave,9
 // newMismatchTestAdapter writes the mismatched CSV to a file and returns an adapter
 // bound to a fresh shared in-memory database. The pool is pinned to a single
 // connection because a bare ":memory:" database is private per connection.
-func newMismatchTestAdapter(t *testing.T) (*FileSQLAdapter, string) {
+func newMismatchTestAdapter(t *testing.T) (*testAdapter, string) {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "malformed.csv")
@@ -51,7 +51,7 @@ func newMismatchTestAdapter(t *testing.T) (*FileSQLAdapter, string) {
 	}
 	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
-	return NewFileSQLAdapter(db), path
+	return newTestAdapter(db), path
 }
 
 func TestFileSQLAdapter_ImportMode_Stop(t *testing.T) {
@@ -130,7 +130,7 @@ func TestFileSQLAdapter_ImportMode_PadRejectsLongRow(t *testing.T) {
 	}
 	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
-	adapter := NewFileSQLAdapter(db)
+	adapter := newTestAdapter(db)
 	adapter.SetRowMismatchPolicy(model.RowMismatchPad)
 
 	if err := adapter.LoadFile(context.Background(), path); err == nil {
@@ -153,7 +153,7 @@ func TestFileSQLAdapter_ImportMode_PadStreamsGzipCSV(t *testing.T) {
 	}
 	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
-	adapter := NewFileSQLAdapter(db)
+	adapter := newTestAdapter(db)
 	adapter.SetRowMismatchPolicy(model.RowMismatchPad)
 
 	if err := adapter.LoadFile(context.Background(), path); err != nil {
@@ -197,7 +197,7 @@ func TestFileSQLAdapter_ImportMode_PadRejectsBeforeEmptyJSONTable(t *testing.T) 
 	}
 	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
-	adapter := NewFileSQLAdapter(db)
+	adapter := newTestAdapter(db)
 	adapter.SetRowMismatchPolicy(model.RowMismatchPad)
 
 	if err := adapter.LoadFiles(context.Background(), emptyJSON, longCSV); err == nil {
@@ -240,7 +240,7 @@ func TestFileSQLAdapter_LoadFilesIsAtomicAcrossInputFormats(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := NewFileSQLAdapter(db).LoadFiles(ctx, emptyJSON, bad); err == nil {
+			if err := newTestAdapter(db).LoadFiles(ctx, emptyJSON, bad); err == nil {
 				t.Fatal("mixed import returned nil, want an error")
 			}
 			var value string
@@ -288,7 +288,7 @@ func TestFileSQLAdapter_LoadFilesPreservesInputOrderForLastWins(t *testing.T) {
 		db.SetMaxOpenConns(1)
 		t.Cleanup(func() { _ = db.Close() })
 		ctx := context.Background()
-		if err := NewFileSQLAdapter(db).LoadFiles(ctx, paths...); err != nil {
+		if err := newTestAdapter(db).LoadFiles(ctx, paths...); err != nil {
 			t.Fatalf("LoadFiles: %v", err)
 		}
 		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM "same"`).Scan(&count); err != nil {
@@ -345,7 +345,7 @@ func TestFileSQLAdapter_LoadFilesRollsBackWhenLaterApplyFails(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	adapter := NewFileSQLAdapter(db)
+	adapter := newTestAdapter(db)
 	err = adapter.LoadFiles(ctx,
 		filepath.Join(dir, "first.csv"),
 		filepath.Join(dir, "same.csv"),
@@ -397,7 +397,7 @@ func TestFileSQLAdapter_LoadFilesEmptyJSONViewCollision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := NewFileSQLAdapter(db).LoadFiles(ctx, emptyJSON); err == nil {
+	if err := newTestAdapter(db).LoadFiles(ctx, emptyJSON); err == nil {
 		t.Fatal("LoadFiles returned nil, want empty-table/view collision error")
 	}
 	var id int


### PR DESCRIPTION
FileSQLAdapter carried `Query`, `Exec`, `GetTableHeader`, and `LoadFile` that no production path called. The session runs SQL through the memory repository and imports through `LoadFiles`; only tests reached the four, which is why the earlier sweep for unreachable code missed them.

The adapter's `Query` was worth removing on its own. It held a second scan loop with its own NULL and type handling over the same rows the repository already reads, so the two readers could have drifted apart with nothing but a user to notice.

Tests that used the deleted methods now go through the repository a session reads with, via a `testAdapter` helper, so they assert on the rows a user would see rather than on a query path kept alive for their sake. The cases that only exercised the deleted methods (their nil-DB guards, their SQL error paths, and `GetTableHeader` against a table the test created itself) are already covered by the memory repository's own tests and are gone.

No user-visible change: `make test`, `make lint`, and the 978 atago E2E scenarios pass unchanged.

Closes #848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified file-based data access by removing unused loading, querying, execution, and table-header operations.
  * Retained existing table naming, import, export, and utility functionality.
  * Reduced duplicate row-processing logic by relying on the production database repository.
* **Tests**
  * Updated integration, coverage, error-handling, mismatch, and benchmark tests to use the revised data-access flow.
  * Preserved coverage for imports, formats, registries, rollback behavior, and edge cases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->