### PR TITLE
docs: prepare the v1.0.0-rc7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Release candidates and what v1.0.0 freezes
 
-`v1.0.0-rc6` is the current release candidate, and it is not the final contract
+`v1.0.0-rc7` is the current release candidate, and it is not the final contract
 either. Breaking changes are still being made, and they are being made now
 rather than after v1.0.0.
 
@@ -14,9 +14,23 @@ rather than after v1.0.0.
   Changes below.
 
 The final RC is announced as the final one in its release notes. That is the
-point to pin a version against; none of rc1 through rc6 is it.
+point to pin a version against; none of rc1 through rc7 is it.
 
-## [Unreleased]
+## [v1.0.0-rc7](https://github.com/nao1215/sqly/compare/v1.0.0-rc6...v1.0.0-rc7) (2026-08-07)
+
+A release candidate for v1.0.0, not the final one. Everything below is a change
+from rc6.
+
+The theme of this one is taking things away. Three surfaces a user could reach
+are gone, each because something else already answered the same question:
+`.header`, which printed the column names `.describe` prints; `.mode excel` and
+`.mode parquet`, which set a mode that then rendered CSV; and the SQLite
+database behind the shell's history, which is now a text file one entry per
+line. Inside, six pieces of scaffolding went the same way — interfaces with one
+implementation and nobody substituting them, an export that wrote every byte
+twice, and functions whose last caller had already been deleted. Two documents
+went too: the internal design prose, and the migration guide that restated these
+notes.
 
 ### Breaking Changes
 * Command history is a text file, and the variable that points at it is `SQLY_HISTORY_PATH`. It was a second SQLite database named by `SQLY_HISTORY_DB_PATH`, which bought nothing a file does not: history is an append-only log, and an append to a file opened `O_APPEND` is atomic per write, so two sqly processes interleave whole lines instead of one of them waiting on a lock and then disabling history. The default moves from `history.db` to `history` under the config directory, one entry per line with newlines escaped, so a session's history is readable with anything. An existing `history.db` is not read; the shell starts with an empty history. Unwritable still means one warning and a run that continues.
@@ -25,8 +39,6 @@ point to pin a version against; none of rc1 through rc6 is it.
 
 ### Documentation
 * The migration guide is gone; a breaking change is described once, in its Breaking Changes entry here. `doc/migration.md` restated those entries as before-and-after commands, which meant every breaking change was written twice and kept in step by hand — and by drift tests that existed because it drifted. Each entry above already says what changed and what a caller does about it. The dead pointers to the guide are removed from the README, the site's front page, and the frozen rc3 through rc6 sections.
-
-### Documentation
 * The internal design documents are gone: `doc/architecture.md` and `doc/design_overview.md`. Prose about internal layering has to be maintained by hand beside the code it describes, and the design overview showed the cost of not doing it — it described format-specific models that filesql replaced, and embedded three images the repository does not hold, while the public about page still sent readers to it. The layering is checked by go-arch-lint against `.go-arch-lint.yml`, where the rationale for each edge now lives; the about page links that file. `doc/build_and_test.md` and `doc/cookbook.md` stay: one is how to build, the other is the cookbook page's source.
 
 ### Refactoring

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedw
 
 Documentation: **https://nao1215.github.io/sqly/**
 
-This documentation describes `v1.0.0-rc6`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, and now an export that refuses a value it cannot write rather than changing it — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) before upgrading.
+This documentation describes `v1.0.0-rc7`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, an export that refuses a value it cannot write rather than changing it, and now a shell with `.header` removed, `.mode` limited to formats a screen can show, and its history in a text file — and more can land before v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) before upgrading.
 
 ![demo](./doc/img/demo.gif)
 
