### PR TITLE
docs(readme): add Awesome Go badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-  
+[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/sqly/coverage.svg)
 [![Build](https://github.com/nao1215/sqly/actions/workflows/build.yml/badge.svg)](https://github.com/nao1215/sqly/actions/workflows/build.yml)
 [![reviewdog](https://github.com/nao1215/sqly/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/sqly/actions/workflows/reviewdog.yml)


### PR DESCRIPTION
## Why

sqly is now listed in [avelino/awesome-go](https://github.com/avelino/awesome-go) (Database category, `sqly`). The listing is worth surfacing on the README the same way gup does.

## What

- Add the `Mentioned in Awesome Go` badge to the README badge block, right after the all-contributors badge — the same position gup uses.
- The line it replaces was a stray whitespace-only line, so the badge block itself is otherwise untouched.

## Note

No functional change; README only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Mentioned in” badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->