### PR TITLE
fix: refuse a zero-row ltsv export instead of writing an empty file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ against.
 
 ### Bug Fixes
 
+* An ltsv export refuses a result with no rows. LTSV records its columns on each row, so a result with no rows has nowhere to put them and the writer produced a zero-byte file — which sqly's own import then refuses as an empty data source, at exit `3`. csv writes its header and json writes `[]`, and both load back as a zero-row table; LTSV has no such form. The export now stops at exit `4`, the way a parquet export of an empty result already does.
+
 * A csv, tsv, or ltsv export refuses a BLOB rather than writing its raw bytes. A BLOB is usually not text at all, and the bytes went into the file as they were, so the export exited `0` and produced a file sqly's own reader then refuses as not UTF-8. XLSX already refused such a value and JSON base64-encodes it; csv, tsv, and ltsv did neither. They now refuse it at exit `4`, naming the column, before anything is written, and the message points at `--output-format json`. XLSX's message, which used to send the user to csv/tsv, points there too. The same refusal covers a text column read with the wrong `--encoding`, which arrives as the same bytes.
 
 * `--row-mismatch skip` says how many rows it dropped. Skipping ragged rows is what the flag asks for, so it is not an error, but an import that reported nothing left one dropped row and most of the file dropped looking exactly alike — and the row count that came out only meant something to someone who already knew what went in. A `.save --in-place` afterwards writes the smaller table back over the source, which is the moment the loss stops being recoverable. Every import path now prints `skipped N of M data rows` on stderr when rows were dropped, and prints nothing when none were.

--- a/domain/model/table.go
+++ b/domain/model/table.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -749,15 +750,23 @@ func jsonRenderableValue(value any) error {
 	}
 }
 
-// EnsureLTSVWritable reports whether the whole table can be written as LTSV: a
-// valid, unique header, and no value holding a tab or a newline. It is checked
+// EnsureLTSVWritable reports whether the whole table can be written as LTSV: at
+// least one row, a valid, unique header, and no value holding a tab or a
+// newline. It is checked
 // in full before any output is produced, so a value LTSV cannot carry fails the
 // export rather than truncating it.
 func (t *Table) EnsureLTSVWritable() error {
 	if err := EnsureLTSVHeaderWritable(t.Header()); err != nil {
 		return err
 	}
-	// The check above compares labels as they are, which leaves the pair an
+	// LTSV records its columns on each row, so a zero-row result has nowhere to
+	// put them and the writer emits nothing. csv's header and json's [] load back
+	// as a zero-row table; an empty file loads as nothing — sqly's own import
+	// refuses it.
+	if t.RowCount() == 0 {
+		return errors.New("ltsv: cannot export a result with no rows; LTSV records its columns on each row, so the file would be empty; use csv/tsv/json")
+	}
+	// The header check above compares labels as they are, which leaves the pair an
 	// import reads as one column: "a" beside "A" is two LTSV labels and one
 	// SQLite column, so the file wrote cleanly and would not load.
 	if err := EnsureHeaderReimportable(formatLTSV, t.Header()); err != nil {

--- a/domain/model/table_test.go
+++ b/domain/model/table_test.go
@@ -984,6 +984,34 @@ func TestTablePrintEscaping(t *testing.T) {
 		}
 	})
 
