### PR TITLE
fix: exit 2 when the .save preflight refuses a script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ against.
 
 ### Bug Fixes
 
+* A script the `.save` preflight refuses exits `2` rather than `1`. The check runs before the first statement, so nothing has run when it fires — no statement feedback is printed and no destination is created — and `2` is the code for a script that was not accepted, where `1` means a statement ran and failed. It reported `1` because the refusal was a bare error, which is the code anything unclassified falls through to.
+
 * An export refuses a header it could not read back. rc8 made one rule of the duplicate header on the way in, and csv, tsv, and excel still wrote one on the way out: `SELECT * FROM a JOIN b ON a.id = b.id` names `id` twice, so the export reported success and the file it produced failed to load with `duplicate column name`. json, jsonl, ltsv, and parquet already refused it, which is what made this a difference between formats rather than one answer. All of them refuse it now, at exit `4`, leaving the destination as it was. The rule is the import's own: names are compared with surrounding whitespace removed, and again with ASCII case ignored, so `x` beside ` x` and `a` beside `A` are each refused, while `ä` beside `Ä` still exports because SQLite tells those apart. LTSV gains the case half it was missing.
+
+### Documentation
+
+* What `--output` does with a destination extension is written down in full. The formats page said the extension "must agree with the chosen format", which holds only for an extension sqly knows: an unknown one is written as given, so `--output report.txt` holds CSV, and a path with no extension gets the format's own, so `--output report` writes `report.csv`. All three are pinned by tests now.
 
 ## [v1.0.0-rc8](https://github.com/nao1215/sqly/compare/v1.0.0-rc7...v1.0.0-rc8) (2026-08-07)
 

--- a/e2e/atomicity_test.go
+++ b/e2e/atomicity_test.go
@@ -281,6 +281,58 @@ func TestSmoke_SaveDoesNotPersistUncommittedData(t *testing.T) {
 	}
 }
 
+// TestSmoke_SavePreflightIsAUsageError pins the class of the .save preflight
+// refusal. The check runs before the first statement, so nothing has run when it
+// fires, and the exit-code table reserves 1 for "a statement ran and failed".
+// It reported 1 anyway, because a bare error falls through to that code.
+func TestSmoke_SavePreflightIsAUsageError(t *testing.T) {
+	dir := t.TempDir()
+	source := writeFixture(t, dir, "src.csv", "id\n1\n")
+	out := filepath.Join(dir, "out")
+
+	script := "CREATE TABLE brand_new (a TEXT);\n" +
+		"INSERT INTO brand_new VALUES ('v');\n" +
+		".save " + out + "\n"
+	stdout, stderr, code := run(t, script, source)
+
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 (the script was not accepted)\nstderr: %s", code, stderr)
+	}
+	if !strings.Contains(stderr, "cannot persist") {
+		t.Errorf("stderr = %q, want the preflight refusal", stderr)
+	}
+	// Nothing ran, so neither statement's feedback line may appear.
+	for _, feedback := range []string{"statement executed successfully", "affected is"} {
+		if strings.Contains(stdout, feedback) {
+			t.Errorf("stdout = %q, want no statement feedback: the script was refused before it ran", stdout)
+		}
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Errorf("a refused script created %s", out)
+	}
+}
+
+// TestSmoke_SaveAfterTheLastSaveIsAllowed is the other side of the preflight
+// window. A statement write-back cannot persist is only a problem when a .save
+// could reach it, so one after the final .save leaves the run alone.
+func TestSmoke_SaveAfterTheLastSaveIsAllowed(t *testing.T) {
+	dir := t.TempDir()
+	source := writeFixture(t, dir, "src.csv", "id\n1\n")
+	out := filepath.Join(dir, "out")
+	if err := os.Mkdir(out, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	script := "UPDATE src SET id = 2;\n" +
+		".save " + out + "\n" +
+		"CREATE TABLE scratch (a TEXT);\n"
+	_, stderr, code := run(t, script, source)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0: the scratch table is after the last .save\nstderr: %s", code, stderr)
+	}
+}
+
 // TestSmoke_NoStrayFilesLeftBehind runs sqly with its working directory inside a
 // directory the test owns and requires that directory to be unchanged
 // afterwards. A temporary staging file or a stray SQLite database left in the

