### PR TITLE
docs: stamp v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,17 @@
 # CHANGELOG
 
-## Release candidates and what v1.0.0 freezes
+## Release candidates and what v1.0.0 froze
 
-`v1.0.0-rc8` is the final release candidate. This is the point to pin a version
-against.
+`v1.0.0` is the stable release. Pin against it.
 
-* Breaking changes landed before this candidate. Each is listed under Breaking
-  Changes in the section for the release that made it, rc1 through rc8.
-* From here on, only bug fixes and documentation changes: no new feature, no
-  breaking change.
-* Nothing user-visible changes between this candidate and v1.0.0 — same flags,
-  same output, same exit codes. A bug fix only moves a run toward what these
-  notes already describe; it does not change what they promise.
+* Breaking changes landed during the release candidates, rc1 through rc8. Each
+  is listed under Breaking Changes in the section for the candidate that made it.
+* Between rc8 and v1.0.0 only bug fixes and documentation changes landed, as
+  rc8 promised: no new flag, no new feature, no changed default. A bug fix
+  moves a run toward what these notes already describe — most turned a silently
+  wrong result into a named error — without changing what the notes promise.
 
-## [Unreleased]
+## [v1.0.0](https://github.com/nao1215/sqly/compare/v1.0.0-rc8...v1.0.0) (2026-08-09)
 
 ### Bug Fixes
 
@@ -52,6 +50,8 @@ against.
 * prompt v0.0.19. Five of its fixes are visible in sqly's shell: input that filled a terminal row exactly no longer erases the line above the prompt (the bottom of the result you are reading), a prompt prefix wider than the terminal no longer leaves a torn copy of itself behind on every line, Ctrl+R redraws its search in place instead of stacking a block per keystroke, a statement recalled from history comes back as it was submitted (a multi-line statement is one entry, and its leading spaces survive), and a completion menu wider than the terminal no longer leaves rows of itself above the prompt.
 
 ### Documentation
+
+* What a write-back does and does not preserve is written down. `.save` keeps a source's compression and encoding but not its bytes: every row it writes ends `\n` and a field is quoted only when CSV requires it, so a saved CRLF file comes back LF and needless quotes are dropped. The formats page says so beside the note that promises the other two, and points at `--output` for a source whose bytes must survive. The line-terminator half is tracked as [filesql#269](https://github.com/nao1215/filesql/issues/269).
 
 * What `--output` does with a destination extension is written down in full. The formats page said the extension "must agree with the chosen format", which holds only for an extension sqly knows: an unknown one is written as given, so `--output report.txt` holds CSV, and a path with no extension gets the format's own, so `--output report` writes `report.csv`. All three are pinned by tests now.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedw
 
 Documentation: **https://nao1215.github.io/sqly/**
 
-This documentation describes `v1.0.0-rc8`, the final release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, an export that refuses a value it cannot write rather than changing it, a shell with `.header` removed, `.mode` limited to formats a screen can show, and its history in a text file, and now a text input that is not valid UTF-8 refused rather than loaded as mojibake — and only bug fixes and documentation changes land between it and v1.0.0, so read the [CHANGELOG](./CHANGELOG.md) before upgrading.
+This documentation describes `v1.0.0`. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, an export that refuses a value it cannot write rather than changing it, a shell with `.header` removed, `.mode` limited to formats a screen can show, and its history in a text file, and a text input that is not valid UTF-8 refused rather than loaded as mojibake — so read the [CHANGELOG](./CHANGELOG.md) before upgrading.
 
 ![demo](./doc/img/demo.gif)
 
