### PR TITLE
test(e2e): run the atago suite on atago v0.20.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.18.0
+          version: v0.20.0
 
       # Combines unit-test coverage with self-hosted E2E coverage (the atago
       # suite runs a `go build -cover` sqly and collects covdata via

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.18.0
+          version: v0.20.0
 
       - name: Run atago end-to-end tests
         # The hermetic runner builds sqly and runs the suite in a temp-backed
@@ -76,7 +76,7 @@ jobs:
       - name: Install atago
         uses: nao1215/setup-atago@e4b6719aea547a68e6c15252222babab7f492a88 # v0.1.1
         with:
-          version: v0.18.0
+          version: v0.20.0
 
       - name: Build sqly
         run: go build -o sqly.exe main.go

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ specs (`e2e/atago/`) that exercises the real `sqly` binary. It runs in CI
 ```shell
 # Install atago once. CI pins the same version in .github/workflows/e2e_test.yml,
 # and TestContributing_PinsTheAtagoVersionCIInstalls fails when the two drift.
-go install github.com/nao1215/atago@v0.18.0
+go install github.com/nao1215/atago@v0.20.0
 
 # Build the binary and run the suite
 make test-e2e

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/sqly/coverage.svg)
+[![tested with atago](https://img.shields.io/badge/tested%20with-atago-7c3aed?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI%2BPHBhdGggZmlsbD0iI2ZmZiIgZD0iTTMuNiA0LjIgMTEuOSAxMmwtOC4zIDcuOC0xLjktMi4yTDcuOSAxMiAxLjcgNi40eiIvPjxyZWN0IGZpbGw9IiNmZmYiIHg9IjEyLjYiIHk9IjE3LjIiIHdpZHRoPSI5LjciIGhlaWdodD0iMi44IiByeD0iMS40Ii8%2BPC9zdmc%2B&logoColor=white)](https://github.com/nao1215/atago)
 [![Build](https://github.com/nao1215/sqly/actions/workflows/build.yml/badge.svg)](https://github.com/nao1215/sqly/actions/workflows/build.yml)
 [![reviewdog](https://github.com/nao1215/sqly/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/sqly/actions/workflows/reviewdog.yml)
 ![GitHub](https://img.shields.io/github/license/nao1215/sqly)

--- a/doc/build_and_test.md
+++ b/doc/build_and_test.md
@@ -32,7 +32,7 @@ E2E suite runs the built `sqly` binary rather than linking a library; install it
 separately with the version CONTRIBUTING.md pins, which is the one CI uses:
 
 ```shell
-$ go install github.com/nao1215/atago@v0.18.0
+$ go install github.com/nao1215/atago@v0.20.0
 ```
 
 ### Build & Test

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -1223,9 +1223,13 @@ func TestREADME_E2EClaimsMatchTheWorkflow(t *testing.T) {
 // releases before this check existed, and a contributor following the docs then
 // ran the suite on a runner older than the specs it was reading.
 //
-// The version is written in three places — the workflow and two pages — so the
-// workflow is treated as the source of truth and every `atago@vX.Y.Z` in the
-// documentation is compared against it.
+// The version is written in four places — the workflow, two pages, and the
+// message `scripts/run_e2e.sh` prints when atago is missing — so the workflow is
+// treated as the source of truth and every `atago@vX.Y.Z` outside it is compared
+// against that. The runner's message was the one that drifted next: it still
+// named v0.18.0 after CI had moved to v0.20.0, so the contributor who hit the
+// "atago is not installed" path was handed the stale version by the very script
+// that refused to run.
 func TestDocs_PinTheAtagoVersionCIInstalls(t *testing.T) {
 	t.Parallel()
 
@@ -1242,14 +1246,17 @@ func TestDocs_PinTheAtagoVersionCIInstalls(t *testing.T) {
 	}
 
 	installed := regexp.MustCompile(`atago@(v[0-9]+\.[0-9]+\.[0-9]+)`)
-	for _, page := range []string{"CONTRIBUTING.md", "doc/build_and_test.md", "README.md"} {
+	// README.md may omit the version; the other three must carry it, since they
+	// are where a contributor is told what to install.
+	optional := map[string]bool{"README.md": true}
+	for _, page := range []string{"CONTRIBUTING.md", "doc/build_and_test.md", "README.md", "scripts/run_e2e.sh"} {
 		found := installed.FindAllStringSubmatch(readDoc(t, page), -1)
 		for _, m := range found {
 			if m[1] != want {
 				t.Errorf("%s tells contributors to install atago@%s, but CI runs the suite with %s", page, m[1], want)
 			}
 		}
-		if page != "README.md" && len(found) == 0 {
+		if !optional[page] && len(found) == 0 {
 			t.Errorf("%s no longer shows how to install atago; it is not part of `make tools`, so a contributor has no other way to learn the version", page)
 		}
 	}

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -14,7 +14,7 @@ cd "$ROOT"
 
 if ! command -v atago >/dev/null 2>&1; then
 	echo "e2e: atago is not installed. Install it from https://github.com/nao1215/atago" >&2
-	echo "e2e: e.g. 'go install github.com/nao1215/atago@v0.18.0' (CI uses nao1215/setup-atago)" >&2
+	echo "e2e: e.g. 'go install github.com/nao1215/atago@v0.20.0' (CI uses nao1215/setup-atago)" >&2
 	exit 127
 fi
 


### PR DESCRIPTION
## Summary

The atago suite was pinned to v0.18.0, two releases behind. This moves the pin to v0.20.0 in the three workflow steps that install atago, and in the two documents that tell a contributor which version to install — CONTRIBUTING.md and doc/build_and_test.md — which `TestDocs_PinTheAtagoVersionCIInstalls` keeps in step with CI. All 1,036 scenarios pass locally on v0.20.0 with no spec changes.

Also adds a tested-with-atago badge next to the coverage badge, so the README says what the E2E suite is driven by.

Related issue:

## Checklist

- [ ] Tests added or updated (Go unit tests, and atago E2E specs for CLI/shell behavior)
- [x] `make test` and `make lint` pass locally
- [x] Docs updated when behavior, help text, or README changed (English `README.md` and `doc/pages/markdown/`)
- [ ] CHANGELOG updated under `## [Unreleased]`
- [x] Cross-platform impact considered for CLI, shell, and path behavior (Linux, macOS, Windows)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Atago installation instructions to version 0.20.0.
  * Added a README badge showing the project is tested with Atago.
  * Improved documentation checks to keep Atago version references consistent across project guides and testing instructions.

* **Chores**
  * Updated automated coverage and end-to-end testing workflows to use Atago 0.20.0.
  * Updated the end-to-end testing setup to recommend Atago 0.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