@@ -91,7 +91,7 @@ sqly --inspect user.csv
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc6",
+  "sqly_version": "v1.0.0-rc7",
   "tables": [
     {
       "name": "user",

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -1945,15 +1945,21 @@ func TestCHANGELOG_ListsTheRc7BreakingChanges(t *testing.T) {
 	if breaking == "" {
 		t.Fatal("the v1.0.0-rc7 CHANGELOG entry has no Breaking Changes section")
 	}
+	// Each removal is checked twice: by what stopped working, which is the string
+	// a reader greps the notes for, and by what to use instead. An entry that
+	// says a thing is gone without naming its replacement leaves the reader where
+	// the error message already left them, and one that names only the
+	// replacement never meets the reader who is searching for the old spelling.
 	for _, claim := range []string{
 		"`.header` is removed",
-		"`.mode` no longer takes `excel` or `parquet`",
-		"SQLY_HISTORY_PATH",
-		// The replacement matters as much as the removal: an entry that says a
-		// command is gone without saying what to type instead leaves the reader
-		// where the error message already left them.
 		"`.describe`",
+
+		"`.mode` no longer takes `excel` or `parquet`",
 		".dump TABLE out.xlsx",
+
+		"SQLY_HISTORY_DB_PATH",
+		"SQLY_HISTORY_PATH",
+		"text file",
 	} {
 		if !strings.Contains(breaking, claim) {
 			t.Errorf("the rc7 Breaking Changes section does not mention %s", claim)

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -1927,6 +1927,40 @@ func TestAbout_BenchmarkIsMarkedHistorical(t *testing.T) {
 	}
 }
 
+// TestCHANGELOG_ListsTheRc7BreakingChanges holds the release notes to the three
+// surfaces rc7 took away.
+//
+// Each is something a user could type into rc6 and cannot type into rc7, so the
+// notes are the only place they learn it before the shell tells them. A removal
+// that reaches a release without an entry here is the failure this catches.
+func TestCHANGELOG_ListsTheRc7BreakingChanges(t *testing.T) {
+	t.Parallel()
+
+	body := readDoc(t, "CHANGELOG.md")
+	rc7 := section(body, "## [v1.0.0-rc7]")
+	if rc7 == "" {
+		t.Fatal("CHANGELOG.md has no v1.0.0-rc7 section")
+	}
+	breaking := flatten(section(rc7, "### Breaking Changes"))
+	if breaking == "" {
+		t.Fatal("the v1.0.0-rc7 CHANGELOG entry has no Breaking Changes section")
+	}
+	for _, claim := range []string{
+		"`.header` is removed",
+		"`.mode` no longer takes `excel` or `parquet`",
+		"SQLY_HISTORY_PATH",
+		// The replacement matters as much as the removal: an entry that says a
+		// command is gone without saying what to type instead leaves the reader
+		// where the error message already left them.
+		"`.describe`",
+		".dump TABLE out.xlsx",
+	} {
+		if !strings.Contains(breaking, claim) {
+			t.Errorf("the rc7 Breaking Changes section does not mention %s", claim)
+		}
+	}
+}
+
 // TestCHANGELOG_ListsTheRc6BreakingChanges is the rc5 check for the release
 // after it: what the guide tells someone to change, the release notes have to
 // record.

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -4,7 +4,7 @@ title: sqly
 
 sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedwire files. It loads them into an in-memory SQLite database, so joins, CTEs, window functions, and aggregates all work — across formats, in one query.
 
-This site describes `v1.0.0-rc6`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, and now an export that refuses a value it cannot write rather than changing it — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) before upgrading.
+This site describes `v1.0.0-rc7`, a release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, an export that refuses a value it cannot write rather than changing it, and now a shell with `.header` removed, `.mode` limited to formats a screen can show, and its history in a text file — and more can land before v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) before upgrading.
 
 ![sqly running a query against a CSV file](/img/demo.gif)
 

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -479,7 +479,7 @@ Every report opens with two fields that answer different questions:
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc6",
+  "sqly_version": "v1.0.0-rc7",
   "tables": []
 }
 ```
@@ -529,7 +529,7 @@ it has sheets, and nothing in `tables` says what is missing.
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc6",
+  "sqly_version": "v1.0.0-rc7",
   "tables": [],
   "excel_sheets": [
     {


### PR DESCRIPTION
The Unreleased entries become the `v1.0.0-rc7` section, dated today, with a summary of what this candidate is: three surfaces taken away because something else already answered the same question (`.header`, `.mode excel`/`.mode parquet`, and the SQLite database behind the shell's history), six pieces of internal scaffolding that nothing substituted, and two documents that restated what is written elsewhere.

The version references move with it: the README's and the front page's "describes vX" line, which now also names the shell changes rc7 makes, and the `sqly_version` in the `--inspect` samples in the README and the reference page. The two `### Documentation` headings the Unreleased section had accumulated are merged into one.

`TestCHANGELOG_ListsTheRc7BreakingChanges` holds the notes to the three removals and to naming the replacement for each — an entry that says a command is gone without saying what to type instead leaves the reader where the error message already left them. I checked it fails when an entry is dropped before relying on it.

Verified before cutting: `make test`, `make lint` (golangci-lint and go-arch-lint), `make website`, and 989 atago E2E scenarios pass, and `goreleaser release --snapshot --clean` builds every archive and package for linux, macOS, and Windows on both architectures. The dry run stops at the SBOM step only because `syft` is not installed locally; the release workflow downloads it via `anchore/sbom-action`.

The tag is pushed after this merges, per doc/RELEASE.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `.header` command.
  * Limited `.mode` to screen-displayable formats; Excel and Parquet modes are no longer available.
  * Replaced SQLite-backed history with text-file history.
  * Use `.describe` and `.dump TABLE out.xlsx` for supported alternatives.

* **Documentation**
  * Updated release information across the changelog, README, and website for v1.0.0-rc7.
  * Added documentation checks covering the updated breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->