### PR TITLE
fix: refuse an export of a header that could not be read back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ against.
   same output, same exit codes. A bug fix only moves a run toward what these
   notes already describe; it does not change what they promise.
 
+## [Unreleased]
+
+### Bug Fixes
+
+* An export refuses a header it could not read back. rc8 made one rule of the duplicate header on the way in, and csv, tsv, and excel still wrote one on the way out: `SELECT * FROM a JOIN b ON a.id = b.id` names `id` twice, so the export reported success and the file it produced failed to load with `duplicate column name`. json, jsonl, ltsv, and parquet already refused it, which is what made this a difference between formats rather than one answer. All of them refuse it now, at exit `4`, leaving the destination as it was. The rule is the import's own: names are compared with surrounding whitespace removed, and again with ASCII case ignored, so `x` beside ` x` and `a` beside `A` are each refused, while `ä` beside `Ä` still exports because SQLite tells those apart. LTSV gains the case half it was missing.
+
 ## [v1.0.0-rc8](https://github.com/nao1215/sqly/compare/v1.0.0-rc7...v1.0.0-rc8) (2026-08-07)
 
 The final release candidate for v1.0.0. Everything below is a change from rc7.

--- a/domain/model/common.go
+++ b/domain/model/common.go
@@ -1,8 +1,77 @@
 // Package model defines Data Transfer Object (Entity, Value Object)
 package model
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Header is CSV/TSV/Table header.
 type Header []string
