### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+## [v1.2.0](https://github.com/nao1215/sqly/compare/v1.1.0...v1.2.0) (2026-08-27)
+
+### Added
+
+* `--dialect googlesql` answers the scalar functions it used to refuse, and gains the DATETIME and TIME families it had no arithmetic for: `DATETIME_ADD`, `DATETIME_SUB`, `DATETIME_DIFF`, `TIME_ADD`, `TIME_SUB`, `TIME_DIFF`, `TIME_TRUNC`, `UNIX_DATE`, `DATE_FROM_UNIX_DATE`, `CURRENT_DATETIME`, `LAST_DAY`, alongside `CONTAINS_SUBSTR`, `NORMALIZE`, `EDIT_DISTANCE`, `FROM_HEX`, `TO_BASE32`, `TO_JSON_STRING`, `IEEE_DIVIDE`, `IS_INF` and the rest. `EXTRACT`, `DATE_TRUNC` and `DATE_DIFF` read `WEEK(<WEEKDAY>)`, so a query grouping by a week that starts on Monday works; `EXTRACT` answers `MILLISECOND` and `MICROSECOND` and `DATE_DIFF` answers `ISOWEEK`, `ISOYEAR` and `QUARTER`; the `SAFE.` prefix works in front of any function sqly computes rather than five of them; `APPROX_COUNT_DISTINCT`, `CORR`, `COVAR_POP` and `COVAR_SAMP` are translated; and `CAST('0x10' AS INT64)` answers a number.
+
+* `--dialect postgresql` answers the scalar functions it used to refuse -- `quote_ident`, `regexp_count`, `cbrt`, `factorial`, `gcd`, `lcm`, the degree trigonometry, `to_number`, `to_timestamp`, `make_date`, `date_bin`, the `sha` family, `encode`, `decode`, `gen_random_uuid` and the clock functions among them. `BETWEEN SYMMETRIC` works, `DATE_PART` and `EXTRACT` answer `millennium`, `century`, `decade`, `isoyear` and the sub-second parts, `SUBSTRING(s FROM pattern)` returns what the pattern matched, and `TO_CHAR` implements the date/time and numeric templates rather than a handful of their patterns.
+
+* `--dialect mysql` and `--dialect googlesql` read `x + INTERVAL n unit`, the operator spelling of date arithmetic that both dialects' own documentation writes first. Only the function form worked, so `SELECT d + INTERVAL 1 DAY` failed with a syntax error naming the number.
+
+### Bug Fixes
+
+* A blank cell in a number column is a missing number, so `MAX` answers the largest value rather than the blank, `AVG` divides by the values that are there, `COUNT(column)` counts them and `WHERE column IS NULL` finds the rows that have none. sqly stored the blank as an empty string, which SQLite orders above every number, so a column with one gap gave wrong answers to all four with nothing to say so.
+
+* A TSV or LTSV file whose lines end with a lone carriage return loads as rows even when a value holds a double quote. One quote made every carriage return after it part of the data, so a three-row file loaded as one row holding the other two, and a wider one failed with a message about a column count that named neither the quote nor the line ending.
+
+* `.save` on an Excel workbook leaves the cells it did not change as they were. A number in a column holding decimals was rewritten as text, so a sheet a spreadsheet was summing had text in it after a save that edited nothing, and a large number came back as `1e+15`; a `TRUE` under a date format became the string `TRUE`.
+
+* `.save` to LTSV refuses a column name with a space at either end instead of writing a label that reads back as a different name, and a table name holding a quote or a backtick loads and saves instead of failing with SQLite's tokenizer error.
+
+* Closing after `.save --in-place` with a transaction still open returns instead of hanging forever, and an in-place save replaces no file until every source is known to be writable, so a run that would fail on the third file no longer rewrites the first two. A save through a symbolic link writes the file the link points at and leaves the link a link.
+
+* A record longer than 64 MiB is refused with a message naming the line and the limit, rather than read whole. A file that is not the format it claims -- one long line with no terminator -- used to cost the process the whole of it before anything noticed.
+
+* `--dialect` answers correctly where it used to answer plausibly: a division by zero is reported as one rather than as NULL, `GCD` never answers a negative number, `TO_CHAR` reads its argument to tell a date from a number, `DATE_DIFF` in weeks counts the boundaries crossed, day and hour differences are exact for every date the calendar holds, BigQuery's `MD5` and `SHA1` answer bytes, its `DATE`, `DATETIME` and `TIME` constructors build a value instead of NULL, and `NOW()` and its siblings read UTC and answer once per statement rather than once per appearance.
+
 ## [v1.1.0](https://github.com/nao1215/sqly/compare/v1.0.4...v1.1.0) (2026-08-26)
 
 ### Added

