### PR TITLE
test(atago): expect exit 2 from the .save preflight refusal

### DIFF
--- a/e2e/atago/readme_examples.atago.yaml
+++ b/e2e/atago/readme_examples.atago.yaml
@@ -369,7 +369,7 @@ scenarios:
             CREATE TABLE backup AS SELECT * FROM user;
             .save out
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "cannot persist"
           file:

--- a/e2e/atago/v0_20_bugs.atago.yaml
+++ b/e2e/atago/v0_20_bugs.atago.yaml
@@ -23,7 +23,7 @@ scenarios:
             ALTER TABLE user RENAME COLUMN first_name TO fname;
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
           stdout:
@@ -39,7 +39,7 @@ scenarios:
             DROP TABLE user;
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
 
@@ -53,7 +53,7 @@ scenarios:
             CREATE VIEW v AS SELECT user_name FROM user;
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
 
@@ -67,7 +67,7 @@ scenarios:
             CREATE INDEX idx ON user(identifier);
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
 
@@ -81,7 +81,7 @@ scenarios:
             CREATE TABLE backup (id INTEGER);
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
 
@@ -95,7 +95,7 @@ scenarios:
             REINDEX;
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
 
@@ -109,7 +109,7 @@ scenarios:
             ANALYZE;
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
 
@@ -123,7 +123,7 @@ scenarios:
             CREATE TABLE backup AS SELECT * FROM user;
             .save out
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
           file:
@@ -138,7 +138,7 @@ scenarios:
           command: sqly user.csv
           stdin: "CREATE TABLE backup AS SELECT * FROM user;\nUPDATE user SET first_name='Z' WHERE identifier=1;\n.save --in-place\n"
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
 

--- a/e2e/atago/v0_21_bugs.atago.yaml
+++ b/e2e/atago/v0_21_bugs.atago.yaml
@@ -174,7 +174,7 @@ scenarios:
             PRAGMA user_version=1;
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
           stdout:
@@ -190,7 +190,7 @@ scenarios:
             PRAGMA incremental_vacuum;
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
           stdout:
@@ -206,7 +206,7 @@ scenarios:
             PRAGMA journal_mode=OFF;
             .save --in-place
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
           stdout:
@@ -222,7 +222,7 @@ scenarios:
             PRAGMA user_version=1;
             .save out
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
           file:
@@ -239,7 +239,7 @@ scenarios:
             PRAGMA incremental_vacuum;
             .save out
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             empty: false
           file:

--- a/e2e/atago/v1_0_rc6_bugs.atago.yaml
+++ b/e2e/atago/v1_0_rc6_bugs.atago.yaml
@@ -260,7 +260,7 @@ scenarios:
       - run:
           command: sqly --script-file before.sqly staff.csv
       - assert:
-          exit_code: 1
+          exit_code: 2
           stderr:
             contains: "changes schema"
 


### PR DESCRIPTION
Fixes main, which is red on the atago and Coverage jobs.

#882 changed the exit code of the `.save` preflight refusal from `1` to `2` — nothing has run when the check fires, so it is a script that was not accepted rather than a statement that ran and failed — and did not update the binary specs that pinned the old code. Sixteen scenarios across four spec files assert it; each one feeds a save-incompatible statement plus a `.save`, so every failure is the same refusal seen from a different scenario.

The Go smoke suite passed because it covers the new behavior; the atago suite covers the old, and neither knew about the other. That is also why this slipped through review: I read the tail of `gh pr checks --watch --fail-fast` on #882 rather than its full result, and the tail was green.

Locally the whole suite passes again: 983 scenarios plus the 26 in the second pass, 0 failed.