### PR TITLE
feat(release): publish Windows builds to winget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          # Fork-scoped token so the winget manifests can be pushed to
+          # nao1215/winget-pkgs and the pull request opened upstream.
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -104,6 +104,56 @@ nfpms:
       - deb
       - rpm
       - apk
+# winget distribution for Windows. The Windows archives are already zips, which
+# winget installs as a portable package, so `winget install nao1215.sqly` puts
+# sqly.exe on PATH without an installer. GoReleaser writes the three manifests
+# (version, installer, locale) to a branch on nao1215/winget-pkgs — a fork of
+# the community repository — and opens the pull request against
+# microsoft/winget-pkgs, so a tag stays the only manual step. `skip_upload: auto`
+# skips the release-candidate tags, which the community repository does not
+# accept.
+winget:
+  - name: sqly
+    package_identifier: nao1215.sqly
+    publisher: nao1215
+    publisher_url: "https://github.com/nao1215"
+    publisher_support_url: "https://github.com/nao1215/sqly/issues"
+    homepage: "https://github.com/nao1215/sqly"
+    short_description: SQL shell for CSV, TSV, LTSV, JSON, JSONL, Parquet, Excel, ACH, Fedwire, and compressed files
+    description: |
+      sqly runs SQL over files you already have. It opens CSV, TSV, LTSV, JSON,
+      JSONL, Parquet, Excel, ACH, and Fedwire — and their compressed forms — as
+      tables in an in-memory SQLite database, joins files of different formats
+      as peers, and can write the result back into the source file. An
+      interactive shell with completion and history is the primary way to use
+      it; a one-shot `--sql` run is available for scripts.
+    license: MIT
+    license_url: "https://github.com/nao1215/sqly/blob/main/LICENSE"
+    copyright: "Copyright (c) 2022 Naohiro CHIKAMATSU"
+    release_notes_url: "https://github.com/nao1215/sqly/releases/tag/{{ .Tag }}"
+    tags:
+      - sql
+      - sqlite
+      - csv
+      - tsv
+      - json
+      - parquet
+      - excel
+      - cli
+      - golang
+    skip_upload: auto
+    repository:
+      owner: nao1215
+      name: winget-pkgs
+      branch: "sqly-{{ .Version }}"
+      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
 brews:
   - name: sqly
     description: SQL shell for CSV/TSV/LTSV/JSON/JSONL/Parquet/Excel/ACH/Fedwire + compressed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Features
+
+* Windows installs through winget: `winget install nao1215.sqly`. A tagged release pushes the generated manifests to a fork of the community repository and opens the pull request against microsoft/winget-pkgs, so the package tracks releases without a separate manual submission. The Windows archives are zips, which winget installs as a portable package — `sqly.exe` lands on PATH with no installer to run. Release-candidate tags are skipped, since the community repository takes stable versions only.
+
 ## Release candidates and what v1.0.0 froze
 
 `v1.0.0` is the stable release. Pin against it.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ go install github.com/nao1215/sqly@latest
 brew install nao1215/tap/sqly
 ```
 
+On Windows, winget installs it from the community repository:
+
+```shell
+winget install nao1215.sqly
+```
+
 Arch Linux users can install the [AUR package](https://aur.archlinux.org/packages/sqly-bin):
 
 ```shell

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -32,11 +32,16 @@ The release workflow then:
 - signs the checksums with cosign (keyless) and attaches an SBOM;
 - attests build provenance via GitHub OIDC;
 - updates the Homebrew tap (`nao1215/homebrew-tap`).
+- pushes the winget manifests to `nao1215/winget-pkgs` and opens the pull
+  request against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs).
+  Release-candidate tags are skipped; the community repository takes stable
+  versions only.
 
 ## Required secrets
 - `GITHUB_TOKEN`: provided automatically; used to create the GitHub Release.
 - `TAP_GITHUB_TOKEN`: a token with write access to `nao1215/homebrew-tap`,
   used to push the updated formula.
