### PR TITLE
fix(query): stop two statements from crashing the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* A query whose first `FROM` is the last word of a comment, of a string literal, or of a column aliased `from` answers instead of crashing. `sqly --sql "SELECT 1 -- from"` and ``sqly --sql "SELECT 1 AS `from`"`` ended the run with a Go panic, which exits 2 and so read as a rejected command line.
+
+* A statement that is only a `#` comment is refused instead of crashing. `#` opens a line comment in MySQL and in GoogleSQL but not in SQLite, so `sqly --dialect mysql --sql "# hello"` survived the check for an empty statement, was translated into nothing, and panicked on the way back from running nothing.
+
 ## [v1.2.1](https://github.com/nao1215/sqly/compare/v1.2.0...v1.2.1) (2026-08-27)
 
 ### Bug Fixes

--- a/e2e/smoke_test.go
+++ b/e2e/smoke_test.go
@@ -462,3 +462,57 @@ func TestSmoke_AtomicPadAndEmptyJSON(t *testing.T) {
 		t.Fatalf("directory rollback created output, stat err=%v", err)
 	}
 }
+
+// TestSmoke_NoStatementCrashesTheProcess pins two statements that used to end the
+// run with a Go panic instead of an answer. A panic is only visible from outside
+// the process: it writes a goroutine dump to stderr and exits 2, which reads as a
+// rejected command line, so the run that crashed and the run that was refused
+// looked the same to a script.
+//
+// "SELECT 1 -- from" ends with the word the result-table name is read from, and
+// reading the word after it ran off the end of the list. "# hello" is a comment
+// in MySQL and in GoogleSQL but not in SQLite, so it survived the check for an
+// empty statement and was translated into nothing, and running nothing gave the
+// driver no result to count rows from.
+func TestSmoke_NoStatementCrashesTheProcess(t *testing.T) {
+	csv := filepath.Join("testdata", "user.csv")
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantCode int
+	}{
+		{
+			name:     "a trailing comment ending in from still answers",
+			args:     []string{"--sql", "SELECT 1 AS n -- from", csv},
+			wantCode: 0,
+		},
+		{
+			name:     "a column aliased from still answers",
+			args:     []string{"--sql", "SELECT 1 AS `from`", csv},
+			wantCode: 0,
+		},
+		{
+			name:     "a mysql comment-only statement is refused",
+			args:     []string{"--dialect", "mysql", "--sql", "# hello", csv},
+			wantCode: 1,
+		},
+		{
+			name:     "a googlesql comment-only statement is refused",
+			args:     []string{"--dialect", "googlesql", "--sql", "# hello", csv},
+			wantCode: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, code := run(t, "", tt.args...)
+			if strings.Contains(stderr, "goroutine 1 [running]") || strings.Contains(stderr, "panic: ") {
+				t.Fatalf("sqly %v crashed:\n%s", tt.args, stderr)
+			}
+			if code != tt.wantCode {
+				t.Fatalf("sqly %v exit = %d, want %d (stdout: %q, stderr: %q)",
+					tt.args, code, tt.wantCode, stdout, stderr)
+			}
+		})
+	}
+}

--- a/infrastructure/memory/sqlite3.go
+++ b/infrastructure/memory/sqlite3.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nao1215/sqly/config"
 	"github.com/nao1215/sqly/domain/model"
 	"github.com/nao1215/sqly/domain/repository"
+	"github.com/nao1215/sqly/domain/sqltext"
 	infra "github.com/nao1215/sqly/infrastructure"
 )
 
@@ -235,21 +236,73 @@ func (r *sqlite3Repository) Query(ctx context.Context, query string) (*model.Tab
 	return model.NewTableFromCells(extractTableName(query), header, cells)
 }
 
