### PR TITLE
docs: stamp v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v1.0.1](https://github.com/nao1215/sqly/compare/v1.0.0...v1.0.1) (2026-08-15)
+
 ### Features
 
 * Windows installs through winget: `winget install nao1215.sqly`. A tagged release pushes the generated manifests to a fork of the community repository and opens the pull request against microsoft/winget-pkgs, so the package tracks releases without a separate manual submission. The Windows archives are zips, which winget installs as a portable package — `sqly.exe` lands on PATH with no installer to run. Release-candidate tags are skipped, since the community repository takes stable versions only.


### PR DESCRIPTION
## Summary

Stamp the winget entry sitting under Unreleased as v1.0.1, the first patch on top of v1.0.0. Nothing else changes.

The tag is what makes the feature real: the winget pipe only runs on a release, so `winget install nao1215.sqly` starts working when this version is tagged rather than when the feature merged. This tagged run also opens the first pull request against microsoft/winget-pkgs, a new-package submission that gets more review than a version update.

Related issue:

## Checklist

- [ ] Tests added or updated (Go unit tests, and atago E2E specs for CLI/shell behavior)
- [x] `make test` and `make lint` pass locally
- [x] Docs updated when behavior, help text, or README changed (English `README.md` and `doc/pages/markdown/`)
- [x] CHANGELOG updated under `## [Unreleased]`
- [x] Cross-platform impact considered for CLI, shell, and path behavior (Linux, macOS, Windows)
