### PR TITLE
chore(release): v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+## [v1.0.4](https://github.com/nao1215/sqly/compare/v1.0.3...v1.0.4) (2026-08-26)
+
+### Bug Fixes
+
+* `.import` of a directory loads every file in it that sqly can read, and follows a symbolic link to one. The directory walk carried a filter written for filesql's own repository, so a supported file whose name it did not recognise was skipped without a word, and a link to a directory was read as a file and refused.
+
+* `.import` of a large workbook or Parquet file costs a fraction of what it did. A sheet's blank rows are no longer counted as records, a workbook's cells are read a row at a time rather than one call per cell, and a Parquet file named by path is read where it lies instead of being copied into memory first. An 18.5 MB workbook of 200,000 rows no longer holds gigabytes while it loads.
+
+* `.import` of a compressed file reads all of it. A `.z` file holding more than one zlib stream read as the first stream alone and said nothing about the rest, and an xz file's second stream and later were not held to the memory limit the first was.
+
+* `.save` and `--output` work on a destination whose name is close to the filesystem's length limit, and report a staged file they cannot remove instead of losing the report inside the operation's error.
+
+* `.save` of a workbook keeps its sheets apart from those of another source whose name it prefixes. Two files named `report.xlsx` and `report_2026.xlsx` had their sheets attributed to whichever matched first.
+
+* `--dialect mysql` computes `WEEK`, `WEEKOFYEAR`, `YEARWEEK`, `QUARTER`, `ADDDATE` and `SUBDATE`, all of which failed as "no such function" or as a syntax error naming a token the query did not contain. `STR_TO_DATE` reads a month, day or time written without a leading zero, which MySQL accepts and sqly refused.
+
+* `--dialect postgresql` answers a timestamp for a date plus an interval, as PostgreSQL 17 does. `DATE '2026-01-31' + INTERVAL '1 month'` was `2026-02-28` and is now `2026-02-28 00:00:00`, which decides a comparison against a timestamp literal.
+
+* A string with a second point in it keeps the number in front of it where a dialect casts it. `'1.2.3'` cast to a number was 0 rather than 1.2, so a version string sorted as if it had no number at all.
+
+### Changed
+
+* filesql v0.45.0 → v0.46.0, which is where the fixes above come from. Its release also removes five exported symbols sqly does not use, and changes filesql's `prep` package: the cross-field tags read every field and value pair they name, an empty cell passes a cross-field comparison, and `required_with_all` and `required_without_all` are accepted. A program that embeds sqly's own packages is unaffected; a program using filesql's `prep` directly should read that release's notes.
+
+* Dependencies: `github.com/moov-io/wire` 0.16.0 → 0.16.1.
+
 ## [v1.0.3](https://github.com/nao1215/sqly/compare/v1.0.2...v1.0.3) (2026-08-24)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug Fixes
 
-* `.import` of a directory loads every file in it that sqly can read, and follows a symbolic link to one. The directory walk carried a filter written for filesql's own repository, so a supported file whose name it did not recognise was skipped without a word, and a link to a directory was read as a file and refused.
+* `.import` of a directory loads every file in it that sqly can read, and follows a symbolic link to one. The directory walk carried a filter written for filesql's own repository, so a supported file whose name it did not recognize was skipped without a word, and a link to a directory was read as a file and refused.
 
 * `.import` of a large workbook or Parquet file costs a fraction of what it did. A sheet's blank rows are no longer counted as records, a workbook's cells are read a row at a time rather than one call per cell, and a Parquet file named by path is read where it lies instead of being copied into memory first. An 18.5 MB workbook of 200,000 rows no longer holds gigabytes while it loads.
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.28
-	github.com/nao1215/filesql v0.45.0
+	github.com/nao1215/filesql v0.46.0
 	github.com/nao1215/prompt v0.0.19
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
@@ -39,7 +39,7 @@ require (
 	github.com/moov-io/base v0.63.0 // indirect
 	github.com/moov-io/iso3166 v0.4.0 // indirect
 	github.com/moov-io/iso4217 v0.4.0 // indirect
-	github.com/moov-io/wire v0.16.0 // indirect
+	github.com/moov-io/wire v0.16.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,10 @@ github.com/moov-io/iso3166 v0.4.0 h1:WtXIptANC16DrHpbSAt4+itFciCCnA+C6eAi9k7HEsA
 github.com/moov-io/iso3166 v0.4.0/go.mod h1:13ubAoOZNfWzs2fN3x467zg8q982U867Ee+ulqrArlM=
 github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE=
 github.com/moov-io/iso4217 v0.4.0/go.mod h1:QvQE6pvu9KItHusChPLOJS10EhJnyQpcKHloIqHkQVM=
-github.com/moov-io/wire v0.16.0 h1:WsZNGXGPreVBl27FFtAUEzuxWZzBOkM89AEP7fDkl9Q=
-github.com/moov-io/wire v0.16.0/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
-github.com/nao1215/filesql v0.45.0 h1:AJycitBvxtNEagNXej1qxp426G3ftTikHCSXv9iOWzc=
-github.com/nao1215/filesql v0.45.0/go.mod h1:7RbamIndXct51swUVWgf1vxMaytgHzOYPPzTFFrFIOs=
+github.com/moov-io/wire v0.16.1 h1:JbeIS8JcmJJuxkXVXG6uGt4xYfEwkYk7xKzf5VbP0yQ=
+github.com/moov-io/wire v0.16.1/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
+github.com/nao1215/filesql v0.46.0 h1:xklfoOrcJ6s2yl6Ju7seHgjg0nrI4Eq+hPuzdJPYJdg=
+github.com/nao1215/filesql v0.46.0/go.mod h1:IDxdopNpawuhkDif2lVPhMsHMDuashPA17jsTP/Kqys=
 github.com/nao1215/prompt v0.0.19 h1:ive/Mh8+9s3K0Mlm43xTl6csTYDfXqctp9DK28PkcJ8=
 github.com/nao1215/prompt v0.0.19/go.mod h1:jcU0SPfCTCBHDQ4Uu0n7ZLrV/+hGXVJ64YRV2aKnqxA=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=


### PR DESCRIPTION
This takes filesql to v0.46.0 and records what its fixes mean for sqly commands. No sqly code changes.

The release reaches the user through `.import`, `.save` and `--dialect`. A directory import now loads every file sqly can read rather than the ones a filter written for filesql's own repository recognised, and follows a symbolic link to a directory. A large workbook or Parquet import costs a fraction of what it did. A `.z` file holding several zlib streams reads as all of them. `--dialect mysql` computes six date functions that failed as "no such function", and `--dialect postgresql` answers a timestamp for a date plus an interval as PostgreSQL 17 does.

`go build`, `go test ./...`, `make smoke` and `make lint` pass on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issues affecting directory handling, workbook and sheet ownership, Parquet and compressed-file processing, saving and output, SQL dialect behavior, and numeric casting.
- **Chores**
  - Updated the embedded FileSQL engine and Wire library to newer versions for improved compatibility and reliability.
- **Documentation**
  - Added the v1.0.4 changelog entry dated August 26, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->