--- a/e2e/atago/dialect.atago.yaml
+++ b/e2e/atago/dialect.atago.yaml
@@ -333,7 +333,7 @@ scenarios:
             equals: "1,2,007,x"
 
   - name: "googlesql dialect translates a negative DATE_DIFF and the WEEK unit"
-    description: "DATE_DIFF must keep its sign when the first argument is the earlier date, and WEEK counts whole week boundaries."
+    description: "DATE_DIFF must keep its sign when the first argument is the earlier date. WEEK counts the week boundaries crossed, not the seven-day spans between the dates: 2026-01-01 is a Thursday and 2026-03-15 a Sunday, and eleven Sundays fall between them."
     steps:
       - fixture: *users
       - run:
@@ -342,7 +342,7 @@ scenarios:
           exit_code: 0
           stdout:
             line: 2
-            equals: "-73,10"
+            equals: "-73,11"
 
   - name: "googlesql dialect rejects SELECT * EXCEPT and ARRAY types"
     description: "Both are GoogleSQL-only syntax with no SQLite equivalent; each must name itself in the error so the user knows which construct to drop."

--- a/e2e/atago/dialect_googlesql.atago.yaml
+++ b/e2e/atago/dialect_googlesql.atago.yaml
@@ -262,6 +262,9 @@ scenarios:
           command: sqly --output-format csv --dialect googlesql --sql "SELECT SAFE.PARSE_DATE('%Y-%m-%d', 'nope') AS v"
       - assert:
           exit_code: 0
+          stdout:
+            line: 2
+            equals: '""'
 
   - name: "googlesql refuses SAFE.CAST, which is not how BigQuery spells it"
     description: "Dropping the prefix would leave a plain CAST that raises where the caller asked for a NULL, so the error names SAFE_CAST instead."

--- a/e2e/atago/dialect_googlesql.atago.yaml
+++ b/e2e/atago/dialect_googlesql.atago.yaml
@@ -244,14 +244,34 @@ scenarios:
           stdout:
             contains: '"v":null'
 
-  - name: "googlesql refuses a SAFE. prefix it cannot honor"
+  - name: "googlesql honors a SAFE. prefix in front of a function it computes"
+    description: "The prefix used to be accepted in front of five names and refused everywhere else, so SAFE.SUBSTR failed on a query BigQuery runs."
     steps:
       - run:
           command: sqly --output-format csv --dialect googlesql --sql "SELECT SAFE.SUBSTR('abc', 1, 2) AS v"
       - assert:
+          exit_code: 0
+          stdout:
+            line: 2
+            equals: "ab"
+
+  - name: "googlesql answers NULL where a SAFE. call could not compute one"
+    description: "That is what the prefix is for: a parse that fails answers nothing instead of stopping the query."
+    steps:
+      - run:
+          command: sqly --output-format csv --dialect googlesql --sql "SELECT SAFE.PARSE_DATE('%Y-%m-%d', 'nope') AS v"
+      - assert:
+          exit_code: 0
+
+  - name: "googlesql refuses SAFE.CAST, which is not how BigQuery spells it"
+    description: "Dropping the prefix would leave a plain CAST that raises where the caller asked for a NULL, so the error names SAFE_CAST instead."
+    steps:
+      - run:
+          command: sqly --output-format csv --dialect googlesql --sql "SELECT SAFE.CAST('x' AS INT64) AS v"
+      - assert:
           exit_code: 1
           stderr:
-            contains: "SAFE.SUBSTR is not supported"
+            contains: "SAFE_CAST"
 
   # SQLite reads "[...]" as identifier quoting, so an array literal used to come
   # back as "no such column: 1,2,3" — about a column the query never wrote.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.28
-	github.com/nao1215/filesql v0.47.0
+	github.com/nao1215/filesql v0.48.0
 	github.com/nao1215/prompt v0.0.19
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE
 github.com/moov-io/iso4217 v0.4.0/go.mod h1:QvQE6pvu9KItHusChPLOJS10EhJnyQpcKHloIqHkQVM=
 github.com/moov-io/wire v0.16.1 h1:JbeIS8JcmJJuxkXVXG6uGt4xYfEwkYk7xKzf5VbP0yQ=
 github.com/moov-io/wire v0.16.1/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
-github.com/nao1215/filesql v0.47.0 h1:X2Tmo0DU4XhbB62VUgEK5WPlPg2lipw38wVHaP2D+ok=
-github.com/nao1215/filesql v0.47.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
+github.com/nao1215/filesql v0.48.0 h1:pWhdFqIFEzS03llDzI9o/x/SBPEbZTsP5r1sxn7k6IY=
+github.com/nao1215/filesql v0.48.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
 github.com/nao1215/prompt v0.0.19 h1:ive/Mh8+9s3K0Mlm43xTl6csTYDfXqctp9DK28PkcJ8=
 github.com/nao1215/prompt v0.0.19/go.mod h1:jcU0SPfCTCBHDQ4Uu0n7ZLrV/+hGXVJ64YRV2aKnqxA=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=


### PR DESCRIPTION
Takes filesql v0.48.0 and releases sqly v1.2.0. The pinned version was v0.47.0, and sixty-nine entries have landed since.

What reaches a sqly user is in the changelog, in sqly's own words. The additions are dialect functions: `--dialect googlesql` gains the scalar functions it used to refuse along with the DATETIME and TIME families, `WEEK(<WEEKDAY>)`, the `SAFE.` prefix in front of anything sqly computes, and the correlation aggregates; `--dialect postgresql` gains its own missing scalar functions, `BETWEEN SYMMETRIC`, the calendar parts of `DATE_PART`, `SUBSTRING(s FROM pattern)` and a `TO_CHAR` that implements the templates rather than a handful of their patterns; and both MySQL and GoogleSQL read `x + INTERVAL n unit`.

The fixes worth naming first are the ones that were answering wrongly rather than failing. A blank cell in a number column was stored as the empty string, which SQLite orders above every number, so `MAX` answered the blank, `AVG` divided by the empty rows, `COUNT(column)` counted them and `WHERE column IS NULL` found none -- all four wrong, with nothing to say so. A TSV or LTSV file whose lines end with a lone carriage return merged its records from the first double quote onward. `.save` on a workbook rewrote numbers as text and booleans as strings in cells nothing had edited. And a run that would fail to write its third file no longer rewrites the first two before finding out.

Minor rather than patch: sqly's own code did not change, but the dialects gain functions a user can call, which is a feature reaching them.

## Verification

- `go build ./...` and `go test ./...` pass against filesql v0.48.0.
- `go mod tidy` left `go.sum` consistent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded GoogleSQL and PostgreSQL dialect support, including broader `SAFE.` function handling.
  * Added date-interval syntax for MySQL and GoogleSQL.
  * Added safeguards for record sizes, table names, and in-place saves.
* **Bug Fixes**
  * Improved blank-value handling.
  * Fixed carriage-return parsing in TSV and LTSV files.
  * Improved Excel save fidelity and LTSV reliability.
  * Corrected dialect-specific behavior and transactional save handling.
* **Documentation**
  * Added the v1.2.0 changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->