+	t.Run("LTSV rejects a result with no rows", func(t *testing.T) {
+		t.Parallel()
+		tbl := NewTable("t", Header{"id", "name"}, []Record{})
+		var buf bytes.Buffer
+		err := tbl.Print(&buf, PrintModeLTSV)
+		if err == nil {
+			t.Fatalf("want error for a zero-row LTSV export, got output %q", buf.String())
+		}
+		if !strings.Contains(err.Error(), "no rows") {
+			t.Errorf("error = %v, want it to mention that the result has no rows", err)
+		}
+		if buf.Len() != 0 {
+			t.Errorf("Print wrote %q before failing", buf.String())
+		}
+	})
+
+	t.Run("CSV writes a header for a result with no rows", func(t *testing.T) {
+		t.Parallel()
+		tbl := NewTable("t", Header{"id", "name"}, []Record{})
+		var buf bytes.Buffer
+		if err := tbl.Print(&buf, PrintModeCSV); err != nil {
+			t.Fatalf("Print CSV: %v", err)
+		}
+		if got, want := buf.String(), "id,name\n"; got != want {
+			t.Errorf("Print CSV = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("CSV rejects duplicate column names", func(t *testing.T) {
 		t.Parallel()
 		tbl := NewTable("t", Header{"x", "x"}, []Record{{"1", "2"}})

--- a/e2e/atago/output_format.atago.yaml
+++ b/e2e/atago/output_format.atago.yaml
@@ -59,6 +59,42 @@ scenarios:
           stdout:
             equals: "[]"
 
+  # csv writes its header and json writes [], and both load back as a zero-row
+  # table. LTSV carries its columns on each row, so a result with none has
+  # nowhere to record them: the writer produced an empty file, which sqly's own
+  # import then refuses as empty. sqly now refuses the export, the way parquet
+  # already does.
+  - name: "--output-format ltsv refuses an empty result rather than writing an unreadable file"
+    steps:
+      - fixture: &user_csv
+          file: user.csv
+          content: |
+            user_name,identifier
+            booker12,1
+      - run:
+          command: sqly --output-format ltsv --output empty.ltsv --sql "SELECT user_name FROM user WHERE 1=0" user.csv
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "no rows"
+      - assert:
+          file:
+            path: empty.ltsv
+            exists: false
+
+  - name: "--output-format csv writes a header for an empty result, which loads back"
+    steps:
+      - fixture: *user_csv
+      - run:
+          command: sh -c 'sqly --output-format csv --output empty.csv --sql "SELECT user_name FROM user WHERE 1=0" user.csv && sqly --output-format csv --sql "SELECT count(*) AS n FROM empty" empty.csv'
+          shell: true
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: |
+              n
+              0
+
   - name: "--output-format jsonl renders one JSON object per line"
     steps:
       - fixture:

--- a/e2e/atago/output_format.atago.yaml
+++ b/e2e/atago/output_format.atago.yaml
@@ -86,8 +86,11 @@ scenarios:
     steps:
       - fixture: *user_csv
       - run:
-          command: sh -c 'sqly --output-format csv --output empty.csv --sql "SELECT user_name FROM user WHERE 1=0" user.csv && sqly --output-format csv --sql "SELECT count(*) AS n FROM empty" empty.csv'
-          shell: true
+          command: sqly --output-format csv --output empty.csv --sql "SELECT user_name FROM user WHERE 1=0" user.csv
+      - assert:
+          exit_code: 0
+      - run:
+          command: sqly --output-format csv --sql "SELECT count(*) AS n FROM empty" empty.csv
       - assert:
           exit_code: 0
           stdout:


### PR DESCRIPTION
Exporting a zero-row result to LTSV wrote an empty file, and an empty file cannot be read back — sqly's own import refuses it at exit `3`:

```
sqly --output-format ltsv --output empty.ltsv --sql "SELECT id, name FROM sample WHERE 1=0" sample.csv
sqly --sql "SELECT count(*) FROM empty" empty.ltsv
# import failed: filesql: empty data source: file is empty
```

LTSV carries its schema on the rows: each row lists its own labels, so a result with no rows has nowhere to record its columns and the writer emits nothing. csv writes its header and json writes `[]`, and both re-import as a table with no rows; LTSV has no such form to write.

Of the two answers the issue allows, this takes the second: the export is refused at exit `4` with the reason, rather than writing a file the tool then rejects. That is not a new rule — a parquet export of an empty result already refuses the same way, so the two export-only formats that cannot represent an empty relation now agree.

The check lives in `EnsureLTSVWritable`, beside the header and value checks, so it runs before the first byte goes out and covers stdout as well as `--output`.

Tests: a model-level case for the refusal, a matching one pinning that csv writes its header for the same query, and atago scenarios for the exit code, the absent file, and the csv contrast round-tripping to `count(*) = 0`.

Closes #892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - LTSV exports now fail with exit code `4` when a query returns no rows, preventing unusable empty files.
  - CSV exports for empty results continue to produce reloadable header-only files.
- **Tests**
  - Added coverage for empty-result behavior across LTSV and CSV exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->