### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -18,9 +18,13 @@ jobs:
           - "windows-latest"
           - "macos-latest"
         go:
+          # Pinned to the patch, not the minor. setup-go resolves a bare "1.25"
+          # from its own manifest and pins GOTOOLCHAIN to what it installs, so a
+          # runner that had 1.25.12 refused a go.mod asking for 1.25.13 and the
+          # job failed on a version this repository never chose.
           - "1"
-          - "1.25"
-          - "1.26"
+          - "1.25.13"
+          - "1.26.6"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [v1.1.0](https://github.com/nao1215/sqly/compare/v1.0.4...v1.1.0) (2026-08-26)
+
+### Added
+
+* `--dialect mysql` answers thirty-eight MySQL functions it used to refuse as "no such function". The names that are a second spelling of something sqly already had: `LCASE`, `UCASE`, `MID`, `DAYOFMONTH`, `ISNULL`, `REGEXP_LIKE`. The strings and numbers: `STRCMP`, `BIT_LENGTH`, `INSERT`, `TO_BASE64`, `FROM_BASE64`, `CONV`, `BIN`, `OCT`, `BIT_COUNT`, `COT`, the two-argument `ATAN`, `CRC32`, `REGEXP_SUBSTR`, `REGEXP_INSTR`, `SHA1`, `SHA2`. The ones a log file wants: `INET_ATON`, `INET_NTOA`, `IS_IPV4`, `IS_IPV6`. And the times and dates: `SEC_TO_TIME`, `TIME_TO_SEC`, `MAKETIME`, `TIME_FORMAT`, `ADDTIME`, `SUBTIME`, `MICROSECOND`, `TO_DAYS`, `FROM_DAYS`, `MAKEDATE`, `PERIOD_ADD`, `PERIOD_DIFF`. A MySQL TIME is a signed span rather than a clock reading, so `SELECT SEC_TO_TIME(360000)` answers `100:00:00` and a negative one keeps its sign.
+
+### Bug Fixes
+
+* `--dialect mysql` matches `REGEXP` and `RLIKE` without regard to case, as MySQL does under its default collation. `WHERE name REGEXP 'a'` used to pass over a row holding `A`, so a filter written against MySQL quietly returned fewer rows, and `REGEXP_REPLACE` quietly left some occurrences alone. `LIKE` already worked this way, so the two halves of one dialect disagreed about the same letter.
+
+* `--dialect mysql` computes `QUOTE`, `ASCII` and `HEX` the way MySQL does. `QUOTE` produced a literal MySQL cannot read back, escaping a quote by doubling it and leaving a number unquoted. `ASCII` answered the code point rather than the first byte, which made it the same function as `ORD`. `HEX` of a negative number answered a decimal with a minus sign in front of it, which holds no hexadecimal digits, so `UNHEX(HEX(n))` came back empty for every negative n.
+
+* `--dialect mysql` shifts with `<<` and `>>` the way MySQL does, on an unsigned 64-bit value. `SELECT -1 >> 1` answered -1 rather than 9223372036854775807, and a shift by 64 or more left a negative value untouched. These were different bits, not a different way of printing the same bits.
+
+* `--dialect mysql` reads a string in the condition of `IF` as the number its leading digits spell, which is what MySQL and SQLite both do. `IF(flag, a, b)` took the a branch for every value that was not a number, and a column sqly typed as text is exactly where that lands: a flag column holding `0` and `1` alongside a stray `no` took the true branch for every `no`.
+
+* `.save` and `--output` of an ACH or Fedwire file no longer write a file with a field replaced by another field's value, and no longer apply an edit to a record other than the one it was made on. A Fedwire message is now read back and compared column by column before a byte reaches the destination, and an ACH row is held against the position it was read from, so a write that cannot be made faithfully fails and leaves the original file where it was.
+
+### Changed
+
+* filesql v0.46.0 → v0.47.0, which is where everything above comes from. That release also removes exported symbols from filesql's `dialect`, `prep` and compression packages and changes `frame.DataFrame`'s `DistinctBy` and `DropNASubset` to return an error. sqly uses none of them, so a program that embeds sqly's own packages is unaffected; a program using filesql directly should read that release's notes.
+
 ## [v1.0.4](https://github.com/nao1215/sqly/compare/v1.0.3...v1.0.4) (2026-08-26)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Changed
 
+* The Go baseline moves to 1.25.13, which is what filesql v0.47.0 requires. The unit test matrix pins the patch rather than the minor: `setup-go` resolves a bare `1.25` from its own manifest and pins the toolchain to what it installs, so a runner that had 1.25.12 refused a `go.mod` asking for 1.25.13 and the job failed on a version this repository never chose.
+
 * filesql v0.46.0 → v0.47.0, which is where everything above comes from. That release also removes exported symbols from filesql's `dialect`, `prep` and compression packages and changes `frame.DataFrame`'s `DistinctBy` and `DropNASubset` to return an error. sqly uses none of them, so a program that embeds sqly's own packages is unaffected; a program using filesql directly should read that release's notes.
 
 ## [v1.0.4](https://github.com/nao1215/sqly/compare/v1.0.3...v1.0.4) (2026-08-26)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nao1215/sqly
 
-go 1.25.8
+go 1.25.13
 
 require (
 	github.com/adrg/xdg v0.5.3
@@ -11,7 +11,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.28
-	github.com/nao1215/filesql v0.46.0
+	github.com/nao1215/filesql v0.47.0
 	github.com/nao1215/prompt v0.0.19
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE
 github.com/moov-io/iso4217 v0.4.0/go.mod h1:QvQE6pvu9KItHusChPLOJS10EhJnyQpcKHloIqHkQVM=
 github.com/moov-io/wire v0.16.1 h1:JbeIS8JcmJJuxkXVXG6uGt4xYfEwkYk7xKzf5VbP0yQ=
 github.com/moov-io/wire v0.16.1/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
-github.com/nao1215/filesql v0.46.0 h1:xklfoOrcJ6s2yl6Ju7seHgjg0nrI4Eq+hPuzdJPYJdg=
-github.com/nao1215/filesql v0.46.0/go.mod h1:IDxdopNpawuhkDif2lVPhMsHMDuashPA17jsTP/Kqys=
+github.com/nao1215/filesql v0.47.0 h1:X2Tmo0DU4XhbB62VUgEK5WPlPg2lipw38wVHaP2D+ok=
+github.com/nao1215/filesql v0.47.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
 github.com/nao1215/prompt v0.0.19 h1:ive/Mh8+9s3K0Mlm43xTl6csTYDfXqctp9DK28PkcJ8=
 github.com/nao1215/prompt v0.0.19/go.mod h1:jcU0SPfCTCBHDQ4Uu0n7ZLrV/+hGXVJ64YRV2aKnqxA=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=


### PR DESCRIPTION
Release v1.1.0. Takes filesql v0.46.0 to v0.47.0, which is where everything in this release comes from, and records it in the CHANGELOG from sqly's side.

A minor rather than a patch, because `--dialect mysql` gains thirty-eight functions it used to refuse as "no such function" and not only fixes. The additions are listed in the CHANGELOG entry; the ones most likely to be reached for when the file is a log are `INET_ATON`, `INET_NTOA`, `IS_IPV4`, `IS_IPV6` and the TIME family, where a MySQL TIME is a signed span rather than a clock reading so `SEC_TO_TIME(360000)` answers `100:00:00`.

The fixes are five in the MySQL dialect and one outside it. `REGEXP` and `RLIKE` now fold case, which is what MySQL's default collation does and what `LIKE` here already did, so a filter written against MySQL no longer quietly returns fewer rows. `QUOTE`, `ASCII` and `HEX` answer what MySQL answers rather than what SQLite means by the same names. `<<` and `>>` shift an unsigned 64-bit value. A string in the condition of `IF` is read as the number its leading digits spell, which matters because a column sqly types as text is exactly where a flag column with a stray non-numeric value lands. The one outside the dialect is the ACH and Fedwire write-back, which can no longer put one field's value into another field or apply an edit to a record other than the one it was made on.

filesql v0.47.0 also removes exported symbols from its `dialect`, `prep` and compression packages and changes `frame.DataFrame`'s `DistinctBy` and `DropNASubset` to return an error. sqly uses none of them, which is why this is not a breaking release for it.

Verified with `make test`, `make smoke`, `make lint`, and by running the built binary against a CSV: `SELECT UCASE(name), SEC_TO_TIME(secs), INET_ATON(ip), name REGEXP 'ALPHA' FROM t` answers `ALPHA`, `01:01:01`, `167772161` and `1`, all four of which failed or answered differently before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded MySQL-compatible function support, including regular expressions, quoting, numeric functions, bit shifts, and conditional string coercion.
  - Improved compatibility with MySQL syntax and behavior.

- **Bug Fixes**
  - Made ACH and Fedwire write-back operations safer.

- **Maintenance**
  - Updated the supported Go baseline to 1.25.13.
  - Improved build consistency across supported Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->