### PR TITLE
fix: import a file whose table name begins with query_result_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ rather than after v1.0.0.
 The final RC is announced as the final one in its release notes. That is the
 point to pin a version against; none of rc1 through rc7 is it.
 
+## [Unreleased]
+
+### Bug Fixes
+
+* A file whose name begins with `query_result_` imports like any other. sqly once materialized results into tables of that name and filtered the prefix out of every listing; the materializing was removed and the filter was not, so it could only reach tables the user owned. Because import decides whether a file produced anything by comparing the table list before and after loading, such a file did not merely go missing from `.tables` and `--inspect` — the import failed outright with "the file has no rows to import" over a file full of rows, and `.save` had no table to write back. `CREATE TABLE query_result_x` had the same result from inside the session. SQLite's own `sqlite_` tables are still excluded, and that prefix is reserved by the engine, so no imported file can land under it.
+
 ## [v1.0.0-rc7](https://github.com/nao1215/sqly/compare/v1.0.0-rc6...v1.0.0-rc7) (2026-08-07)
 
 A release candidate for v1.0.0, not the final one. Everything below is a change

--- a/e2e/atago/reserved_table_prefix.atago.yaml
+++ b/e2e/atago/reserved_table_prefix.atago.yaml
@@ -1,0 +1,113 @@
+# sqly once materialized query results into tables named query_result_<id> and
+# hid them from every listing by filtering the name prefix out of sqlite_master.
+# The materializing is long gone, so the filter only reaches user tables now: a
+# file named query_result_*.csv imported into a table no listing would admit
+# existed. The import check compares the table set before and after loading, so
+# the file did not merely go missing from .tables — the import itself failed with
+# "the file has no rows to import" over a file full of rows. Run with: make test-e2e
+version: "1"
+
+suite:
+  name: sqly tables named with a formerly reserved prefix
+
+scenarios:
+  - name: imports a file whose name begins with query_result_
+    steps:
+      - fixture: &report
+          file: query_result_report.csv
+          content: |
+            id,amount
+            1,100
+            2,250
+      - run:
+          command: sqly --output-format csv --sql 'SELECT amount FROM query_result_report WHERE id = 2' query_result_report.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: "250"
+
+  - name: lists a query_result_ table in .tables
+    steps:
+      - fixture: *report
+      - run:
+          command: sqly query_result_report.csv
+          stdin: ".tables\n"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: query_result_report
+
+  - name: reports a query_result_ table in --inspect
+    steps:
+      - fixture: *report
+      - run:
+          command: sqly --inspect query_result_report.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: "$.tables[0].name"
+              equals: query_result_report
+
+  # The write-back path enumerates tables to match each one to its source, so a
+  # table missing from that enumeration is a table .save cannot write.
+  - name: writes a query_result_ table back to its source
+    steps:
+      - fixture: *report
+      - run:
+          command: sqly query_result_report.csv
+          stdin: |
+            UPDATE query_result_report SET amount = 999 WHERE id = 1;
+            .save --in-place
+      - assert:
+          exit_code: 0
+          stderr:
+            contains: "Saved query_result_report to"
+      - run:
+          command: sqly --output-format csv --sql 'SELECT amount FROM query_result_report WHERE id = 1' query_result_report.csv
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: "999"
+
+  # A table created by hand in the session is the same case reached through SQL
+  # rather than through a file name.
+  - name: lists a query_result_ table created by CREATE TABLE
+    steps:
+      - fixture:
+          file: sample.csv
+          content: |
+            id
+            1
+      - run:
+          command: sqly sample.csv
+          stdin: |
+            CREATE TABLE query_result_scratch (a INTEGER);
+            .tables
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: query_result_scratch
+
+  # SQLite reserves the sqlite_ prefix for its own bookkeeping (sqlite_sequence,
+  # sqlite_stat1) and refuses to create such a table, so that filter still has
+  # something to hide and stays.
+  - name: keeps SQLite internal tables out of .tables
+    steps:
+      - fixture:
+          file: sample.csv
+          content: |
+            id
+            1
+      - run:
+          command: sqly sample.csv
+          stdin: |
+            CREATE TABLE seq (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);
+            INSERT INTO seq (name) VALUES ('a');
+            .tables
+      - assert:
+          exit_code: 0
+          stdout:
+            not_contains: sqlite_sequence

--- a/infrastructure/filesql/adapter.go
+++ b/infrastructure/filesql/adapter.go
@@ -289,8 +289,10 @@ func (f *FileSQLAdapter) GetTableNames(ctx context.Context) ([]*model.Table, err
 		return nil, &FileSQLError{Op: opGetTables, Err: errDatabaseNotInit}
 	}
 
