### PR TITLE
refactor: write an export once, to the path it was given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Upgrading between candidates: [doc/migration.md](doc/migration.md).
 
 ### Refactoring
 * FileSQLAdapter carries only the methods sqly calls. Its Query, Exec, GetTableHeader, and LoadFile were reached by tests alone: the session runs SQL through the memory repository and imports through LoadFiles. The adapter's Query held a second scan loop over the same rows, so the two readers could have diverged with only a user to notice.
+* An export writes its bytes once. Every caller of DumpTable already hands it a scratch path that its own staging and rename commit from, so serializing into a second temporary file in the OS temp directory and copying it across wrote every exported byte twice and made the export depend on free space in two filesystems.
 * SQLite3Repository no longer declares CreateTable and Insert. Imports have gone through filesql since the loader was replaced, so the row-by-row write path they backed, including the statement builders behind it, was reachable only from tests while still obliging every implementation and mock to carry it.
 
 ## [v1.0.0-rc6](https://github.com/nao1215/sqly/compare/v1.0.0-rc5...v1.0.0-rc6) (2026-08-06)

--- a/domain/repository/file.go
+++ b/domain/repository/file.go
@@ -6,8 +6,4 @@ import "os"
 type FileRepository interface {
 	// Create creates or opens a file at the given path for writing.
 	Create(filePath string) (*os.File, error)
-	// CreateTemp creates a temporary file in the specified directory.
-	CreateTemp(dir, pattern string) (*os.File, error)
-	// Remove deletes a file.
-	Remove(path string) error
 }

--- a/e2e/atago/compression_roundtrip.atago.yaml
+++ b/e2e/atago/compression_roundtrip.atago.yaml
@@ -100,3 +100,58 @@ scenarios:
           exit_code: 0
           stdout:
             contains: bobqworst
+
+  # The export writes its bytes straight to the path it is handed. These pin the
+  # count, not just one value: a serializer that truncated or duplicated its tail
+  # would still let a single-row lookup pass.
+  - name: dump preserves every row through gzip
+    steps:
+      - fixture: *src
+      - run:
+          command: sqly src.csv
+          stdin: |
+            .dump src out.csv.gz
+      - assert:
+          exit_code: 0
+      - run:
+          command: sqly --output-format csv --sql "SELECT COUNT(*) AS n FROM out" out.csv.gz
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: |
+              n
+              2
+
+  - name: dump preserves every row uncompressed
+    steps:
+      - fixture: *src
+      - run:
+          command: sqly src.csv
+          stdin: |
+            .dump src out.csv
+      - assert:
+          exit_code: 0
+      - run:
+          command: sqly --output-format csv --sql "SELECT COUNT(*) AS n FROM out" out.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: |
+              n
+              2
+
+  - name: output preserves every row as tsv
+    steps:
+      - fixture: *src
+      - run:
+          command: sqly --sql "SELECT * FROM src ORDER BY id" src.csv --output result.tsv
+      - assert:
+          exit_code: 0
+      - run:
+          command: sqly --output-format csv --sql "SELECT COUNT(*) AS n FROM result" result.tsv
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: |
+              n
+              2

