### PR TITLE
test(e2e): stop asserting that gzip hides a short plaintext

### DIFF
--- a/e2e/atago/export_inference.atago.yaml
+++ b/e2e/atago/export_inference.atago.yaml
@@ -36,11 +36,28 @@ scenarios:
           file:
             path: result.ndjson.gz
             exists: true
-      # The payload is gzip-compressed, so the plaintext value is not present.
+      # What "writes a compressed file" means is checked against the .jsonl.gz
+      # the same query writes: the two are byte-identical, and that one loads
+      # back, so the .ndjson.gz path produced a real gzip of real JSONL.
+      #
+      # Asserting the plaintext is absent from the bytes said this only by
+      # accident. Deflate may store a payload this short verbatim rather than
+      # coding it, and whether it does is up to the compressor, so the same
+      # correct file passed on one Go release and failed on another.
+      - run:
+          command: sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" user.csv --output result.jsonl.gz
       - assert:
+          exit_code: 0
           file:
             path: result.ndjson.gz
-            not_contains: booker12
+            equals_file: result.jsonl.gz
+      - run:
+          command: sqly --output-format csv --sql "SELECT json_extract(data, '$.user_name') AS user_name FROM result LIMIT 1" result.jsonl.gz
+      - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: booker12
 
   - name: re-imports a gzip-compressed csv it wrote
     steps:


### PR DESCRIPTION
The `.ndjson.gz` export scenario asserted that the compressed file does not contain the plaintext it was made from. That is not a property of gzip. Deflate may store a payload this short verbatim rather than coding it, and whether it does is up to the compressor, so the same correct file passes on one Go release and fails on another. It currently fails on the ubuntu runner while passing locally, which blocks every pull request.

What the scenario claims is checked directly instead. The same query is written to `result.jsonl.gz`, the two files are required to be byte-identical, and the second is loaded back through sqly, which a plain file under a `.gz` name cannot survive. A regression that stopped compressing fails on that load rather than on whichever block type the compressor happened to pick.

`sh scripts/run_e2e.sh` passes all 1010 scenarios locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of compressed inference exports.
  * Confirmed compressed outputs can be re-imported and queried successfully.
  * Replaced brittle compression checks with a comparison against explicitly requested compressed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->