--- a/e2e/formats_test.go
+++ b/e2e/formats_test.go
@@ -413,10 +413,12 @@ func TestSmoke_ExportedHeadersReimport(t *testing.T) {
 }
 
 // TestSmoke_OutputExtensionRules pins what --output does with each kind of
-// destination extension. The formats page claimed the extension "must agree with
-// the chosen format", which is true only of an extension sqly recognizes: an
-// unknown one is written as given and a missing one gets the format's own, and
-// neither was written down.
+// destination extension: a known one must agree with the chosen format, an
+// unknown one is written as given, and a missing one gets the format's own.
+//
+// Only the first was documented. The formats page said the extension "must agree
+// with the chosen format" without qualification, so the two escape hatches were
+// behavior nothing described and nothing held in place.
 func TestSmoke_OutputExtensionRules(t *testing.T) {
 	dir := t.TempDir()
 	source := writeFixture(t, dir, "src.csv", "id\n1\n")

--- a/e2e/formats_test.go
+++ b/e2e/formats_test.go
@@ -412,6 +412,50 @@ func TestSmoke_ExportedHeadersReimport(t *testing.T) {
 	}
 }
 
+// TestSmoke_OutputExtensionRules pins what --output does with each kind of
+// destination extension. The formats page claimed the extension "must agree with
+// the chosen format", which is true only of an extension sqly recognizes: an
+// unknown one is written as given and a missing one gets the format's own, and
+// neither was written down.
+func TestSmoke_OutputExtensionRules(t *testing.T) {
+	dir := t.TempDir()
+	source := writeFixture(t, dir, "src.csv", "id\n1\n")
+
+	t.Run("a known extension must agree with the format", func(t *testing.T) {
+		out := filepath.Join(dir, "disagree.json")
+		_, stderr, code := run(t, "", "--output-format", "csv", "--output", out, "--sql", "SELECT 1", source)
+		if code != 2 {
+			t.Errorf("exit code = %d, want 2\nstderr: %s", code, stderr)
+		}
+		if _, err := os.Stat(out); !os.IsNotExist(err) {
+			t.Errorf("a refused export created %s", out)
+		}
+	})
+
+	t.Run("an unknown extension is written as given", func(t *testing.T) {
+		out := filepath.Join(dir, "report.txt")
+		if _, stderr, code := run(t, "", "--output-format", "csv", "--output", out, "--sql", "SELECT 1 AS n", source); code != 0 {
+			t.Fatalf("exit code = %d, want 0\nstderr: %s", code, stderr)
+		}
+		if _, err := os.Stat(out); err != nil {
+			t.Errorf("want %s written at the path given: %v", out, err)
+		}
+	})
+
+	t.Run("no extension gets the format's own", func(t *testing.T) {
+		out := filepath.Join(dir, "report")
+		if _, stderr, code := run(t, "", "--output-format", "tsv", "--output", out, "--sql", "SELECT 1 AS n", source); code != 0 {
+			t.Fatalf("exit code = %d, want 0\nstderr: %s", code, stderr)
+		}
+		if _, err := os.Stat(out + ".tsv"); err != nil {
+			t.Errorf("want %s.tsv written: %v", out, err)
+		}
+		if _, err := os.Stat(out); !os.IsNotExist(err) {
+			t.Errorf("the extensionless path %s should not also be written", out)
+		}
+	})
+}
+
 // TestSmoke_ExcelExportRefusesValuesXLSXCannotCarry covers the one format that
 // used to answer an unrepresentable value by changing it. XLSX is XML, and XML
 // 1.0 has no way to write most control characters, so the writer substituted

