### PR TITLE
chore: release v1.2.1 with filesql v0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [v1.2.1](https://github.com/nao1215/sqly/compare/v1.2.0...v1.2.1) (2026-08-27)
+
+### Bug Fixes
+
+* An import that is canceled -- Ctrl-C on a long `.import`, or a request that goes away under `sqly` used as a library -- stops reading the file it was reading, and reports the cancellation as one. A source arriving over a slow connection used to be read to the end whatever the cancellation said, and the error that came back was about a closed statement rather than about the context, so a caller could not tell a canceled import from a failed one.
+
+* A JSON file whose array is followed by a stray `]` or `}` is refused instead of importing as the rows before it. `[{"a":1}]}[{"a":2}]` imported as a one-row table and reported success, with the second array's rows gone and nothing said about them.
+
+* An LTSV line holding a field that names no label is handled by `--row-mismatch` rather than dropped in silence. A stray log line in the middle of an LTSV file used to vanish, leaving an import that reported success and a table missing a row.
+
+* An import error names sqly's file layer once. Two of them said `filesql: database operation failed:` twice in one message.
+
 ## [v1.2.0](https://github.com/nao1215/sqly/compare/v1.1.0...v1.2.0) (2026-08-27)
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.28
-	github.com/nao1215/filesql v0.48.0
+	github.com/nao1215/filesql v0.49.0
 	github.com/nao1215/prompt v0.0.19
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE
 github.com/moov-io/iso4217 v0.4.0/go.mod h1:QvQE6pvu9KItHusChPLOJS10EhJnyQpcKHloIqHkQVM=
 github.com/moov-io/wire v0.16.1 h1:JbeIS8JcmJJuxkXVXG6uGt4xYfEwkYk7xKzf5VbP0yQ=
 github.com/moov-io/wire v0.16.1/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
-github.com/nao1215/filesql v0.48.0 h1:pWhdFqIFEzS03llDzI9o/x/SBPEbZTsP5r1sxn7k6IY=
-github.com/nao1215/filesql v0.48.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
+github.com/nao1215/filesql v0.49.0 h1:X92xf7FIQxmmvHPF0IeFAb6iDnLpUOmcaFjSj3JEW/w=
+github.com/nao1215/filesql v0.49.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
 github.com/nao1215/prompt v0.0.19 h1:ive/Mh8+9s3K0Mlm43xTl6csTYDfXqctp9DK28PkcJ8=
 github.com/nao1215/prompt v0.0.19/go.mod h1:jcU0SPfCTCBHDQ4Uu0n7ZLrV/+hGXVJ64YRV2aKnqxA=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/infrastructure/filesql/adapter.go
+++ b/infrastructure/filesql/adapter.go
@@ -194,12 +194,8 @@ func (f *FileSQLAdapter) stageFile(ctx context.Context, tx *sql.Tx, path string)
 		AddPath(path).
 		WithMalformedRowPolicy(filesqlRowMismatchPolicy(f.rowMismatchPolicy)).
 		WithExcelSheetPolicy(filesqlExcelSheetPolicy(f.includeHiddenSheets))
-	validated, err := builder.Build(ctx)
-	if err != nil {
-		return importError(path, err)
-	}
-	err = validated.LoadIntoTx(ctx, tx)
-	f.recordSkippedRows(validated.SkippedRows())
+	err := builder.LoadIntoTx(ctx, tx)
+	f.recordSkippedRows(builder.SkippedRows())
 	if err != nil {
 		if f.rowMismatchPolicy == model.RowMismatchPad && errors.Is(err, filesql.ErrColumnMismatch) {
 			return importError(path, fmt.Errorf("--row-mismatch pad refuses to truncate a long row: %w", unnamedCause(err)))


### PR DESCRIPTION
Updates filesql to v0.49.0 and releases it as sqly v1.2.1.

What reaches a sqly user is four fixes to importing. A canceled import stops reading its source and reports the cancellation as one, where it used to read the file to the end and then report a closed statement. A JSON file whose array is followed by a stray `]` or `}` is refused instead of importing as the rows before the bracket and reporting success. An LTSV line holding a field that names no label goes through `--row-mismatch` rather than vanishing. And an import error names the file layer once instead of twice in one message.

filesql v0.49.0 also deprecates `DBBuilder.Build`, since `Open`, `OpenReadOnly`, `LoadInto` and `LoadIntoTx` validate the builder themselves. `stageFile` was the one caller here: it now calls `LoadIntoTx` on the builder and reads `SkippedRows` from it.

Verified with `make lint` (golangci-lint and go-arch-lint), `go test ./...`, and `make smoke`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canceled imports now stop promptly and clearly report cancellation.
  * JSON files with trailing unmatched brackets or braces are rejected instead of partially imported.
  * LTSV rows with unlabeled fields now follow the configured row-mismatch behavior.
  * Import errors no longer repeat the same file-layer message.
  * Improved handling of skipped rows during imports for more consistent row-mismatch reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->