+
+// EnsureHeaderReimportable reports an error when a header holds two column names
+// that an import would read as one column.
+//
+// Such a header is refused on the way in, so writing one reports success and
+// leaves behind a file sqly cannot load. That is the silent loss a value the
+// format cannot represent used to cause, and it is refused for the same reason.
+//
+// An import applies two comparisons, and either alone is a refusal, so both are
+// checked here rather than the stricter single rule that combining them gives.
+// Names are compared with surrounding whitespace removed, making "x" and " x"
+// one name; and the CREATE TABLE behind the import compares them as they are
+// with ASCII case ignored, making "a" and "A" one name. Neither rejects a pair
+// that only the two together would, such as "a" beside " A", and that header
+// loads.
+//
+// The fold stops at ASCII because that is the comparison SQLite makes: "ä" and
+// "Ä" are two columns to it, and folding them would refuse a header that loads.
+func EnsureHeaderReimportable(format string, header Header) error {
+	trimmed := make(map[string]string, len(header))
+	folded := make(map[string]string, len(header))
+	for _, name := range header {
+		if first, ok := trimmed[strings.TrimSpace(name)]; ok {
+			return headerConflictError(format, first, name)
+		}
+		if first, ok := folded[asciiFold(name)]; ok {
+			return headerConflictError(format, first, name)
+		}
+		trimmed[strings.TrimSpace(name)] = name
+		folded[asciiFold(name)] = name
+	}
+	return nil
+}
+
+// headerConflictError words the refusal above. It names both columns because
+// they are not always the same text: naming one is enough for a repeat, and says
+// nothing at all when the pair differs only in case or in whitespace.
+func headerConflictError(format, first, second string) error {
+	return fmt.Errorf(
+		"%s: column names %q and %q are one column to an import, which compares them with surrounding whitespace removed and ASCII case ignored, so the file could not be read back; alias one of them (SELECT a AS a1, b AS a2)",
+		format, first, second)
+}
+
+// asciiFold lowercases the ASCII letters in s and leaves every other byte as it
+// is, which is how SQLite compares two column names: its default case folding
+// stops at ASCII, so "ä" and "Ä" stay two names. It returns s unchanged when
+// there is nothing to fold, which is the common case.
+func asciiFold(s string) string {
+	var folded []byte
+	for i := range len(s) {
+		c := s[i]
+		if c < 'A' || c > 'Z' {
+			continue
+		}
+		if folded == nil {
+			folded = []byte(s)
+		}
+		folded[i] = c + ('a' - 'A')
+	}
+	if folded == nil {
+		return s
+	}
+	return string(folded)
+}
 
 // Equal compare Header.
 func (h Header) Equal(h2 Header) bool {

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -482,6 +482,9 @@ func (t *Table) printMarkdownTable(out io.Writer) error {
 // escaped, matching the --output file path and staying valid when redirected to
 // a file or piped to a CSV-aware tool.
 func (t *Table) printCSV(out io.Writer) error {
+	if err := EnsureHeaderReimportable(formatCSV, t.Header()); err != nil {
+		return err
+	}
 	return t.writeDelimited(out, ',')
 }
 
@@ -489,6 +492,9 @@ func (t *Table) printCSV(out io.Writer) error {
 // uses a writer that quotes values containing the delimiter, quotes, or newlines,
 // so the stream stays a valid tabular record when redirected or piped.
 func (t *Table) printTSV(out io.Writer) error {
+	if err := EnsureHeaderReimportable(formatTSV, t.Header()); err != nil {
+		return err
+	}
 	return t.writeDelimited(out, '\t')
 }
 
@@ -709,6 +715,12 @@ func jsonRenderableValue(value any) error {
 // export rather than truncating it.
 func (t *Table) EnsureLTSVWritable() error {
 	if err := EnsureLTSVHeaderWritable(t.Header()); err != nil {
+		return err
+	}
+	// The check above compares labels as they are, which leaves the pair an
+	// import reads as one column: "a" beside "A" is two LTSV labels and one
+	// SQLite column, so the file wrote cleanly and would not load.
+	if err := EnsureHeaderReimportable(formatLTSV, t.Header()); err != nil {
 		return err
 	}
 	for _, v := range t.Rows {

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -984,6 +984,65 @@ func TestTablePrintEscaping(t *testing.T) {
 		}
 	})
 
+	t.Run("CSV rejects duplicate column names", func(t *testing.T) {
+		t.Parallel()
+		tbl := NewTable("t", Header{"x", "x"}, []Record{{"1", "2"}})
+		var buf bytes.Buffer
+		if err := tbl.Print(&buf, PrintModeCSV); err == nil {
+			t.Errorf("want error for duplicate CSV header, got output %q", buf.String())
+		}
+	})
+
+	t.Run("TSV rejects duplicate column names", func(t *testing.T) {
+		t.Parallel()
+		tbl := NewTable("t", Header{"x", "x"}, []Record{{"1", "2"}})
+		var buf bytes.Buffer
+		if err := tbl.Print(&buf, PrintModeTSV); err == nil {
+			t.Errorf("want error for duplicate TSV header, got output %q", buf.String())
+		}
+	})
+
+	t.Run("CSV rejects column names the importer reads as one name", func(t *testing.T) {
+		t.Parallel()
+		// The importer compares names with surrounding whitespace removed and
+		// ASCII case folded, so a header unique byte-for-byte can still be one
+		// no sqly run could load back.
+		for _, tt := range []struct {
+			name   string
+			header Header
+		}{
+			{name: "differ only by case", header: Header{"a", "A"}},
+			{name: "differ only by surrounding whitespace", header: Header{"x", " x"}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				tbl := NewTable("t", tt.header, []Record{{"1", "2"}})
+				var buf bytes.Buffer
+				if err := tbl.Print(&buf, PrintModeCSV); err == nil {
+					t.Errorf("want error for header %v, got output %q", tt.header, buf.String())
+				}
+			})
+		}
+	})
+
+	t.Run("CSV keeps non-ASCII case pairs, which SQLite tells apart", func(t *testing.T) {
+		t.Parallel()
+		tbl := NewTable("t", Header{"ä", "Ä"}, []Record{{"1", "2"}})
+		var buf bytes.Buffer
+		if err := tbl.Print(&buf, PrintModeCSV); err != nil {
+			t.Errorf("Print CSV: %v, want success for names SQLite tells apart", err)
+		}
+	})
+
+	t.Run("LTSV rejects labels that differ only by case", func(t *testing.T) {
+		t.Parallel()
+		tbl := NewTable("t", Header{"a", "A"}, []Record{{"1", "2"}})
+		var buf bytes.Buffer
+		if err := tbl.Print(&buf, PrintModeLTSV); err == nil {
+			t.Errorf("want error for case-folded duplicate LTSV labels, got output %q", buf.String())
+		}
+	})
+
 	t.Run("JSON rejects duplicate column names", func(t *testing.T) {
 		t.Parallel()
 		tbl := NewTable("t", Header{"x", "x"}, []Record{{"1", "2"}})

--- a/e2e/formats_test.go
+++ b/e2e/formats_test.go
@@ -333,6 +333,85 @@ func hexOf(s string) string {
 	return b.String()
 }
 
+// exportExtension is the destination extension each writable format requires,
+// so the round-trip test below can name a file --output will accept.
+var exportExtension = map[string]string{
+	"csv":     ".csv",
+	"tsv":     ".tsv",
+	"ltsv":    ".ltsv",
+	"json":    ".json",
+	"jsonl":   ".jsonl",
+	"excel":   ".xlsx",
+	"parquet": ".parquet",
+}
+
+// TestSmoke_ExportedHeadersReimport is the round-trip property for a header: an
+// export that reports success has written a file sqly can read back.
+//
+// csv, tsv, and excel used to break it. An import reads two column names that
+// differ only in case, or only in surrounding whitespace, as one column and
+// refuses the file; those three writers compared nothing, so `SELECT id AS x,
+// label AS x` exported at exit 0 and the file it produced failed to load at exit
+// 3. json, jsonl, ltsv, and parquet already refused a repeat, which is what made
+// the gap a difference between formats rather than one rule.
+//
+// The property is stated over every writable format rather than over the three
+// that were wrong, and it does not say which side of the line a header falls on:
+// each format is asked, and whichever answer it gives has to hold up — a success
+// must re-import, and a refusal must leave no file behind. A format free to
+// disagree about a header is not free to write one it cannot read.
+func TestSmoke_ExportedHeadersReimport(t *testing.T) {
+	headers := []struct {
+		name    string
+		columns []string
+	}{
+		{name: "a name repeated", columns: []string{"x", "x"}},
+		{name: "names differing only by case", columns: []string{"a", "A"}},
+		{name: "names differing only by surrounding whitespace", columns: []string{"x", " x"}},
+		{name: "names differing by both, which an import tells apart", columns: []string{"a", " A"}},
+		{name: "names differing by non-ASCII case, which SQLite tells apart", columns: []string{"ä", "Ä"}},
+		{name: "distinct names", columns: []string{"a", "b"}},
+	}
+
+	for _, format := range []string{"csv", "tsv", "ltsv", "json", "jsonl", "excel", "parquet"} {
+		t.Run(format, func(t *testing.T) {
+			for _, header := range headers {
+				t.Run(header.name, func(t *testing.T) {
+					dir := t.TempDir()
+					out := filepath.Join(dir, "out"+exportExtension[format])
+					source := writeFixture(t, dir, "src.csv", "id\n1\n")
+
+					selectList := make([]string, 0, len(header.columns))
+					for i, column := range header.columns {
+						selectList = append(selectList,
+							strconv.Itoa(i+1)+` AS "`+column+`"`)
+					}
+					query := "SELECT " + strings.Join(selectList, ", ") + " FROM src"
+
+					_, stderr, code := run(t, "", "--output-format", format, "--output", out, "--sql", query, source)
+					if code != 0 {
+						if code != 4 {
+							t.Fatalf("export exit code = %d, want 0 or 4 (a header the format refuses)\nstderr: %s", code, stderr)
+						}
+						// A refused export leaves the destination alone, as every
+						// other refusal in this file does.
+						if _, err := os.Stat(out); !os.IsNotExist(err) {
+							t.Errorf("refused export left %s behind, want no file", out)
+						}
+						return
+					}
+
+					// The query names no table, so it proves the file loaded rather
+					// than anything about what the load produced.
+					if _, stderr, code := run(t, "", "--sql", "SELECT 1", out); code != 0 {
+						t.Errorf("export succeeded but the file it wrote does not load: exit %d\nstderr: %s", code, stderr)
+					}
+				})
+			}
+		})
+	}
+}
+
 // TestSmoke_ExcelExportRefusesValuesXLSXCannotCarry covers the one format that
 // used to answer an unrepresentable value by changing it. XLSX is XML, and XML
 // 1.0 has no way to write most control characters, so the writer substituted

--- a/infrastructure/persistence/excel.go
+++ b/infrastructure/persistence/excel.go
@@ -78,6 +78,9 @@ func DumpExcel(excelFilePath string, table *model.Table) (err error) {
 			return err
 		}
 	}
+	if err := model.EnsureHeaderReimportable("excel", header); err != nil {
+		return err
+	}
 	if err := f.SetSheetRow(sheetName, "A1", &header); err != nil {
 		return err
 	}

--- a/website/content/formats.md
+++ b/website/content/formats.md
@@ -119,6 +119,18 @@ XLSX — being XML — has no way to hold a control character other than tab,
 newline, and carriage return, nor the two noncharacters `U+FFFE` and `U+FFFF`. Either one names the column and exits `4`, leaving
 the destination as it was; csv, tsv, and json carry all of them.
 
+An export also refuses a header sqly could not read back, by the same rule the
+read side applies: names compared with surrounding whitespace removed, and again
+with ASCII case ignored. `SELECT * FROM a JOIN b ON a.id = b.id` names `id`
+twice, so it is refused in every format at exit `4` — alias one of them:
+
+```shell
+sqly --output-format csv --output out.csv \
+  --sql "SELECT a.id AS a_id, b.id AS b_id FROM a JOIN b ON a.id = b.id" a.csv b.csv
+```
+
+`ä` beside `Ä` is two columns, not one, because that is what SQLite compares.
+
 ## Compression
 
 CSV, TSV, LTSV, JSON, JSONL, Parquet, and Excel are read through `.gz`, `.bz2`, `.xz`, `.zst`, `.z`, `.snappy`, `.s2`, and `.lz4` — so `data.csv.gz` is table `data`, with nothing to declare.


### PR DESCRIPTION
rc8 made one rule of the duplicate header on the way in. csv, tsv, and excel still wrote one on the way out.

`SELECT * FROM a JOIN b ON a.id = b.id` names `id` twice, which is the plainest form of sqly's headline feature. The export reported success, and the file it produced failed to load with `duplicate column name` at exit 3. json, jsonl, ltsv, and parquet already refused such a header, which is what made this a difference between formats rather than one answer.

Every format refuses it now, at exit 4, leaving the destination as it was.

The rule is the import's own, and it is two comparisons rather than one: names compared with surrounding whitespace removed, and names compared as they are with ASCII case ignored. Either alone is a refusal on the way in, so both are checked here rather than the stricter single rule that combining them would give — the pair only their combination rejects, `a` beside ` A`, still exports, because that header loads. The fold stops at ASCII because that is what SQLite compares, so `ä` beside `Ä` stays two columns. LTSV gains the case half it was missing, where `a` beside `A` wrote two labels that read back as one column.

The e2e test states the round-trip property over every writable format rather than over the three that were wrong, and it does not say which side of the line a header falls on: whichever answer a format gives has to hold up, so a successful export must re-import and a refused one must leave no file behind. Reverting the three source files makes it fail in 10 cases.

`make test`, `make lint`, and `go test -tags smoke ./e2e/...` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exports now consistently reject duplicate or unreadable column headers across CSV, TSV, LTSV, and Excel formats.
  * Header comparisons trim surrounding whitespace and ignore ASCII letter case, while preserving distinctions between non-ASCII characters.
  * Refused exports exit with code `4` and leave the destination file unchanged.
  * Error messages identify conflicting columns and indicate when aliases are required.
* **Documentation**
  * Updated format documentation with validation rules and examples for resolving duplicate headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->