-	// Query sqlite_master for table names, excluding system tables and temporary query result tables
-	query := "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'query_result_%'"
+	// Exclude only SQLite's own bookkeeping tables. Their sqlite_ prefix is
+	// reserved by the engine, which refuses to create a table under it, so no
+	// imported file can be hidden by this.
+	query := "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
 	rows, err := f.sharedDB.QueryContext(ctx, query)
 	if err != nil {
 		return nil, &FileSQLError{Op: opGetTables, Err: err.Error()}

--- a/infrastructure/filesql/adapter_test.go
+++ b/infrastructure/filesql/adapter_test.go
@@ -269,6 +269,33 @@ func TestFileSQLAdapter_GetTableNames(t *testing.T) {
 	}
 }
 
+// TestFileSQLAdapter_GetTableNamesIncludesQueryResultPrefix pins the visibility
+// of a table named query_result_*. Import compares this list before and after
+// loading to decide whether a file produced anything, so a name this list
+// refuses is a file that cannot be imported at all.
+func TestFileSQLAdapter_GetTableNamesIncludesQueryResultPrefix(t *testing.T) {
+	t.Parallel()
+
+	sharedDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("Failed to create shared database: %v", err)
+	}
+	defer func() { _ = sharedDB.Close() }()
+
+	if _, err := sharedDB.ExecContext(context.Background(), `CREATE TABLE query_result_report (id INTEGER)`); err != nil {
+		t.Fatalf("Failed to create query_result_report: %v", err)
+	}
+
+	tables, err := newTestAdapter(sharedDB).GetTableNames(context.Background())
+	if err != nil {
+		t.Fatalf("GetTableNames failed: %v", err)
+	}
+
+	if len(tables) != 1 || tables[0].Name() != "query_result_report" {
+		t.Errorf("GetTableNames() = %v, want [query_result_report]", tables)
+	}
+}
+
 func TestNewFileSQLAdapter(t *testing.T) {
 	t.Parallel()
 

--- a/infrastructure/memory/sqlite3.go
+++ b/infrastructure/memory/sqlite3.go
@@ -37,14 +37,16 @@ func (r *sqlite3Repository) inTx(ctx context.Context, fn func(tx *sql.Tx) error)
 }
 
 // TablesName return all table name in import order.