+- `WINGET_GITHUB_TOKEN`: a **classic** personal access token with the `public_repo` scope. GoReleaser v2.16.0 uses this one token for both writes: committing the manifests to a branch on `nao1215/winget-pkgs`, the fork of the community repository, and opening the pull request against microsoft/winget-pkgs. A fine-grained token cannot do the second — it can only be scoped to repositories you own, and microsoft/winget-pkgs is not one of them, so the push succeeds and the pull request fails with 403. A failure is logged without failing the release, so a rejected or delayed pull request never blocks a version. If a release finishes but no pull request appears, `dist/winget/manifests/n/nao1215/sqly/<version>/` still holds the three files and they can be submitted by hand from a `sqly-<version>` branch on the fork.
 
 ## After releasing
 - Check the [Releases page](https://github.com/nao1215/sqly/releases) for the

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -1787,12 +1787,14 @@ func TestGoReleaser_DescriptionsNameTheCurrentFormats(t *testing.T) {
 		t.Error(".goreleaser.yml's release header does not mention compressed inputs")
 	}
 
-	// Both package descriptions — nFPM and Homebrew — must have moved off the old
-	// four-format list. They are checked by absence of the stale phrasing and by
-	// presence of the formats that were missing from it.
-	descriptions := regexp.MustCompile(`(?m)^\s*description:\s*(.+)$`).FindAllStringSubmatch(config, -1)
-	if len(descriptions) != 2 {
-		t.Fatalf("found %d description fields in .goreleaser.yml, want 2 (nFPM and Homebrew)", len(descriptions))
+	// Every one-line package description — nFPM, winget, and Homebrew — must have
+	// moved off the old four-format list. They are checked by absence of the stale
+	// phrasing and by presence of the formats that were missing from it. winget's
+	// prose description is a block scalar, which the pattern skips: it is covered
+	// by the whole-file format check above.
+	descriptions := regexp.MustCompile(`(?m)^\s*(?:short_)?description:[ \t]+([^|>\s].*)$`).FindAllStringSubmatch(config, -1)
+	if len(descriptions) != 3 {
+		t.Fatalf("found %d one-line description fields in .goreleaser.yml, want 3 (nFPM, winget, and Homebrew)", len(descriptions))
 	}
 	for i, match := range descriptions {
 		desc := strings.TrimSpace(match[1])
@@ -1806,10 +1808,10 @@ func TestGoReleaser_DescriptionsNameTheCurrentFormats(t *testing.T) {
 		}
 	}
 
-	// Homebrew rejects a formula whose desc runs past 80 characters, so the
-	// shorter of the two has to stay short. The second description is the brews
-	// one; the file's order is asserted above by there being exactly two.
-	brew := strings.TrimSpace(descriptions[1][1])
+	// Homebrew rejects a formula whose desc runs past 80 characters, so that one
+	// has to stay short. The last description is the brews one; the file's order is
+	// asserted above by there being exactly three.
+	brew := strings.TrimSpace(descriptions[len(descriptions)-1][1])
 	if len(brew) > 80 {
 		t.Errorf("the Homebrew description is %d characters; brew audit caps it at 80: %q", len(brew), brew)
 	}

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -84,4 +84,4 @@ See [Shell](/shell/) for every dot-command.
 go install github.com/nao1215/sqly@latest
 ```
 
-Homebrew, the AUR, aqua, mise, and prebuilt binaries are on the [install page](/install/).
+Homebrew, winget, the AUR, aqua, mise, and prebuilt binaries are on the [install page](/install/).

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -1,6 +1,6 @@
 ---
 title: Install
-description: Install sqly with go install, Homebrew, the AUR, aqua, mise, or a prebuilt binary, and verify the release signature.
+description: Install sqly with go install, Homebrew, winget, the AUR, aqua, mise, or a prebuilt binary, and verify the release signature.
 weight: 10
 ---
 
@@ -16,6 +16,12 @@ go install github.com/nao1215/sqly@latest
 
 ```shell
 brew install nao1215/tap/sqly
+```
+
+## winget (Windows)
+
+```shell
+winget install nao1215.sqly
 ```
 
 ## Arch Linux (AUR)


### PR DESCRIPTION
## Summary

sqly has no Windows package manager today — a Windows user downloads a zip from the release page and puts it on PATH by hand. winget ships with Windows, and the release already builds what it needs: the Windows archives are zips, which winget installs as a portable package, so `winget install nao1215.sqly` puts sqly.exe on PATH with no installer to build or sign.

GoReleaser writes the three manifests to a branch on nao1215/winget-pkgs, a fork of the community repository, and opens the pull request against microsoft/winget-pkgs. A tag stays the only manual step. Release-candidate tags are skipped via `skip_upload: auto` because the community repository takes stable versions only, and a failure there is logged without failing the release, so a rejected or delayed pull request cannot block a version.

`TestGoReleaser_DescriptionsNameTheCurrentFormats` asserted exactly two description fields. winget's `short_description` is a third, and it names the same nine formats; its prose `description` is a block scalar, which the pattern now skips, since the whole-file format check above it already covers that text. The Homebrew 80-character check now reads the last description rather than the second.

Verified with the pinned GoReleaser (v2.16.0): it generates the version, installer, and locale manifests, with x64 and arm64 installers pointing at the release zips, `NestedInstallerType: portable`, and `PortableCommandAlias: sqly`.

Related issue:

## Checklist

- [x] Tests added or updated (Go unit tests, and atago E2E specs for CLI/shell behavior)
- [x] `make test` and `make lint` pass locally
- [x] Docs updated when behavior, help text, or README changed (English `README.md` and `doc/pages/markdown/`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] Cross-platform impact considered for CLI, shell, and path behavior (Linux, macOS, Windows)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows installation through WinGet using `winget install nao1215.sqly`.
  * Stable releases can publish WinGet manifests automatically and open upstream pull requests.
  * Release candidates are excluded from WinGet publishing.
  * Portable ZIP installation is supported for Windows.

* **Documentation**
  * Updated the README, website, changelog, and release documentation with WinGet installation, publishing details, and available installation options such as mise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
