### PR TITLE
docs(readme): credit the two sponsors who shaped sqly

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -82,6 +82,27 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "adamdecaf",
+      "name": "Adam Shannon",
+      "avatar_url": "https://avatars.githubusercontent.com/u/120951?v=4",
+      "profile": "https://ashannon.us",
+      "contributions": [
+        "financial",
+        "ideas"
+      ]
+    },
+    {
+      "login": "sho-hata",
+      "name": "Shoki Hata",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37888628?v=4",
+      "profile": "https://sho-hata.com",
+      "contributions": [
+        "financial",
+        "ideas",
+        "userTesting"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
   
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/sqly/coverage.svg)
@@ -358,6 +358,14 @@ Bugs and feature requests go to [GitHub Issues](https://github.com/nao1215/sqly/
 - [prompt](https://github.com/nao1215/prompt) — the line editor behind the interactive shell
 - [atago](https://github.com/nao1215/atago) — the end-to-end test runner: it drives the real `sqly` binary, not a mock, from the plain-YAML specs in `e2e/atago/`. `make test-e2e` runs that suite locally, and CI runs it on Linux, macOS, and Windows after installing atago with [setup-atago](https://github.com/nao1215/setup-atago)
 
+## Acknowledgments
+
+sqly is a memorable project for me because it connected me with two GitHub Sponsors.
+
+[Adam Shannon](https://github.com/adamdecaf), who works in the payments industry at Moov, inspired sqly's support for financial file formats such as ACH and Fedwire. [Shoki Hata](https://github.com/sho-hata), a colleague of mine, has actively used both filesql and sqly; feedback from an actual user improved filesql's performance and led to many bug fixes in sqly.
+
+Thank you both for supporting the project as sponsors, and thanks to everyone who has improved sqly through code, documentation, bug reports, and other contributions.
+
 ## LICENSE
 
 The sqly project is licensed under the terms of [MIT LICENSE](./LICENSE).
@@ -382,6 +390,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/SnowleopardXI"><img src="https://avatars.githubusercontent.com/u/69493681?v=4?s=75" width="75px;" alt="Ephraim Steve Micaiah"/><br /><sub><b>Ephraim Steve Micaiah</b></sub></a><br /><a href="https://github.com/nao1215/sqly/issues?q=author%3ASnowleopardXI" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://ashannon.us"><img src="https://avatars.githubusercontent.com/u/120951?v=4?s=75" width="75px;" alt="Adam Shannon"/><br /><sub><b>Adam Shannon</b></sub></a><br /><a href="#financial-adamdecaf" title="Financial">💵</a> <a href="#ideas-adamdecaf" title="Ideas, Planning, &amp; Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://sho-hata.com"><img src="https://avatars.githubusercontent.com/u/37888628?v=4?s=75" width="75px;" alt="Shoki Hata"/><br /><sub><b>Shoki Hata</b></sub></a><br /><a href="#financial-sho-hata" title="Financial">💵</a> <a href="#ideas-sho-hata" title="Ideas, Planning, &amp; Feedback">🤔</a> <a href="#userTesting-sho-hata" title="User Testing">📓</a></td>
     </tr>
   </tbody>
   <tfoot>


### PR DESCRIPTION
## Summary

The v1.0.0 release notes thanked two GitHub Sponsors whose support shaped sqly, but the README credited neither. This adds them to the README so the acknowledgment lives with the project rather than only in a single release's notes.

## Changes

- `README.md`: adds an Acknowledgments section before LICENSE, carrying over the wording from the v1.0.0 release notes.
- `README.md`: adds both people to the all-contributors table and bumps the badge count from 8 to 10.
- `.all-contributorsrc`: adds the matching entries so the bot does not drop them on its next run.

## Design Decisions

Contribution types follow the all-contributors emoji key rather than inventing new ones: Financial for the sponsorship, Ideas for the feature direction (the payments-format support that became ACH and Fedwire), and User Testing for the real-world use of filesql and sqly that produced the performance and bug-fix feedback.

Both people are referenced by name with a plain profile link instead of an at-handle, in the README, in the commit message, and here. An at-handle in a pull request body or commit message notifies the person, and neither of them asked to be pulled into this thread.

Profile links point at the personal sites listed on their GitHub profiles, matching how the existing table entry for the maintainer is written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributor count from 8 to 10.
  * Added acknowledgments for Adam Shannon and Shoki Hata.
  * Recognized contributions related to financial support, feedback, ideas, and user testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->