--- a/shell/save.go
+++ b/shell/save.go
@@ -128,10 +128,14 @@ func (s *Shell) preflightSave(elements []scriptElement) error {
 	// changes, ANALYZE, maintenance). Only read-only queries and row-modifying DML
 	// on imported tables are persisted, so a schema-only run must fail loudly here
 	// instead of exiting 0 while leaving the source unchanged.,
+	// An invocationError, not a bare one: this refusal is decided before the first
+	// statement runs, so it is a script that was not accepted (exit 2) rather than
+	// a statement that ran and failed (exit 1), which is what a bare error would
+	// have been classified as.
 	if stmt := firstSaveIncompatibleStatement(elements); stmt != "" {
-		return fmt.Errorf(
+		return &invocationError{Err: fmt.Errorf(
 			".save cannot persist %q: it changes schema or runs a maintenance statement that has no file write-back; only INSERT/UPDATE/DELETE on imported tables are saved",
-			trimGaps(stmt))
+			trimGaps(stmt))}
 	}
 	return nil
 }

--- a/website/content/formats.md
+++ b/website/content/formats.md
@@ -109,7 +109,7 @@ header refused in one format is refused in all of them.
 
 `--output-format csv`, `--output-format tsv`, `--output-format ltsv`, `--output-format json`, `--output-format jsonl`, `--output-format markdown`, `--output-format excel`, `--output-format parquet`, and the default `table`.
 
-`--output PATH` writes to a file; its extension must agree with the chosen format. With the default `table` mode the format is inferred from the extension instead, falling back to CSV.
+`--output PATH` writes to a file. An extension sqly knows must agree with the chosen format, and `--output-format csv --output out.json` is refused as a usage error, exit `2`. An extension it does not know is written as given, so `--output report.txt` holds CSV; a path with no extension gets the format's own, so `--output report` writes `report.csv`. With the default `table` mode the format is inferred from the extension instead, falling back to CSV.
 
 ACH and Fedwire tables can be exported to csv/tsv/xlsx like any other table. Writing them back into a valid `.ach`/`.fed` file is what `.save` does, not `--output`.
 


### PR DESCRIPTION
The `.save` preflight runs before the first statement, so nothing has run when it fires — no statement feedback reaches stdout and no destination is created. The exit-code table reserves `1` for "a statement ran and failed" and `2` for "the script was not accepted", and every other pre-execution rejection already exits `2`: a dot-command written wrong, a `.mode` contradicting a `.dump` destination, a result-set count the format cannot separate. This one reported `1` because the refusal was a bare `fmt.Errorf`, and a bare error is what `ExitCode` falls through to `ExitFailure` for. It is an `invocationError` now; the message is unchanged.

The formats page also says what `--output` does with a destination extension. It claimed the extension "must agree with the chosen format", which holds only for an extension sqly knows: `--output-format csv --output out.json` is refused at exit `2`, but an unknown extension is written as given, so `--output report.txt` holds CSV, and a path with no extension gets the format's own, so `--output report` writes `report.csv`. The extensionless rule was documented for `.dump` and not for `--output`. No behavior changes here — only the page.

Both are pinned at the binary level. The preflight tests assert the exit code, the absence of statement feedback, and that no destination was created, plus the boundary of the preflight window: a statement write-back cannot persist is allowed after the last `.save`, where no save can reach it. The `--output` tests cover all three extension cases, including that the extensionless path is not written alongside the one that gets the suffix.

Closes #878
Closes #881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `.save` preflight refusals now return usage error code 2 with clear persistence errors and no partial output.
  - Duplicate export headers are consistently rejected with exit code 4.
  - Statements after the final valid `.save` no longer cause failures.
  - Output paths now correctly handle conflicting, unknown, and extensionless file extensions.

- **Documentation**
  - Clarified `--output` extension behavior, including format inference and default CSV fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->