### PR TITLE
fix: refuse an excel value longer than a cell holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ against.
 
 ### Bug Fixes
 
+* An excel export refuses a value longer than an XLSX cell instead of cutting it to fit. Excel stops a cell at 32,767 characters, and the writer wrote the first 32,767 of a longer value at exit `0` — a 40,000-character value lost 7,233 characters with nothing said. The length is now checked beside the character check that already refuses a value XLSX cannot carry, in characters because that is the unit the limit is in, and the message names the column, the length, and the limit. A value of exactly the limit still writes and reads back whole.
+
 * An infinity exported to parquet keeps its type. sqly wrote a genuine double into the file, but reading it back gave `+Inf` typed as text, because filesql rendered a non-finite double with `%g` and SQLite's REAL affinity cannot read `+Inf`: the value landed as text in a column declared REAL. Fixed in filesql v0.40.1, which this release depends on. The text formats already spelled the three values `Infinity`, `-Infinity`, and `NaN` everywhere, and JSON already quoted the same words as PostgreSQL's `row_to_json` does; what each format does with a value it cannot hold is now written down in the reference under "What a format cannot hold".
 
 * An ltsv export refuses a result with no rows. LTSV records its columns on each row, so a result with no rows has nowhere to put them and the writer produced a zero-byte file — which sqly's own import then refuses as an empty data source, at exit `3`. csv writes its header and json writes `[]`, and both load back as a zero-row table; LTSV has no such form. The export now stops at exit `4`, the way a parquet export of an empty result already does.

--- a/e2e/atago/excel_export.atago.yaml
+++ b/e2e/atago/excel_export.atago.yaml
@@ -49,6 +49,39 @@ scenarios:
   # excel and parquet name a file, not a screen. .mode used to accept them and
   # then print CSV under the name, with the banner admitting it was "same as csv
   # mode"; a script scraping that output depended on excel meaning csv forever.
+  # Excel stops a cell at 32,767 characters and excelize cuts a longer value to
+  # fit, so the export used to report success having dropped the tail. A value at
+  # the limit still writes, so the refusal is the length past it, not the length.
+  - name: refuses an excel export of a value past the cell limit
+    steps:
+      - fixture: *user
+      - run:
+          command: sqly --output-format excel --output big.xlsx --sql "SELECT printf('%.40000d', 1) AS s FROM user" user.csv
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "an XLSX cell holds 32767"
+      - assert:
+          file:
+            path: big.xlsx
+            exists: false
+
+  - name: writes a value of exactly the cell limit whole
+    steps:
+      - fixture: *user
+      - run:
+          command: sqly --output-format excel --output limit.xlsx --sql "SELECT printf('%.32767d', 1) AS s FROM user" user.csv
+      - assert:
+          exit_code: 0
+      - run:
+          command: sqly --output-format csv --sql "SELECT length(s) AS n FROM limit_user" limit.xlsx
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: |
+              n
+              32767
+
   - name: .mode excel is refused and says what to use instead
     steps:
       - fixture: &modegone

--- a/go.mod
+++ b/go.mod
@@ -78,5 +78,3 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
-
-replace github.com/nao1215/filesql => /home/nao/ghq/github.com/nao1215/filesql

--- a/go.mod
+++ b/go.mod
@@ -78,3 +78,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace github.com/nao1215/filesql => /home/nao/ghq/github.com/nao1215/filesql