@@ -91,7 +91,7 @@ sqly --inspect user.csv
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc8",
+  "sqly_version": "v1.0.0",
   "tables": [
     {
       "name": "user",

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -4,7 +4,7 @@ title: sqly
 
 sqly runs SQL against CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, and Fedwire files. It loads them into an in-memory SQLite database, so joins, CTEs, window functions, and aggregates all work — across formats, in one query.
 
-This site describes `v1.0.0-rc8`, the final release candidate. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, an export that refuses a value it cannot write rather than changing it, a shell with `.header` removed, `.mode` limited to formats a screen can show, and its history in a text file, and now a text input that is not valid UTF-8 refused rather than loaded as mojibake — and only bug fixes and documentation changes land between it and v1.0.0, so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) before upgrading.
+This site describes `v1.0.0`. It carries substantial breaking changes over v0.x — classified exit codes, visible-only Excel sheets, SIGTERM `143`, multiple inputs as one atomic import, a schema-only `--inspect`, default-deny remote input, stdout carrying nothing but data in every machine-readable format, an export that refuses a value it cannot write rather than changing it, a shell with `.header` removed, `.mode` limited to formats a screen can show, and its history in a text file, and a text input that is not valid UTF-8 refused rather than loaded as mojibake — so read the [CHANGELOG](https://github.com/nao1215/sqly/blob/main/CHANGELOG.md) before upgrading.
 
 ![sqly running a query against a CSV file](/img/demo.gif)
 

--- a/website/content/formats.md
+++ b/website/content/formats.md
@@ -454,6 +454,13 @@ the user already had.
 `--output` and `.dump` are unaffected: they create new files rather than
 rewriting one the session read, and a new file is UTF-8.
 
+A write-back preserves values, not bytes. The text writers end every row with
+`\n` and quote a field only when CSV requires it, so a CRLF file saved in place
+comes back LF throughout, untouched rows included, and a field the source quoted
+needlessly comes back bare. That matters to a diff or a repository that expects
+the original bytes; if they must survive, leave the source untouched and export
+a copy with `--output`.
+
 Binary containers are not affected: Parquet and Excel state their own encoding,
 and ACH and Fedwire are fixed-width records, so none of them is validated as
 UTF-8 text.

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -512,7 +512,7 @@ Every report opens with two fields that answer different questions:
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc8",
+  "sqly_version": "v1.0.0",
   "tables": []
 }
 ```
@@ -562,7 +562,7 @@ it has sheets, and nothing in `tables` says what is missing.
 ```json
 {
   "schema_version": 1,
-  "sqly_version": "v1.0.0-rc8",
+  "sqly_version": "v1.0.0",
   "tables": [],
   "excel_sheets": [
     {


### PR DESCRIPTION
Stamps the repository for the v1.0.0 release. Documentation only; no code changes.

Pre-release audit, for the record: sqly has zero open issues and zero open pull requests, main's workflows are green, the atago suite passes 1036 scenarios, and the release pipeline needs nothing from this PR — GoReleaser stamps `config.Version` from the tag and the Makefile derives its version from `git describe`. The dialect gaps under `e2e/atago/known_bugs/` are deliberate, documented limitations with executable records, not open defects.

What this PR changes. The CHANGELOG's `Unreleased` section becomes `v1.0.0`, and the intro that framed rc8 as the final candidate now records that the promise was kept: only bug fixes and documentation changes landed after it, each moving a run toward what the notes already describe. The README and website banners stop describing a release candidate. The `--inspect` sample outputs on the README and the reference page say `"sqly_version": "v1.0.0"`.

One known limitation is written down rather than fixed, because the fix belongs to filesql and is tracked there as filesql#269: a write-back preserves a source's compression and encoding but not its bytes — every row the text writers emit ends `\n` and a field is quoted only when CSV requires it, so a CRLF file saved in place comes back LF throughout and needless quotes are dropped. Both halves are verified against the current binary, and the formats page now says so beside the note that promises compression and encoding, pointing at `--output` for a source whose bytes must survive. That issue's own acceptance criteria list documenting the limitation beside that note as a resolution.

After merge, pushing the `v1.0.0` tag triggers the release workflow (GoReleaser, cosign, SBOM, provenance).