--- a/infrastructure/persistence/file.go
+++ b/infrastructure/persistence/file.go
@@ -29,13 +29,3 @@ func NewFileRepository() repository.FileRepository {
 func (fr *fileRepository) Create(path string) (*os.File, error) {
 	return os.OpenFile(filepath.Clean(path), os.O_RDWR|os.O_CREATE|os.O_TRUNC, defaultFilePerm)
 }
-
-// CreateTemp creates a temporary file in the specified directory.
-func (fr *fileRepository) CreateTemp(dir, pattern string) (*os.File, error) {
-	return os.CreateTemp(dir, pattern)
-}
-
-// Remove deletes a file.
-func (fr *fileRepository) Remove(path string) error {
-	return os.Remove(path)
-}

--- a/interactor/errorpath_test.go
+++ b/interactor/errorpath_test.go
@@ -1,6 +1,8 @@
 package interactor
 
 import (
+	"compress/gzip"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,42 +58,129 @@ func TestDumpTable_ParquetEmpty(t *testing.T) {
 	}
 }
 
-func TestDumpTable_PreservesExistingFileOnFailure(t *testing.T) {
+// TestDumpTable_ReportsTheSerializerFailure checks that a value the format
+// cannot carry is reported rather than written. What happens to the user's
+// destination when it is not this scratch path is decided a layer up, by the
+// staging and rename in shell.writeFileAtomically and in the save flow, which is
+// where the preservation tests live.
+func TestDumpTable_ReportsTheSerializerFailure(t *testing.T) {
 	t.Parallel()
 
-	t.Run("preserves existing file and cleans up temp files when LTSV dump fails due to tab", func(t *testing.T) {
-		t.Parallel()
-
-		exp := newTestExportInteractor()
-		// Table with a tab character in a value, which is invalid in LTSV format
-		table := model.NewTable("test", model.NewHeader([]string{"id", "name"}), []model.Record{
-			model.Record([]string{"1", "alice\tbob"}),
-		})
-
-		tempDir := t.TempDir()
-		outPath := filepath.Join(tempDir, "original.ltsv")
-
-		// Create an existing file with content
-		originalContent := []byte("original data")
-		if err := os.WriteFile(outPath, originalContent, 0o600); err != nil {
-			t.Fatalf("failed to write original file: %v", err)
-		}
-
-		// Try to dump invalid table to the file path, which should fail
-		err := exp.DumpTable(outPath, table, model.ExportLTSV, model.CompressionNone)
-		if err == nil {
-			t.Fatal("expected DumpTable to fail due to tab in LTSV value, but it succeeded")
-		}
-
-		// Verify that the file still contains its original data and has not been truncated
-		currentContent, err := os.ReadFile(outPath) //nolint:gosec // test file with controlled path
-		if err != nil {
-			t.Fatalf("failed to read file: %v", err)
-		}
-		if string(currentContent) != string(originalContent) {
-			t.Errorf("file was altered! got %q, want %q", string(currentContent), string(originalContent))
-		}
+	exp := newTestExportInteractor()
+	// A tab in a value has no representation in LTSV, so the dump must fail.
+	table := model.NewTable("test", model.NewHeader([]string{"id", "name"}), []model.Record{
+		model.Record([]string{"1", "alice\tbob"}),
 	})
+	staging := filepath.Join(t.TempDir(), "staging.ltsv")
+
+	if err := exp.DumpTable(staging, table, model.ExportLTSV, model.CompressionNone); err == nil {
+		t.Fatal("DumpTable with a tab in an LTSV value = nil error, want error")
+	}
+}
+
+// TestDumpTable_WritesOnlyToThePathItIsGiven pins that the export leaves nothing
+// behind anywhere else: it used to serialize into a file in the OS temp
+// directory and copy that across, so a failure could strand one there.
+func TestDumpTable_WritesOnlyToThePathItIsGiven(t *testing.T) {
+	exp := newTestExportInteractor()
+	table := model.NewTable("t", model.NewHeader([]string{"id"}), []model.Record{
+		model.Record([]string{"1"}),
+	})
+
+	before, err := filepath.Glob(filepath.Join(os.TempDir(), "sqly-export-tmp-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := exp.DumpTable(filepath.Join(dir, "ok.csv"), table, model.ExportCSV, model.CompressionNone); err != nil {
+		t.Fatalf("DumpTable = %v, want nil", err)
+	}
+	// A serializer failure is the case that used to leave the strays.
+	bad := model.NewTable("t", model.NewHeader([]string{"id"}), []model.Record{
+		model.Record([]string{"a\tb"}),
+	})
+	if err := exp.DumpTable(filepath.Join(dir, "bad.ltsv"), bad, model.ExportLTSV, model.CompressionNone); err == nil {
+		t.Fatal("DumpTable with a tab in an LTSV value = nil error, want error")
+	}
+
+	after, err := filepath.Glob(filepath.Join(os.TempDir(), "sqly-export-tmp-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Errorf("export left %d file(s) in the OS temp directory, want none", len(after)-len(before))
+	}
+}
+
+// TestDumpTable_RoundTripsThroughItsOwnOutput checks that what the export writes
+// is what the format reads back, for a compressed and an uncompressed
+// destination. Writing the bytes once instead of copying them between two files
+// must not change the file that results.
+func TestDumpTable_RoundTripsThroughItsOwnOutput(t *testing.T) {
+	t.Parallel()
+
+	table := model.NewTable("t", model.NewHeader([]string{"id", "name"}), []model.Record{
+		model.Record([]string{"1", "alice"}),
+		model.Record([]string{"2", "bob"}),
+	})
+	const want = "id,name\n1,alice\n2,bob\n"
+
+	for _, tt := range []struct {
+		name string
+		file string
+		comp model.Compression
+		read func(t *testing.T, path string) string
+	}{
+		{
+			name: "uncompressed csv is the bytes themselves",
+			file: "out.csv",
+			comp: model.CompressionNone,
+			read: func(t *testing.T, path string) string {
+				t.Helper()
+				b, err := os.ReadFile(path) //nolint:gosec // test path under t.TempDir
+				if err != nil {
+					t.Fatal(err)
+				}
+				return string(b)
+			},
+		},
+		{
+			name: "gzip csv decompresses to the same bytes",
+			file: "out.csv.gz",
+			comp: model.CompressionGzip,
+			read: func(t *testing.T, path string) string {
+				t.Helper()
+				f, err := os.Open(path) //nolint:gosec // test path under t.TempDir
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = f.Close() }()
+				zr, err := gzip.NewReader(f)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = zr.Close() }()
+				b, err := io.ReadAll(zr)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return string(b)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := filepath.Join(t.TempDir(), tt.file)
+			if err := newTestExportInteractor().DumpTable(out, table, model.ExportCSV, tt.comp); err != nil {
+				t.Fatalf("DumpTable = %v, want nil", err)
+			}
+			if got := tt.read(t, out); got != want {
+				t.Errorf("round trip = %q, want %q", got, want)
+			}
+		})
+	}
 }
 
 func TestDumpTable_PreservesFilePermissions(t *testing.T) {

--- a/interactor/export.go
+++ b/interactor/export.go
@@ -86,28 +86,28 @@ func (e *exportInteractor) dumpViaPrint(filePath string, table *model.Table, com
 	})
 }
 
-// withCompressedWriter opens filePath, optionally wraps it in a compression
+// withCompressedWriter creates filePath, optionally wraps it in a compression
 // codec, and passes the resulting writer to write. The codec is finalized before
 // the file is closed (deferred close runs in reverse order), so all buffered
 // compressed bytes reach disk.
+//
+// The bytes are written once, straight to filePath. Every caller already hands
+// this a scratch path rather than the user's destination — .dump and --output
+// through writeFileAtomically, .save through its own staging — and that is where
+// "the previous file survives a failed export" is decided. Serializing into a
+// second temporary file first, then copying it across, wrote every exported byte
+// twice and made the export depend on free space in the OS temp directory as
+// well as in the destination's own filesystem.
 func (e *exportInteractor) withCompressedWriter(filePath string, compression model.Compression, write func(io.Writer) error) (err error) {
-	// Create a temporary file in the OS temp directory (does not require write access to target parent directory during staging).
-	tmpFile, err := e.fileRepo.CreateTemp("", "sqly-export-tmp-*")
+	file, err := e.fileRepo.Create(filePath)
 	if err != nil {
-		return fmt.Errorf("create temporary output file: %w", err)
+		return fmt.Errorf("create output file %q: %w", filePath, err)
 	}
-	tmpPath := tmpFile.Name()
-
-	// Ensure cleanup of the temporary file. Both failures are joined onto
-	// whatever the export returned rather than replacing it: a staging file left
-	// on disk is precisely the leftover a caller needs to hear about, and it is
-	// most likely to be left there when the export already failed.
 	defer func() {
-		err = cleanup.Join(err, tmpFile.Close(), "close temporary file")
-		err = cleanup.Join(err, e.fileRepo.Remove(tmpPath), fmt.Sprintf("remove temporary file %q", tmpPath))
+		err = cleanup.Join(err, file.Close(), fmt.Sprintf("close output file %q", filePath))
 	}()
 
-	w, closeComp, err := filesql.NewCompressingWriter(tmpFile, compression)
+	w, closeComp, err := filesql.NewCompressingWriter(file, compression)
 	if err != nil {
 		return fmt.Errorf("init compression for %q: %w", filePath, err)
 	}
@@ -129,28 +129,11 @@ func (e *exportInteractor) withCompressedWriter(filePath string, compression mod
 		return fmt.Errorf("dump to %q: %w", filePath, err)
 	}
 
-	// Flush and close the compression codec.
+	// Finalize the codec here rather than leaving it to the deferred call, so a
+	// codec that fails while flushing its tail is reported as the export failing
+	// instead of as a cleanup note on a success.
 	if err = finalizeComp(); err != nil {
 		return fmt.Errorf("finalize compression for %q: %w", filePath, err)
-	}
-
-	// Rewind the temporary file to the beginning for reading.
-	if _, err = tmpFile.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("seek temporary file: %w", err)
-	}
-
-	// Open the target file in-place (this preserves original permissions, ownership, and metadata).
-	targetFile, err := e.fileRepo.Create(filePath)
-	if err != nil {
-		return fmt.Errorf("create output file %q: %w", filePath, err)
-	}
-	defer func() {
-		err = cleanup.Join(err, targetFile.Close(), fmt.Sprintf("close output file %q", filePath))
-	}()
-
-	// Copy the validated content from the temp file to the target file.
-	if _, err = io.Copy(targetFile, tmpFile); err != nil {
-		return fmt.Errorf("write output file %q: %w", filePath, err)
 	}
 
 	return nil


### PR DESCRIPTION
Every caller of `DumpTable` hands it a scratch path: `.dump` and `--output` through `writeFileAtomically`, `.save` through its own staging. Inside, the export then created a second temporary file in the OS temp directory, serialized into that, seeked back, and copied the bytes across.

The reason given for it, opening the target in place to keep its permissions, stopped applying when the callers moved to stage-and-rename: the path the export receives is never the user's destination. What was left was every exported byte written twice and read once, a dependency on free space in two filesystems rather than one, and a cleanup path for a file that should not have existed. `FileRepository` loses `CreateTemp` and `Remove` with it, leaving `Create`.

The interactor test that asserted an existing file survives a failed dump was asserting a guarantee this layer no longer makes; that guarantee is made by the staging and rename a layer up, where the preservation tests already live (`shell/partialwrite_test.go`). In its place: the serializer failure is reported, nothing is left in the OS temp directory after a success and a failure, and a compressed and an uncompressed export each round-trip through their own output.

Three atago scenarios count the rows back out of a `.dump` to `out.csv.gz`, a `.dump` to `out.csv`, and an `--output result.tsv`, since a single-value lookup would still pass on a truncated tail.

No user-visible change: `make test`, `make lint`, and 956 atago E2E scenarios pass.

Closes #850