### PR TITLE
refactor: stop declaring a write path the session does not have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Upgrading between candidates: [doc/migration.md](doc/migration.md).
 
 ### Refactoring
 * FileSQLAdapter carries only the methods sqly calls. Its Query, Exec, GetTableHeader, and LoadFile were reached by tests alone: the session runs SQL through the memory repository and imports through LoadFiles. The adapter's Query held a second scan loop over the same rows, so the two readers could have diverged with only a user to notice.
+* SQLite3Repository no longer declares CreateTable and Insert. Imports have gone through filesql since the loader was replaced, so the row-by-row write path they backed, including the statement builders behind it, was reachable only from tests while still obliging every implementation and mock to carry it.
 
 ## [v1.0.0-rc6](https://github.com/nao1215/sqly/compare/v1.0.0-rc5...v1.0.0-rc6) (2026-08-06)
 

--- a/domain/repository/sqlite.go
+++ b/domain/repository/sqlite.go
@@ -18,15 +18,11 @@ var ErrNoRows = errors.New("execute query, however return no records")
 
 // SQLite3Repository is a repository that handles SQLite3.
 type SQLite3Repository interface {
-	// CreateTable create a DB table with columns given as model.Table
-	CreateTable(ctx context.Context, t *model.Table) error
 	// TablesName return all table name.
 	TablesName(ctx context.Context) ([]*model.Table, error)
 	// SchemaObjects returns every queryable table and view in the session,
 	// including TEMP tables and views, for enumeration by .tables.
 	SchemaObjects(ctx context.Context) ([]*model.Table, error)
-	// Insert set records in DB
-	Insert(ctx context.Context, t *model.Table) error
 	// List get records in the specified table
 	List(ctx context.Context, tableName string) (*model.Table, error)
 	// Header get table header name.

--- a/infrastructure/memory/coverage_test.go
+++ b/infrastructure/memory/coverage_test.go
@@ -26,50 +26,11 @@ func covMemNewRepo(t *testing.T) repository.SQLite3Repository {
 // and streaming subtests.
 func covMemSeedTable(t *testing.T, r repository.SQLite3Repository) {
 	t.Helper()
-	table := model.NewTable("sample", model.Header{"id", "name"}, []model.Record{
-		{"1", "alice"},
-		{"2", "bob"},
-	})
-	if err := r.CreateTable(context.Background(), table); err != nil {
+	if _, err := r.Exec(context.Background(), "CREATE TABLE sample (id TEXT, name TEXT)"); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Insert(context.Background(), table); err != nil {
+	if _, err := r.Exec(context.Background(), "INSERT INTO sample VALUES ('1', 'alice'), ('2', 'bob')"); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func TestSqlite3Repository_CreateTable_DuplicateReturnsError(t *testing.T) {
-	t.Parallel()
-
-	r := covMemNewRepo(t)
-	table := model.NewTable("dup", model.Header{"id"}, []model.Record{{"1"}})
-	if err := r.CreateTable(context.Background(), table); err != nil {
-		t.Fatalf("first CreateTable error = %v, want nil", err)
-	}
-	// The second CREATE reaches ExecContext and fails because the table exists.
-	if err := r.CreateTable(context.Background(), table); err == nil {
-		t.Error("expected error creating a duplicate table, got nil")
-	}
-}
-
-func TestSqlite3Repository_Insert_InvalidTableReturnsError(t *testing.T) {
-	t.Parallel()
-
-	r := covMemNewRepo(t)
-	// An empty table fails Valid() before any SQL runs.
-	if err := r.Insert(context.Background(), model.NewTable("", model.Header{}, []model.Record{})); err == nil {
-		t.Error("expected error inserting an invalid table, got nil")
-	}
-}
-
-func TestSqlite3Repository_Insert_MissingTableReturnsError(t *testing.T) {
-	t.Parallel()
-
-	r := covMemNewRepo(t)
-	// The table is valid but was never created, so ExecContext fails.
-	table := model.NewTable("ghost", model.Header{"id"}, []model.Record{{"1"}})
-	if err := r.Insert(context.Background(), table); err == nil {
-		t.Error("expected error inserting into a missing table, got nil")
 	}
 }
 

--- a/infrastructure/memory/errorpath_test.go
+++ b/infrastructure/memory/errorpath_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/nao1215/sqly/config"
-	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/domain/repository"
 )
 
@@ -25,25 +24,10 @@ func covMemClosedRepo(t *testing.T) repository.SQLite3Repository {
 	return NewSQLite3Repository(memoryDB)
 }
 
-// covMemValidTable builds a minimal table that passes Valid() so a write method
-// reaches the DB call and fails there (from the closed DB) rather than during
-// validation.
-func covMemValidTable() *model.Table {
-	return model.NewTable("closed_sample", model.Header{"id"}, []model.Record{{"1"}})
-}
-
 func TestSqlite3Repository_ClosedDB_ReturnsErrors(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-
-	t.Run("CreateTable returns error when DB is closed", func(t *testing.T) {
-		t.Parallel()
-		r := covMemClosedRepo(t)
-		if err := r.CreateTable(ctx, covMemValidTable()); err == nil {
-			t.Error("expected error from CreateTable on a closed DB, got nil")
-		}
-	})
 
 	t.Run("TablesName returns error when DB is closed", func(t *testing.T) {
 		t.Parallel()
@@ -58,14 +42,6 @@ func TestSqlite3Repository_ClosedDB_ReturnsErrors(t *testing.T) {
 		r := covMemClosedRepo(t)
 		if _, err := r.SchemaObjects(ctx); err == nil {
 			t.Error("expected error from SchemaObjects on a closed DB, got nil")
-		}
-	})
-
-	t.Run("Insert returns error when DB is closed", func(t *testing.T) {
-		t.Parallel()
-		r := covMemClosedRepo(t)
-		if err := r.Insert(ctx, covMemValidTable()); err == nil {
-			t.Error("expected error from Insert on a closed DB, got nil")
 		}
 	})
 

--- a/infrastructure/memory/sqlite3.go
+++ b/infrastructure/memory/sqlite3.go
@@ -36,18 +36,6 @@ func (r *sqlite3Repository) inTx(ctx context.Context, fn func(tx *sql.Tx) error)
 	return err
 }
 
-// CreateTable create a DB table with columns given as model.Table
-func (r *sqlite3Repository) CreateTable(ctx context.Context, t *model.Table) error {
-	if err := t.Valid(); err != nil {
-		return err
-	}
-
-	return r.inTx(ctx, func(tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, infra.GenerateCreateTableStatement((t)))
-		return err
-	})
-}
-
 // TablesName return all table name in import order.
 // Internal tables (sqlite_* and query_result_*) are excluded from the result.
 // Rows are ordered by sqlite_master.rowid, which is assigned in CREATE order, so
@@ -117,22 +105,6 @@ func (r *sqlite3Repository) SchemaObjects(ctx context.Context) ([]*model.Table, 
 		return nil, err
 	}
 	return tables, nil
-}
-
-// Insert set records in DB
-func (r *sqlite3Repository) Insert(ctx context.Context, t *model.Table) error {
-	if err := t.Valid(); err != nil {
-		return err
-	}
-
-	return r.inTx(ctx, func(tx *sql.Tx) error {
-		for _, v := range t.Rows {
-			if _, err := tx.ExecContext(ctx, infra.GenerateInsertStatement(t.Name(), v)); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
 }
 
 // List get records in the specified table

--- a/infrastructure/memory/sqlite3_test.go
+++ b/infrastructure/memory/sqlite3_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/nao1215/sqly/config"
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/domain/repository"
@@ -170,118 +169,6 @@ func TestQueryStreamCellSemantics(t *testing.T) {
 	}
 }
 
-func TestSqlite3RepositoryCreateTable(t *testing.T) {
-	t.Run("Create table", func(t *testing.T) {
-		memoryDB, cleanup, err := config.NewInMemDB()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer cleanup()
-
-		r := NewSQLite3Repository(memoryDB)
-		want := model.NewTable(
-			"sample",
-			model.Header{"aaa", "bbb", "ccc"},
-			[]model.Record{
-				{"111", "222", "333"},
-				{"444", "555", "666"},
-				{"777", "888", "999"},
-			},
-		)
-
-		if err := r.CreateTable(context.Background(), want); err != nil {
-			t.Fatal(err)
-		}
-
-		got, err := r.TablesName(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(got) == 0 {
-			t.Fatal("falied to create table (no table in memory db)")
-		}
-
-		if diff := cmp.Diff(got[0].Name(), want.Name()); diff != "" {
-			t.Fatalf("mismatch (-got +want):\n%s", diff)
-		}
-
-		got2, err := r.List(context.Background(), "sample")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(got2.Header(), want.Header()); diff != "" {
-			t.Fatalf("mismatch (-got +want):\n%s", diff)
-		}
-
-		got3, err := r.Header(context.Background(), "sample")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(got3.Header(), want.Header()); diff != "" {
-			t.Fatalf("mismatch (-got +want):\n%s", diff)
-		}
-	})
-}
-
-func TestSqlite3RepositoryInsert(t *testing.T) {
-	t.Run("INSERT data", func(t *testing.T) {
-		memoryDB, cleanup, err := config.NewInMemDB()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer cleanup()
-
-		r := NewSQLite3Repository(memoryDB)
-		table := model.NewTable(
-			"sample",
-			model.Header{"aaa", "bbb", "ccc"},
-			[]model.Record{
-				{"111", "222", "333"},
-				{"444", "555", "666"},
-				{"777", "888", "999"},
-			},
-		)
-		if err := r.CreateTable(context.Background(), table); err != nil {
-			t.Fatal(err)
-		}
-
-		input := model.NewTable(
-			"sample",
-			model.Header{"aaa", "bbb", "ccc"},
-			[]model.Record{
-				{"111", "222", "333"},
-				{"444", "555", "666"},
-				{"777", "888", "999"},
-			},
-		)
-		if err := r.Insert(context.Background(), input); err != nil {
-			t.Fatal(err)
-		}
-
-		if _, err := r.Exec(context.Background(), "DELETE FROM sample WHERE aaa = '111'"); err != nil {
-			t.Fatal(err)
-		}
-
-		got, err := r.Query(context.Background(), "SELECT * FROM sample ORDER BY aaa")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		want := model.NewTable(
-			"sample",
-			model.Header{"aaa", "bbb", "ccc"},
-			[]model.Record{
-				{"444", "555", "666"},
-				{"777", "888", "999"},
-			},
-		)
-		if diff := cmp.Diff(got, want); diff != "" {
-			t.Fatalf("mismatch (-got +want):\n%s", diff)
-		}
-	})
-}
-
 func TestExtractTableName(t *testing.T) {
 	t.Parallel()
 
@@ -346,13 +233,7 @@ func TestSqlite3RepositoryTablesNameExcludesInternalTables(t *testing.T) {
 
 		r := NewSQLite3Repository(memoryDB)
 
-		// Create a regular table (must have at least one record for Valid() check)
-		regularTable := model.NewTable(
-			"users",
-			model.Header{"id", "name"},
-			[]model.Record{{"1", "test_user"}},
-		)
-		if err := r.CreateTable(context.Background(), regularTable); err != nil {
+		if _, err := r.Exec(context.Background(), "CREATE TABLE users (id TEXT, name TEXT)"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -364,13 +245,7 @@ func TestSqlite3RepositoryTablesNameExcludesInternalTables(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Create another regular table (must have at least one record for Valid() check)
-		anotherTable := model.NewTable(
-			"products",
-			model.Header{"id", "price"},
-			[]model.Record{{"1", "100"}},
-		)
-		if err := r.CreateTable(context.Background(), anotherTable); err != nil {
+		if _, err := r.Exec(context.Background(), "CREATE TABLE products (id TEXT, price TEXT)"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -428,13 +303,7 @@ func TestSqlite3RepositoryTablesNameExcludesInternalTables(t *testing.T) {
 
 		r := NewSQLite3Repository(memoryDB)
 
-		// Create a regular table (must have at least one record for Valid() check)
-		regularTable := model.NewTable(
-			"data",
-			model.Header{"id", "value"},
-			[]model.Record{{"1", "test_value"}},
-		)
-		if err := r.CreateTable(context.Background(), regularTable); err != nil {
+		if _, err := r.Exec(context.Background(), "CREATE TABLE data (id TEXT, value TEXT)"); err != nil {
 			t.Fatal(err)
 		}
 
@@ -474,8 +343,7 @@ func TestSqlite3RepositoryTablesNameExcludesInternalTables(t *testing.T) {
 		// Create "zebra" before "ant" so creation order and alphabetical order
 		// disagree; TablesName preserves creation (import) order.
 		for _, name := range []string{"zebra", "ant"} {
-			table := model.NewTable(name, model.Header{"id"}, []model.Record{{"1"}})
-			if err := r.CreateTable(context.Background(), table); err != nil {
+			if _, err := r.Exec(context.Background(), "CREATE TABLE "+name+" (id TEXT)"); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -503,14 +371,10 @@ func newSampleRepo(t *testing.T) repository.SQLite3Repository {
 	t.Cleanup(cleanup)
 
 	r := NewSQLite3Repository(memoryDB)
-	table := model.NewTable("sample", model.Header{"id", "name"}, []model.Record{
-		{"1", "alice"},
-		{"2", "bob"},
-	})
-	if err := r.CreateTable(context.Background(), table); err != nil {
+	if _, err := r.Exec(context.Background(), "CREATE TABLE sample (id TEXT, name TEXT)"); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Insert(context.Background(), table); err != nil {
+	if _, err := r.Exec(context.Background(), "INSERT INTO sample VALUES ('1', 'alice'), ('2', 'bob')"); err != nil {
 		t.Fatal(err)
 	}
 	return r
@@ -538,14 +402,6 @@ func TestSqlite3Repository_Exec_InvalidStatementReturnsError(t *testing.T) {
 	r := newSampleRepo(t)
 	if _, err := r.Exec(context.Background(), "UPDATE no_such_table SET x = 1"); err == nil {
 		t.Error("expected error for exec against missing table, got nil")
-	}
-}
-
-func TestSqlite3Repository_CreateTable_InvalidTableReturnsError(t *testing.T) {
-	r := newSampleRepo(t)
-	// An empty table (no name/header/records) fails Valid() before any SQL runs.
-	if err := r.CreateTable(context.Background(), model.NewTable("", model.Header{}, []model.Record{})); err == nil {
-		t.Error("expected error for invalid table, got nil")
 	}
 }
 

--- a/infrastructure/mock/sqlite.go
+++ b/infrastructure/mock/sqlite.go
@@ -41,44 +41,6 @@ func (m *MockSQLite3Repository) EXPECT() *MockSQLite3RepositoryMockRecorder {
 	return m.recorder
 }
 
-// CreateTable mocks base method.
-func (m *MockSQLite3Repository) CreateTable(ctx context.Context, t *model.Table) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTable", ctx, t)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateTable indicates an expected call of CreateTable.
-func (mr *MockSQLite3RepositoryMockRecorder) CreateTable(ctx, t any) *MockSQLite3RepositoryCreateTableCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTable", reflect.TypeOf((*MockSQLite3Repository)(nil).CreateTable), ctx, t)
-	return &MockSQLite3RepositoryCreateTableCall{Call: call}
-}
-
-// MockSQLite3RepositoryCreateTableCall wrap *gomock.Call
-type MockSQLite3RepositoryCreateTableCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockSQLite3RepositoryCreateTableCall) Return(arg0 error) *MockSQLite3RepositoryCreateTableCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockSQLite3RepositoryCreateTableCall) Do(f func(context.Context, *model.Table) error) *MockSQLite3RepositoryCreateTableCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSQLite3RepositoryCreateTableCall) DoAndReturn(f func(context.Context, *model.Table) error) *MockSQLite3RepositoryCreateTableCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // Exec mocks base method.
 func (m *MockSQLite3Repository) Exec(ctx context.Context, statement string) (int64, error) {
 	m.ctrl.T.Helper()
@@ -153,44 +115,6 @@ func (c *MockSQLite3RepositoryHeaderCall) Do(f func(context.Context, string) (*m
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockSQLite3RepositoryHeaderCall) DoAndReturn(f func(context.Context, string) (*model.Table, error)) *MockSQLite3RepositoryHeaderCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// Insert mocks base method.
-func (m *MockSQLite3Repository) Insert(ctx context.Context, t *model.Table) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Insert", ctx, t)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Insert indicates an expected call of Insert.
-func (mr *MockSQLite3RepositoryMockRecorder) Insert(ctx, t any) *MockSQLite3RepositoryInsertCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Insert", reflect.TypeOf((*MockSQLite3Repository)(nil).Insert), ctx, t)
-	return &MockSQLite3RepositoryInsertCall{Call: call}
-}
-
-// MockSQLite3RepositoryInsertCall wrap *gomock.Call
-type MockSQLite3RepositoryInsertCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockSQLite3RepositoryInsertCall) Return(arg0 error) *MockSQLite3RepositoryInsertCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockSQLite3RepositoryInsertCall) Do(f func(context.Context, *model.Table) error) *MockSQLite3RepositoryInsertCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSQLite3RepositoryInsertCall) DoAndReturn(f func(context.Context, *model.Table) error) *MockSQLite3RepositoryInsertCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/infrastructure/sql.go
+++ b/infrastructure/sql.go
@@ -1,13 +1,7 @@
 package infrastructure
 
 import (
-	"fmt"
-	"runtime"
-	"strconv"
 	"strings"
-	"sync"
-
-	"github.com/nao1215/sqly/domain/model"
 )
 
 // Quote returns quoted string.
@@ -67,75 +61,4 @@ func SingleQuote(s string) string {
 	}
 	buf.WriteByte('\'')
 	return buf.String()
-}
-
-// GenerateCreateTableStatement returns create table statement.
-// e.g. CREATE TABLE `table_name` (`column1` INTEGER, `column2` TEXT, ...);
-func GenerateCreateTableStatement(t *model.Table) string {
-	indexTypeMap := make(map[int]string, len(t.Header()))
-	semaphore := make(chan int, runtime.NumCPU())
-	wg := &sync.WaitGroup{}
-
-	var mu sync.RWMutex
-	for i := range t.Header() {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			semaphore <- 1
-			defer func() { <-semaphore }()
-			if isNumeric(t, i) {
-				mu.Lock()
-				indexTypeMap[i] = "INTEGER"
-				mu.Unlock()
-			} else {
-				mu.Lock()
-				indexTypeMap[i] = "TEXT"
-				mu.Unlock()
-			}
-		}(i)
-	}
-	wg.Wait()
-
-	var builder strings.Builder
-	builder.WriteString("CREATE TABLE " + Quote(t.Name()) + "(")
-	for i, v := range t.Header() {
-		fmt.Fprintf(&builder, "%s %s", Quote(v), indexTypeMap[i])
-		if i != len(t.Header())-1 {
-			builder.WriteString(", ")
-		} else {
-			builder.WriteString(");")
-		}
-	}
-	return builder.String()
-}
-
-// isNumeric returns true if all records are numeric.
-func isNumeric(t *model.Table, index int) bool {
-	if t.RowCount() == 0 {
-		return false
-	}
-
-	for _, record := range t.Rows {
-		_, err := strconv.ParseFloat(record.At(index), 64)
-		if err != nil {
-			return false
-		}
-	}
-	return true
-}
-
-// GenerateInsertStatement returns insert statement.
-// e.g. INSERT INTO `table_name` VALUES ('value1', 'value2', ...);
-func GenerateInsertStatement(name string, record model.RecordView) string {
-	var builder strings.Builder
-	builder.WriteString("INSERT INTO " + Quote(name) + " VALUES (")
-	for i := range record.Len() {
-		builder.WriteString(SingleQuote(record.At(i)))
-		if i != record.Len()-1 {
-			builder.WriteString(", ")
-		} else {
-			builder.WriteString(");")
-		}
-	}
-	return builder.String()
 }

--- a/infrastructure/sql_test.go
+++ b/infrastructure/sql_test.go
@@ -2,84 +2,7 @@ package infrastructure
 
 import (
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/nao1215/sqly/domain/model"
 )
-
-func TestGenerateCreateTableStatement(t *testing.T) {
-	type args struct {
-		t *model.Table
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "success to generate create table statement with no records",
-			args: args{
-				t: model.NewTable("test", model.Header{"id", "name", "number_and_string"}, nil),
-			},
-			want: "CREATE TABLE `test`(`id` TEXT, `name` TEXT, `number_and_string` TEXT);",
-		},
-		{
-			name: "success to generate create table statement with records",
-			args: args{
-				t: model.NewTable(
-					"test",
-					model.Header{"id", "name", "number_and_string"},
-					[]model.Record{
-						{"1", "name1", "1"},
-						{"2", "name2", "a"},
-						{"3", "name3", "3"},
-					},
-				),
-			},
-			want: "CREATE TABLE `test`(`id` INTEGER, `name` TEXT, `number_and_string` TEXT);",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := GenerateCreateTableStatement(tt.args.t)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("mismatch: (-got +want)\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestGenerateInsertStatement(t *testing.T) {
-	type args struct {
-		t *model.Table
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "success to generate insert recored statement",
-			args: args{
-				t: model.NewTable(
-					"test",
-					model.Header{"a_header", "b_header", "c_header"},
-					[]model.Record{
-						{"a", "b", "c"},
-					},
-				),
-			},
-			want: "INSERT INTO `test` VALUES ('a', 'b', 'c');",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GenerateInsertStatement(tt.args.t.Name(), mustRow(t, tt.args.t)); got != tt.want {
-				t.Errorf("generateInsertStatement() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 // TestQuoteTableRef verifies that a bare name is backtick-quoted and a
 // schema-qualified name is quoted per part, so helper commands can reference
@@ -107,15 +30,4 @@ func TestQuoteTableRef(t *testing.T) {
 			t.Errorf("QuoteTableRef(%q) = %q, want %q", tt.in, got, tt.want)
 		}
 	}
-}
-
-// mustRow returns the table's first row as a read-only view, failing the test
-// when the table is empty.
-func mustRow(t *testing.T, table *model.Table) model.RecordView {
-	t.Helper()
-	row, ok := table.Row(0)
-	if !ok {
-		t.Fatalf("table %q has no rows", table.Name())
-	}
-	return row
 }

--- a/interactor/sqlite3.go
+++ b/interactor/sqlite3.go
@@ -84,11 +84,6 @@ func NewMetadataUsecase(i *SQLite3Interactor) usecase.MetadataUsecase { return i
 // (native financial write-back).
 func NewPersistenceUsecase(i *SQLite3Interactor) usecase.PersistenceUsecase { return i }
 
-// CreateTable create a DB table with columns given as model.Table
-func (si *SQLite3Interactor) CreateTable(ctx context.Context, t *model.Table) error {
-	return si.r.CreateTable(ctx, t)
-}
-
 // TablesName return all table name.
 func (si *SQLite3Interactor) TablesName(ctx context.Context) ([]*model.Table, error) {
 	return si.r.TablesName(ctx)
@@ -98,11 +93,6 @@ func (si *SQLite3Interactor) TablesName(ctx context.Context) ([]*model.Table, er
 // views, for enumeration by .tables.
 func (si *SQLite3Interactor) SchemaObjects(ctx context.Context) ([]*model.Table, error) {
 	return si.r.SchemaObjects(ctx)
-}
-
-// Insert set records in DB
-func (si *SQLite3Interactor) Insert(ctx context.Context, t *model.Table) error {
-	return si.r.Insert(ctx, t)
 }
 
 // List get records in the specified table

--- a/interactor/sqlite3_test.go
+++ b/interactor/sqlite3_test.go
@@ -529,56 +529,6 @@ func TestSQLite3InteractorExecSQL(t *testing.T) {
 	})
 }
 
-func TestSqlite3InteractorCreateTable(t *testing.T) {
-	t.Parallel()
-
-	t.Run("create table succeeded", func(t *testing.T) {
-		t.Parallel()
-
-		ctrl := gomock.NewController(t)
-		repo := infrastructure.NewMockSQLite3Repository(ctrl)
-
-		table := model.NewTable(
-			"test",
-			model.Header{"id", "name"},
-			[]model.Record{
-				{"1", "Gina"},
-				{"2", "Yulia"},
-			},
-		)
-		repo.EXPECT().CreateTable(gomock.Any(), table).Return(nil)
-
-		interactor := NewSQLite3Interactor(repo, NewSQL(), nil)
-		if err := interactor.CreateTable(context.Background(), table); err != nil {
-			t.Errorf("want: nil, got: %v", err)
-		}
-	})
-
-	t.Run("create table failed", func(t *testing.T) {
-		t.Parallel()
-
-		ctrl := gomock.NewController(t)
-		repo := infrastructure.NewMockSQLite3Repository(ctrl)
-
-		table := model.NewTable(
-			"test",
-			model.Header{"id", "name"},
-			[]model.Record{
-				{"1", "Gina"},
-				{"2", "Yulia"},
-			},
-		)
-
-		someErr := errors.New("failed to create table")
-		repo.EXPECT().CreateTable(gomock.Any(), table).Return(someErr)
-
-		interactor := NewSQLite3Interactor(repo, NewSQL(), nil)
-		if err := interactor.CreateTable(context.Background(), table); !errors.Is(err, someErr) {
-			t.Errorf("want: %v, got: %v", someErr, err)
-		}
-	})
-}
-
 func TestSqlite3InteractorTablesName(t *testing.T) {
 	t.Parallel()
 
@@ -617,57 +567,6 @@ func TestSqlite3InteractorTablesName(t *testing.T) {
 		interactor := NewSQLite3Interactor(repo, NewSQL(), nil)
 		_, err := interactor.TablesName(context.Background())
 		if !errors.Is(err, someErr) {
-			t.Errorf("want: %v, got: %v", someErr, err)
-		}
-	})
-}
-
-func TestSqlite3InteractorInsert(t *testing.T) {
-	t.Parallel()
-
-	t.Run("insert records succeeded", func(t *testing.T) {
-		t.Parallel()
-
-		ctrl := gomock.NewController(t)
-		repo := infrastructure.NewMockSQLite3Repository(ctrl)
-
-		table := model.NewTable(
-			"test",
-			model.Header{"id", "name"},
-			[]model.Record{
-				{"1", "Gina"},
-				{"2", "Yulia"},
-			},
-		)
-
-		repo.EXPECT().Insert(gomock.Any(), table).Return(nil)
-
-		interactor := NewSQLite3Interactor(repo, NewSQL(), nil)
-		if err := interactor.Insert(context.Background(), table); err != nil {
-			t.Errorf("want: nil, got: %v", err)
-		}
-	})
-
-	t.Run("insert records failed", func(t *testing.T) {
-		t.Parallel()
-
-		ctrl := gomock.NewController(t)
-		repo := infrastructure.NewMockSQLite3Repository(ctrl)
-
-		table := model.NewTable(
-			"test",
-			model.Header{"id", "name"},
-			[]model.Record{
-				{"1", "Gina"},
-				{"2", "Yulia"},
-			},
-		)
-
-		someErr := errors.New("failed to insert records")
-		repo.EXPECT().Insert(gomock.Any(), table).Return(someErr)
-
-		interactor := NewSQLite3Interactor(repo, NewSQL(), nil)
-		if err := interactor.Insert(context.Background(), table); !errors.Is(err, someErr) {
 			t.Errorf("want: %v, got: %v", someErr, err)
 		}
 	})


### PR DESCRIPTION
`SQLite3Repository` declared `CreateTable` and `Insert`, the v0-era import that built a table and pushed rows into it one statement at a time. Imports have gone through filesql since the loader was replaced, so nothing but tests reached either method, while every implementation and every regenerated mock still had to carry them.

The two statement builders behind them, `GenerateCreateTableStatement` and `GenerateInsertStatement`, had no other caller and go with them. The type inference in the first was already the wrong answer for the parquet export, which says so in a comment and does its own.

Tests that used the pair as setup now create and populate their fixtures with `Exec`, the write path a session actually has. The cases that only tested the removed methods (duplicate CREATE, insert into a missing table, the `Valid()` guards, and the closed-DB variants of both) are gone with them.

No user-visible change: `make test`, `make lint`, and the 978 atago E2E scenarios pass unchanged.

Closes #849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the table creation and record insertion operations from the SQLite data access API.
  * Removed related SQL generation utilities and supporting test coverage.
  * Existing table listing and query capabilities remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->