--- a/infrastructure/persistence/excel.go
+++ b/infrastructure/persistence/excel.go
@@ -14,6 +14,12 @@ import (
 // excelSheetNameMaxLen is Excel's hard limit on a worksheet name length.
 const excelSheetNameMaxLen = 31
 
+// excelCellMaxLen is Excel's hard limit on the characters one cell holds.
+// A sheet name past its own limit is shortened, because the name is derived from
+// a file name and shortening it costs nothing the data needs; a value is the
+// data, so it is refused instead.
+const excelCellMaxLen = 32767
+
 // excelForbiddenSheetChars are the characters Excel rejects in a worksheet name.
 const excelForbiddenSheetChars = `:\/?*[]`
 
@@ -182,6 +188,12 @@ func ensureExcelRepresentable(label, value string) error {
 	// the wrong --encoding, so the message says so.
 	if !utf8.ValidString(value) {
 		return fmt.Errorf("excel: value for column %q is not valid UTF-8, so XLSX cannot carry it unchanged; re-read the input with the right --encoding, or use --output-format json", label)
+	}
+	// Length is checked in characters because that is the unit Excel's limit is
+	// in. The writer cuts a longer value to fit, which is the same silent loss
+	// the character check above exists to stop, arriving by a different door.
+	if n := utf8.RuneCountInString(value); n > excelCellMaxLen {
+		return fmt.Errorf("excel: value for column %q is %d characters, and an XLSX cell holds %d, so it would be written cut short; export to csv/tsv/json instead", label, n, excelCellMaxLen)
 	}
 	for _, r := range value {
 		if !xmlCanCarry(r) {

--- a/infrastructure/persistence/excel_test.go
+++ b/infrastructure/persistence/excel_test.go
@@ -351,6 +351,19 @@ func TestExcelDumpRefusesAValuePastTheCellLimit(t *testing.T) {
 		}
 	})
 
+	// The limit is in characters, and this is the case that says so: counted in
+	// bytes the value is three times over it. Refusing at 32,768 multi-byte runes
+	// proves nothing on its own, because a byte count refuses that too.
+	t.Run("a multi-byte value of exactly the limit is written whole", func(t *testing.T) {
+		t.Parallel()
+
+		out := filepath.Join(t.TempDir(), "out.xlsx")
+		table := model.NewTable("t", model.Header{"v"}, []model.Record{{strings.Repeat("あ", limit)}})
+		if err := DumpExcel(out, table); err != nil {
+			t.Fatalf("Dump refused a value the cell holds: %v", err)
+		}
+	})
+
 	tests := []struct {
 		name  string
 		table *model.Table
@@ -364,9 +377,7 @@ func TestExcelDumpRefusesAValuePastTheCellLimit(t *testing.T) {
 			table: model.NewTable("t", model.Header{strings.Repeat("x", limit+1)}, []model.Record{{"ok"}}),
 		},
 		{
-			// Characters, not bytes: a multi-byte rune counts once, so a value of
-			// the limit in runes is written however many bytes it takes.
-			name:  "counted in characters, not bytes",
+			name:  "a multi-byte value past the limit",
 			table: model.NewTable("t", model.Header{"v"}, []model.Record{{strings.Repeat("あ", limit+1)}}),
 		},
 	}

--- a/infrastructure/persistence/excel_test.go
+++ b/infrastructure/persistence/excel_test.go
@@ -331,6 +331,65 @@ func TestExcelDumpRefusesInvalidUTF8(t *testing.T) {
 	}
 }
 
+// TestExcelDumpRefusesAValuePastTheCellLimit pins the length half of what a cell
+// can hold. Excel stops at 32,767 characters and excelize cuts a longer value to
+// fit, so a 40,000-character value was written as its first 32,767 with the
+// export reporting success — the same silent truncation the character check
+// already refuses for a byte XLSX cannot carry.
+func TestExcelDumpRefusesAValuePastTheCellLimit(t *testing.T) {
+	t.Parallel()
+
+	const limit = 32767
+
+	t.Run("a value of exactly the limit is written whole", func(t *testing.T) {
+		t.Parallel()
+
+		out := filepath.Join(t.TempDir(), "out.xlsx")
+		table := model.NewTable("t", model.Header{"v"}, []model.Record{{strings.Repeat("x", limit)}})
+		if err := DumpExcel(out, table); err != nil {
+			t.Fatalf("Dump refused a value the cell holds: %v", err)
+		}
+	})
+
+	tests := []struct {
+		name  string
+		table *model.Table
+	}{
+		{
+			name:  "in a value",
+			table: model.NewTable("t", model.Header{"v"}, []model.Record{{strings.Repeat("x", limit+1)}}),
+		},
+		{
+			name:  "in a column name",
+			table: model.NewTable("t", model.Header{strings.Repeat("x", limit+1)}, []model.Record{{"ok"}}),
+		},
+		{
+			// Characters, not bytes: a multi-byte rune counts once, so a value of
+			// the limit in runes is written however many bytes it takes.
+			name:  "counted in characters, not bytes",
+			table: model.NewTable("t", model.Header{"v"}, []model.Record{{strings.Repeat("あ", limit+1)}}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := filepath.Join(t.TempDir(), "out.xlsx")
+			err := DumpExcel(out, tt.table)
+			if err == nil {
+				t.Fatal("Dump succeeded, want a refusal: the value would be cut to the cell limit")
+			}
+			if !strings.Contains(err.Error(), "32767") {
+				t.Errorf("error = %v, want it to name the limit", err)
+			}
+			if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+				t.Errorf("Dump left a file behind at %s; a refused export writes nothing", out)
+			}
+		})
+	}
+}
+
 // TestExcelDumpRefusesATrailingEmptyRow pins the refusal ensureLastRowSurvives
 // exists for: such a file reads back one row short.
 func TestExcelDumpRefusesATrailingEmptyRow(t *testing.T) {

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -322,6 +322,7 @@ and nothing is written.
 | NaN | `NaN` | the string `"NaN"` | `NaN` | NULL, which is what SQLite has for it |
 | a tab or a newline inside a value | kept, quoted where the delimiter needs it; ltsv refuses | kept | kept | kept |
 | a result with no rows | csv and tsv write a header; ltsv refuses | `[]` | written | refused |
+| a value longer than 32,767 characters | kept | kept | refused, because a cell holds no more | kept |
 
 The three words are how the text formats spell the floats that have no decimal
 form; JSON quotes the same words, which is what PostgreSQL's `row_to_json`


### PR DESCRIPTION
An XLSX cell holds 32,767 characters, and excelize cuts a longer value to fit. So an export of a 40,000-character value reported success and wrote its first 32,767 — 7,233 characters gone, exit `0`, nothing on stderr.

`ensureExcelRepresentable` already refuses a value XLSX cannot carry: a byte that is not UTF-8, a character XML's Char production excludes. The length was the case it did not check, and it is the same answer for the same reason — a file the format has to alter to accept is not the file the user asked for. The check now sits beside the others, so it runs before anything is written and the destination is left untouched.

Length is counted in characters, because that is the unit Excel's limit is in: a value of 32,767 multi-byte runes is written however many bytes it takes, and a value of 32,768 is refused whatever its byte length. The message names the column, the value's length, and the limit.

A value of exactly the limit still writes and reads back whole, so what is refused is the length past it, not a margin around it.

A sheet name past its own 31-character limit is still shortened rather than refused. That name is derived from a file name and shortening it costs nothing the data needs; a value is the data.

Tests: the at-limit and past-limit cases, a column name past the limit, a multi-byte value that is past the limit in characters, and atago scenarios that pin the exit code, the message, the absent file, and a 32,767-character value round-tripping to `length(s) = 32767`. The reference table of what each format cannot hold gains the row.

Closes #896

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Excel exports now reject cell values or column names exceeding 32,767 characters instead of truncating them.
  * Error messages identify the affected value, its length, and the supported limit.
  * Values exactly at the 32,767-character limit remain supported.

* **Documentation**
  * Clarified character-length limitations across supported export formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->