-// extractTableName extract table name from query.
-// The query must be "SELECT" or "EXPLAIN" statement.
+// extractTableName returns the object named by the query's first FROM clause. It
+// names the result table, which is what an Excel export uses as its worksheet
+// name, so a query with no FROM (or none that names anything) yields "" and the
+// writer falls back to its own name.
+//
+// The FROM is found through sqltext rather than by splitting the query into
+// words. A word split cannot tell code from the rest: it read the "from" of a
+// trailing comment, of a string literal, and of a column aliased `from` as the
+// clause, and then read the word after it — which, when that "from" was the last
+// word, was past the end of the list.
 func extractTableName(query string) string {
-	query = strings.ReplaceAll(query, "`", "")
-	words := strings.Fields(query)
-	for i, v := range words {
-		if strings.EqualFold(v, "FROM") || strings.EqualFold(v, "from") {
-			return words[i+1]
+	for token := range sqltext.Tokens(query) {
+		if token.Kind == sqltext.Word && strings.EqualFold(token.Text(query), "FROM") {
+			return firstIdentifier(query[token.End:])
 		}
 	}
 	return ""
 }
 
+// firstIdentifier returns the identifier that opens s, with one layer of SQLite
+// quoting removed (`x`, "x", [x]). A schema qualifier stays part of the name, so
+// "main.people" is reported whole.
+//
+// It returns "" when s opens with something that is not a name — most often the
+// "(" of a subquery, whose SELECT is not a table anyone can refer to.
+func firstIdentifier(s string) string {
+	s = strings.TrimLeft(s, " \t\r\n")
+	if s == "" {
+		return ""
+	}
+	if closer, quoted := identifierQuotes[s[0]]; quoted {
+		end := strings.IndexByte(s[1:], closer)
+		if end < 0 {
+			return "" // the quote never closes, so there is no name to read
+		}
+		return s[1 : 1+end]
+	}
+	end := 0
+	for end < len(s) && isIdentifierByte(s[end]) {
+		end++
+	}
+	return s[:end]
+}
+
+// identifierQuotes maps each character that opens a quoted identifier in SQLite
+// to the one that closes it.
+var identifierQuotes = map[byte]byte{'`': '`', '"': '"', '[': ']'}
+
+// isIdentifierByte reports whether c can be part of an unquoted table reference.
+// "." is included so a schema-qualified name is read as one.
+func isIdentifierByte(c byte) bool {
+	return c == '_' || c == '.' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
 // Exec execute "INSERT" or "UPDATE" or "DELETE" statement
+//
+// A statement with nothing executable in it — empty, whitespace, a bare ";", a
+// comment — affects no rows and is not sent to the driver. The driver answers
+// such a statement with a result that carries no underlying result, and reading a
+// row count off that crashes rather than returning an error. Callers reach here
+// with one when a dialect translation removes the only thing the statement held.
 func (r *sqlite3Repository) Exec(ctx context.Context, statement string) (int64, error) {
+	if sqltext.StripNoise(statement) == "" {
+		return 0, nil
+	}
+
 	var result sql.Result
 	if err := r.inTx(ctx, func(tx *sql.Tx) error {
 		var err error

--- a/infrastructure/memory/sqlite3.go
+++ b/infrastructure/memory/sqlite3.go
@@ -255,39 +255,61 @@ func extractTableName(query string) string {
 	return ""
 }
 
-// firstIdentifier returns the identifier that opens s, with one layer of SQLite
-// quoting removed (`x`, "x", [x]). A schema qualifier stays part of the name, so
-// "main.people" is reported whole.
+// firstIdentifier returns the table reference that opens s, with one layer of
+// SQLite quoting removed from each of its parts. A schema qualifier is part of
+// the reference, so both main.people and "main"."people" are read whole, and the
+// comments a query may put between FROM and its table are skipped.
 //
 // It returns "" when s opens with something that is not a name — most often the
 // "(" of a subquery, whose SELECT is not a table anyone can refer to.
 func firstIdentifier(s string) string {
-	s = strings.TrimLeft(s, " \t\r\n")
+	var parts []string
+	for {
+		part, rest, ok := readIdentifierPart(sqltext.StripNoise(s))
+		if !ok {
+			break
+		}
+		parts = append(parts, part)
+		s = sqltext.StripNoise(rest)
+		if !strings.HasPrefix(s, ".") {
+			break
+		}
+		s = s[1:]
+	}
+	return strings.Join(parts, ".")
+}
+
+// readIdentifierPart reads one part of a table reference off the front of s and
+// returns it unquoted, together with what follows it. ok is false when s does not
+// open with a name at all.
+func readIdentifierPart(s string) (part, rest string, ok bool) {
 	if s == "" {
-		return ""
+		return "", s, false
 	}
 	if closer, quoted := identifierQuotes[s[0]]; quoted {
 		end := strings.IndexByte(s[1:], closer)
 		if end < 0 {
-			return "" // the quote never closes, so there is no name to read
+			return "", s, false // the quote never closes, so there is no name to read
 		}
-		return s[1 : 1+end]
+		return s[1 : 1+end], s[end+2:], true
 	}
 	end := 0
 	for end < len(s) && isIdentifierByte(s[end]) {
 		end++
 	}
-	return s[:end]
+	if end == 0 {
+		return "", s, false
+	}
+	return s[:end], s[end:], true
 }
 
 // identifierQuotes maps each character that opens a quoted identifier in SQLite
 // to the one that closes it.
 var identifierQuotes = map[byte]byte{'`': '`', '"': '"', '[': ']'}
 
-// isIdentifierByte reports whether c can be part of an unquoted table reference.
-// "." is included so a schema-qualified name is read as one.
+// isIdentifierByte reports whether c can be part of an unquoted identifier.
 func isIdentifierByte(c byte) bool {
-	return c == '_' || c == '.' ||
+	return c == '_' ||
 		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 

--- a/infrastructure/memory/sqlite3_test.go
+++ b/infrastructure/memory/sqlite3_test.go
@@ -212,6 +212,21 @@ func TestExtractTableName(t *testing.T) {
 			want: "my table",
 		},
 		{
+			name: "a comment between from and its table is skipped",
+			args: args{query: "SELECT * FROM /* source */ people"},
+			want: "people",
+		},
+		{
+			name: "a quoted schema-qualified name is read whole",
+			args: args{query: `SELECT * FROM "main"."people"`},
+			want: "main.people",
+		},
+		{
+			name: "a line comment between from and its table is skipped",
+			args: args{query: "SELECT * FROM -- source\npeople"},
+			want: "people",
+		},
+		{
 			name: "the first from wins over a later one",
 			args: args{query: "SELECT * FROM a JOIN b ON a.id = b.id WHERE a.x IN (SELECT x FROM c)"},
 			want: "a",

--- a/infrastructure/memory/sqlite3_test.go
+++ b/infrastructure/memory/sqlite3_test.go
@@ -227,6 +227,16 @@ func TestExtractTableName(t *testing.T) {
 			want: "people",
 		},
 		{
+			name: "an unterminated quoted name names nothing",
+			args: args{query: `SELECT * FROM "people`},
+			want: "",
+		},
+		{
+			name: "a qualified name whose second part is unterminated keeps the first",
+			args: args{query: "SELECT * FROM main.`people"},
+			want: "main",
+		},
+		{
 			name: "the first from wins over a later one",
 			args: args{query: "SELECT * FROM a JOIN b ON a.id = b.id WHERE a.x IN (SELECT x FROM c)"},
 			want: "a",

--- a/infrastructure/memory/sqlite3_test.go
+++ b/infrastructure/memory/sqlite3_test.go
@@ -166,6 +166,56 @@ func TestExtractTableName(t *testing.T) {
 			args: args{query: ""},
 			want: "",
 		},
+		{
+			name: "a from in a trailing line comment names nothing",
+			args: args{query: "SELECT 1 -- from"},
+			want: "",
+		},
+		{
+			name: "a from in a block comment names nothing",
+			args: args{query: "SELECT 1 /* from */"},
+			want: "",
+		},
+		{
+			name: "a column aliased from names nothing",
+			args: args{query: "SELECT 1 AS `from`"},
+			want: "",
+		},
+		{
+			name: "a from in a string literal names nothing",
+			args: args{query: "SELECT 'from t' AS s"},
+			want: "",
+		},
+		{
+			name: "a subquery after from names nothing",
+			args: args{query: "SELECT * FROM (SELECT 1 AS a)"},
+			want: "",
+		},
+		{
+			name: "a terminator is not part of the name",
+			args: args{query: "SELECT * FROM people;"},
+			want: "people",
+		},
+		{
+			name: "a schema-qualified name is kept whole",
+			args: args{query: "SELECT * FROM main.people"},
+			want: "main.people",
+		},
+		{
+			name: "a double-quoted name is unquoted",
+			args: args{query: `SELECT * FROM "my table"`},
+			want: "my table",
+		},
+		{
+			name: "a bracket-quoted name is unquoted",
+			args: args{query: "SELECT * FROM [my table]"},
+			want: "my table",
+		},
+		{
+			name: "the first from wins over a later one",
+			args: args{query: "SELECT * FROM a JOIN b ON a.id = b.id WHERE a.x IN (SELECT x FROM c)"},
+			want: "a",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -362,6 +412,23 @@ func TestSqlite3Repository_Exec_InvalidStatementReturnsError(t *testing.T) {
 	r := newSampleRepo(t)
 	if _, err := r.Exec(context.Background(), "UPDATE no_such_table SET x = 1"); err == nil {
 		t.Error("expected error for exec against missing table, got nil")
+	}
+}
+
+// TestSqlite3Repository_Exec_StatementWithNothingToRun covers a statement the
+// driver accepts without running anything: it answers with no result at all, and
+// reading a row count off that answer dereferenced nothing. A dialect that
+// translates its own comment syntax away is how such a statement reaches here.
+func TestSqlite3Repository_Exec_StatementWithNothingToRun(t *testing.T) {
+	r := newSampleRepo(t)
+	for _, statement := range []string{"", "   ", "-- only a comment", "/* only a comment */", ";"} {
+		affected, err := r.Exec(context.Background(), statement)
+		if err != nil {
+			t.Errorf("Exec(%q) error = %v, want nil", statement, err)
+		}
+		if affected != 0 {
+			t.Errorf("Exec(%q) affected = %d, want 0", statement, affected)
+		}
 	}
 }
 

--- a/interactor/dialect_test.go
+++ b/interactor/dialect_test.go
@@ -3,6 +3,7 @@ package interactor
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/nao1215/filesql/dialect"
@@ -81,5 +82,52 @@ func TestSQLite3Interactor_ExecSQLTranslates(t *testing.T) {
 	si.SetDialect(dialect.SQLite)
 	if _, _, err := si.ExecSQL(ctx, "SELECT name FROM t"); err != nil {
 		t.Fatalf("ExecSQL(sqlite): %v", err)
+	}
+}
+
+// TestSQLite3Interactor_ExecSQLRejectsStatementTranslatedToNothing covers a
+// statement that is only a comment in its own dialect. MySQL and GoogleSQL write
+// a line comment with "#", which SQLite does not, so the check for an empty
+// statement made before the translation still sees something to run. What the
+// translation leaves is empty, and running that reached the driver, which
+// answered with no result and crashed the row count. The dialect that named the
+// comment is the one that has to notice it.
+func TestSQLite3Interactor_ExecSQLRejectsStatementTranslatedToNothing(t *testing.T) {
+	config.InitSQLite3()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	si := NewSQLite3Interactor(
+		memory.NewSQLite3Repository(db),
+		NewSQL(),
+		ifilesql.NewFileSQLAdapter(db),
+	)
+
+	tests := []struct {
+		name      string
+		dialect   dialect.Dialect
+		statement string
+	}{
+		{name: "mysql hash comment", dialect: dialect.MySQL, statement: "# hello"},
+		{name: "mysql bare hash", dialect: dialect.MySQL, statement: "#"},
+		{name: "mysql block comment then hash comment", dialect: dialect.MySQL, statement: "/* c */ # d"},
+		{name: "googlesql hash comment", dialect: dialect.GoogleSQL, statement: "# hello"},
+		{name: "googlesql bare hash", dialect: dialect.GoogleSQL, statement: "#"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			si.SetDialect(tt.dialect)
+			table, affected, err := si.ExecSQL(context.Background(), tt.statement)
+			if err == nil {
+				t.Fatalf("ExecSQL(%q) = (%v, %d, nil), want an error", tt.statement, table, affected)
+			}
+			if !strings.Contains(err.Error(), "no executable SQL statement") {
+				t.Errorf("ExecSQL(%q) error = %v, want it to say there is no executable statement", tt.statement, err)
+			}
+		})
 	}
 }

--- a/interactor/sqlite3.go
+++ b/interactor/sqlite3.go
@@ -132,6 +132,15 @@ func (si *SQLite3Interactor) ExecSQL(ctx context.Context, statement string) (*mo
 	// Rewrite shorthands the engine does not accept (e.g. "TABLE name").
 	stmt = normalizeStatement(stmt)
 
+	// The check above ran on what the user wrote, in SQLite's spelling of a
+	// comment. MySQL and GoogleSQL also write a line comment with "#", which that
+	// check reads as something to run and the translation then removes, leaving
+	// nothing. Asking the engine to run nothing is not a statement, so it is
+	// refused the same way an empty one is.
+	if sqltext.StripNoise(stmt) == "" {
+		return nil, 0, errors.New("no executable SQL statement: " + color.CyanString(statement))
+	}
+
 	// Reject statements sqly cannot run safely or correctly under its per-statement
 	// transaction and in-memory session model (explicit transaction control,
 	// VACUUM, ATTACH/DETACH), with a clear error instead of SQLite's confusing


### PR DESCRIPTION
Two statements ended a run with a Go panic instead of an answer. A panic is only visible from outside the process: it writes a goroutine dump to stderr and exits 2, which is the code for a rejected command line, so a script could not tell the crash from a refusal.

`sqly --sql "SELECT 1 -- from"` and ``sqly --sql "SELECT 1 AS `from`"`` crashed in `extractTableName`, which names a query result (and so an exported worksheet) from the query's first FROM clause. It split the query into words and read the one after "from", with no regard for whether that "from" was code: a trailing comment, a string literal, and a column aliased `from` all matched, and when the match was the last word, reading the next one ran off the end of the list. The FROM is now found through `domain/sqltext`, the package that already knows which regions of a statement are code, and the name after it is read with one layer of SQLite quoting removed. A FROM that opens a subquery names nothing, which is what it always meant.

`sqly --dialect mysql --sql "# hello"` crashed on the way back from running nothing. `#` opens a line comment in MySQL and in GoogleSQL but not in SQLite, so the check for an empty statement — made before the translation, in SQLite's spelling of a comment — saw something to run, and the translation then removed it. The driver answers an empty statement with a result that carries no underlying result, and reading a row count off that dereferences nil. The check now runs again after the translation, so the statement is refused with the same message an empty one gets, and the repository no longer sends a statement with nothing executable in it to the driver at all.

Regression tests cover all three levels: `extractTableName` directly, `ExecSQL` per dialect, and the built binary, where a panic is asserted by the absence of a goroutine dump on stderr.

While confirming these, a third defect surfaced that is not fixed here: sqly's statement splitter is dialect-blind, so `--sql "SELECT 1 # note; more"` is read as two statements, and MySQL's `\'` and PostgreSQL's `$$...$$` split a statement in the wrong place. Fixing it means threading the dialect into `domain/sqltext`, which is a design change rather than a bug fix, so it gets its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented crashes when `FROM` appears in comments, string literals, or column aliases.
  - Comment-only and empty SQL statements are now rejected safely with a clear error.
  - Improved handling of subqueries, quoted identifiers, schemas, and multiple `FROM` clauses.
  - Prevented unexpected process panics and exits during SQL execution.
  - Statements containing only comments or terminators no longer cause database execution errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->