-// Internal tables (sqlite_* and query_result_*) are excluded from the result.
+// SQLite's own bookkeeping tables (sqlite_sequence, sqlite_stat1) are excluded;
+// SQLite reserves that prefix and refuses to create a table under it, so nothing
+// a user imports can be hidden by the exclusion.
 // Rows are ordered by sqlite_master.rowid, which is assigned in CREATE order, so
 // the result follows the order the source files were imported.
 func (r *sqlite3Repository) TablesName(ctx context.Context) ([]*model.Table, error) {
 	tables := []*model.Table{}
 	err := r.inTx(ctx, func(tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx,
-			"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'query_result_%' ORDER BY rowid")
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY rowid")
 		if err != nil {
 			return err
 		}
@@ -68,9 +70,9 @@ func (r *sqlite3Repository) TablesName(ctx context.Context) ([]*model.Table, err
 // SchemaObjects returns every queryable table and view in the session: base
 // tables and views in the main schema plus TEMP tables and views. It backs
 // .tables, which should enumerate everything the user can query, not only the
-// file-imported base tables that write-back targets. Internal bookkeeping tables
-// (sqlite_* and query_result_*) are excluded, and names are sorted for stable
-// output.
+// file-imported base tables that write-back targets. SQLite's own bookkeeping
+// tables (the reserved sqlite_ prefix) are excluded, and names are sorted for
+// stable output.
 //
 // Each returned table carries the raw object name in Name() and the owning schema
 // ("main" or "temp") as the single Header entry, so .tables can disambiguate a
@@ -78,10 +80,10 @@ func (r *sqlite3Repository) TablesName(ctx context.Context) ([]*model.Table, err
 // (not UNION) keeps both rows of such a collision.
 func (r *sqlite3Repository) SchemaObjects(ctx context.Context) ([]*model.Table, error) {
 	const query = "SELECT name, 'main' AS schema_name FROM sqlite_master " +
-		"WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'query_result_%' " +
+		"WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' " +
 		"UNION ALL " +
 		"SELECT name, 'temp' AS schema_name FROM sqlite_temp_master " +
-		"WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'query_result_%' " +
+		"WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' " +
 		"ORDER BY name"
 
 	tables := []*model.Table{}

--- a/infrastructure/memory/sqlite3_test.go
+++ b/infrastructure/memory/sqlite3_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/nao1215/sqly/config"
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/domain/repository"
@@ -222,7 +223,11 @@ func TestExtractTableName(t *testing.T) {
 func TestSqlite3RepositoryTablesNameExcludesInternalTables(t *testing.T) {
 	t.Parallel()
 
-	t.Run("excludes query_result_ tables", func(t *testing.T) {
+	// A table named query_result_* is the user's, not sqly's. sqly once
+	// materialized results into tables of that name and filtered them out of
+	// every listing; it no longer creates them, so the filter could only ever
+	// reach a table the user imported or created.
+	t.Run("lists a user table whose name begins with query_result_", func(t *testing.T) {
 		t.Parallel()
 
 		memoryDB, cleanup, err := config.NewInMemDB()
@@ -233,62 +238,59 @@ func TestSqlite3RepositoryTablesNameExcludesInternalTables(t *testing.T) {
 
 		r := NewSQLite3Repository(memoryDB)
 
-		if _, err := r.Exec(context.Background(), "CREATE TABLE users (id TEXT, name TEXT)"); err != nil {
-			t.Fatal(err)
+		for _, stmt := range []string{
+			"CREATE TABLE users (id TEXT, name TEXT)",
+			"CREATE TABLE query_result_report (col1 TEXT, col2 TEXT)",
+			"CREATE TABLE products (id TEXT, price TEXT)",
+		} {
+			if _, err := r.Exec(context.Background(), stmt); err != nil {
+				t.Fatal(err)
+			}
 		}
 
-		// Create a query_result_ table (simulating internal table)
-		db := (*sql.DB)(memoryDB)
-		_, err = db.ExecContext(context.Background(),
-			"CREATE TABLE query_result_abc123 (col1 TEXT, col2 TEXT)")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if _, err := r.Exec(context.Background(), "CREATE TABLE products (id TEXT, price TEXT)"); err != nil {
-			t.Fatal(err)
-		}
-
-		// Get table names
 		tables, err := r.TablesName(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		// Verify query_result_ table is excluded
 		tableNames := make([]string, len(tables))
 		for i, table := range tables {
 			tableNames[i] = table.Name()
 		}
 
-		// Should have exactly 2 tables (users and products)
-		if len(tables) != 2 {
-			t.Errorf("Expected 2 tables, got %d: %v", len(tables), tableNames)
+		want := []string{"users", "query_result_report", "products"}
+		if diff := cmp.Diff(want, tableNames); diff != "" {
+			t.Errorf("TablesName() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("reports a query_result_ table in SchemaObjects", func(t *testing.T) {
+		t.Parallel()
+
+		memoryDB, cleanup, err := config.NewInMemDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cleanup()
+
+		r := NewSQLite3Repository(memoryDB)
+		if _, err := r.Exec(context.Background(), "CREATE TABLE query_result_report (a TEXT)"); err != nil {
+			t.Fatal(err)
 		}
 
-		// Verify query_result_ table is not in the list
-		for _, name := range tableNames {
-			if name == "query_result_abc123" {
-				t.Error("query_result_ table should be excluded from TablesName result")
-			}
+		tables, err := r.SchemaObjects(context.Background())
+		if err != nil {
+			t.Fatal(err)
 		}
 
-		// Verify regular tables are included
-		hasUsers := false
-		hasProducts := false
-		for _, name := range tableNames {
-			if name == "users" {
-				hasUsers = true
-			}
-			if name == "products" {
-				hasProducts = true
+		found := false
+		for _, table := range tables {
+			if table.Name() == "query_result_report" {
+				found = true
 			}
 		}
-		if !hasUsers {
-			t.Error("Expected 'users' table to be in the list")
-		}
-		if !hasProducts {
-			t.Error("Expected 'products' table to be in the list")
+		if !found {
+			t.Errorf("SchemaObjects() omitted query_result_report; got %v", tables)
 		}
 	})
 


### PR DESCRIPTION
sqly once materialized query results into tables named `query_result_<id>` and filtered that prefix out of `sqlite_master` in every listing. The materializing was removed long ago; the filter was not, so the only tables it could still reach were the user's own.

Import decides whether a file produced anything by diffing the table list before and after loading, and that list ran through the filter. A file named `query_result_report.csv` therefore did not merely go missing from `.tables` and `--inspect` — the import failed outright with "the file has no rows to import" over a file full of rows, exit 3, and `.save` had no table to write back. `CREATE TABLE query_result_x` inside the session reached the same state.

The filter is removed from the three listings that carried it: `TablesName`, `SchemaObjects`, and the filesql adapter's `GetTableNames`. The `sqlite_` exclusion stays, because SQLite reserves that prefix for its own bookkeeping (`sqlite_sequence`, `sqlite_stat1`) and refuses to create a table under it, so it cannot hide anything a user imported.

## Tests

`e2e/atago/reserved_table_prefix.atago.yaml` covers the user-visible surface: query, `.tables`, `--inspect`, `.save --in-place`, and a table created by `CREATE TABLE` — plus one scenario pinning that `sqlite_sequence` stays hidden. Five of its six scenarios failed before the fix. Unit regressions cover `TablesName`, `SchemaObjects`, and `GetTableNames`; the existing unit test asserted the old behavior and now asserts the new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User-created tables beginning with `query_result_` are now properly listed and recognized.
  * These tables are supported during import, inspection, saving, and manual table creation.
  * SQLite’s internal `sqlite_` tables remain hidden from table listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->