### PR TITLE
chore: release v1.2.2 with filesql v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 ## [Unreleased]
 
+## [v1.2.2](https://github.com/nao1215/sqly/compare/v1.2.1...v1.2.2) (2026-08-27)
+
 ### Bug Fixes
 
 * A query whose first `FROM` is the last word of a comment, of a string literal, or of a column aliased `from` answers instead of crashing. `sqly --sql "SELECT 1 -- from"` and ``sqly --sql "SELECT 1 AS `from`"`` ended the run with a Go panic, which exits 2 and so read as a rejected command line.
 
 * A statement that is only a `#` comment is refused instead of crashing. `#` opens a line comment in MySQL and in GoogleSQL but not in SQLite, so `sqly --dialect mysql --sql "# hello"` survived the check for an empty statement, was translated into nothing, and panicked on the way back from running nothing.
+
+* A blank cell written as a space rather than as nothing is a missing number, so `MAX` over a number column answers the largest value rather than the space, `SUM` and `COUNT` skip it and `IS NULL` finds it. It used to sit in the column as text, which SQLite orders above every number, and only an empty cell was read as missing. This holds for a file imported by path and for one read from a stream, which had disagreed.
+
+* `.save` to Excel refuses a value a worksheet cannot carry -- a control character other than tab, newline and carriage return -- instead of writing it back as the replacement character. The same table saves as CSV, which holds it.
+
+* `.save` to Excel keeps the table's name when the name is longer than a worksheet name may be. A table of 32 characters came back from the saved workbook with its own truncated name appended, 64 characters long, and grew again on every save and reimport.
+
+* `.save` refuses a table whose name or column names an import would spell differently, naming what an import would call them, instead of writing files that cannot be read back: a table named `with space` came back as `with_space`, and two tables named `a b` and `a-b` wrote two files that could not be imported together at all.
+
+* A damaged Parquet file costs no more than its own size to refuse. One 473-byte file allocated 98 MiB before failing, and did it again on every import of the same file.
 
 ## [v1.2.1](https://github.com/nao1215/sqly/compare/v1.2.0...v1.2.1) (2026-08-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,11 @@
 
 * A blank cell written as a space rather than as nothing is a missing number, so `MAX` over a number column answers the largest value rather than the space, `SUM` and `COUNT` skip it and `IS NULL` finds it. It used to sit in the column as text, which SQLite orders above every number, and only an empty cell was read as missing. This holds for a file imported by path and for one read from a stream, which had disagreed.
 
-* `.save` to Excel refuses a value a worksheet cannot carry -- a control character other than tab, newline and carriage return -- instead of writing it back as the replacement character. The same table saves as CSV, which holds it.
-
-* `.save` to Excel keeps the table's name when the name is longer than a worksheet name may be. A table of 32 characters came back from the saved workbook with its own truncated name appended, 64 characters long, and grew again on every save and reimport.
-
-* `.save` refuses a table whose name or column names an import would spell differently, naming what an import would call them, instead of writing files that cannot be read back: a table named `with space` came back as `with_space`, and two tables named `a b` and `a-b` wrote two files that could not be imported together at all.
+* An Excel workbook whose sheet is named after the file, shortened to what Excel allows, imports as one table named after the file. A worksheet name is at most 31 characters, so a workbook named `quarterly_revenue_by_region_2026.xlsx` holding the sheet Excel had to shorten imported as the table `quarterly_revenue_by_region_2026_quarterly_revenue_by_region_202`.
 
 * A damaged Parquet file costs no more than its own size to refuse. One 473-byte file allocated 98 MiB before failing, and did it again on every import of the same file.
+
+* `--output` to Parquet no longer fails on a result with no table name. The export stages the result in a temporary database, and the staging table now carries a name of its own rather than the result's, which could be empty.
 
 ## [v1.2.1](https://github.com/nao1215/sqly/compare/v1.2.0...v1.2.1) (2026-08-27)
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.28
-	github.com/nao1215/filesql v0.49.0
+	github.com/nao1215/filesql v0.50.0
 	github.com/nao1215/prompt v0.0.19
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE
 github.com/moov-io/iso4217 v0.4.0/go.mod h1:QvQE6pvu9KItHusChPLOJS10EhJnyQpcKHloIqHkQVM=
 github.com/moov-io/wire v0.16.1 h1:JbeIS8JcmJJuxkXVXG6uGt4xYfEwkYk7xKzf5VbP0yQ=
 github.com/moov-io/wire v0.16.1/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
-github.com/nao1215/filesql v0.49.0 h1:X92xf7FIQxmmvHPF0IeFAb6iDnLpUOmcaFjSj3JEW/w=
-github.com/nao1215/filesql v0.49.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
+github.com/nao1215/filesql v0.50.0 h1:21vXnKLy2W0AnULJ2GSAGvW8zMFlSsqqK3m37+m9XII=
+github.com/nao1215/filesql v0.50.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
 github.com/nao1215/prompt v0.0.19 h1:ive/Mh8+9s3K0Mlm43xTl6csTYDfXqctp9DK28PkcJ8=
 github.com/nao1215/prompt v0.0.19/go.mod h1:jcU0SPfCTCBHDQ4Uu0n7ZLrV/+hGXVJ64YRV2aKnqxA=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/infrastructure/filesql/parquet.go
+++ b/infrastructure/filesql/parquet.go
@@ -16,6 +16,14 @@ import (
 	_ "modernc.org/sqlite" // register the "sqlite" driver used for the staging DB
 )
 
+// parquetStagingTableName is the table the export stages its rows in. It is a
+// name of the export's own rather than the result's: a result has whatever name
+// the query gave it, including none, and the staging table becomes a file name
+// that filesql refuses when a load of it would name the table something else.
+// The produced file is renamed to what the caller asked for either way, so the
+// staging name is never seen.
+const parquetStagingTableName = "sqly_export"
+
 // DumpTableToParquet writes a single table to a Parquet file at filePath.
 //
 // filesql can read Parquet but only exposes a whole-database dump
@@ -118,7 +126,7 @@ func DumpTableToParquet(filePath string, table *model.Table) (err error) {
 // parquetStagingColumnType decides instead.
 func parquetStagingCreateTable(t *model.Table, types []string) string {
 	var b strings.Builder
-	b.WriteString("CREATE TABLE " + infra.Quote(t.Name()) + " (")
+	b.WriteString("CREATE TABLE " + infra.Quote(parquetStagingTableName) + " (")
 	for i, col := range t.Header() {
 		if i > 0 {
 			b.WriteString(", ")
@@ -239,7 +247,7 @@ func parquetStagingColumnType(t *model.Table, col int) string {
 // the whole export instead of once per row.
 func parquetInsertStatement(t *model.Table) string {
 	var b strings.Builder
-	b.WriteString("INSERT INTO " + infra.Quote(t.Name()) + " VALUES (")
+	b.WriteString("INSERT INTO " + infra.Quote(parquetStagingTableName) + " VALUES (")
 	for col := range t.Header() {
 		if col > 0 {
 			b.WriteString(", ")


### PR DESCRIPTION
Updates filesql to v0.50.0 and releases it as sqly v1.2.2, together with the two query fixes already on main.

What reaches a sqly user from filesql is three fixes. A blank cell written as a space rather than as nothing is now a missing number, so `MAX` over a number column answers the largest value rather than the space, `SUM` and `COUNT` skip it and `IS NULL` finds it -- and that holds for a file imported by path and for one read from a stream, which had disagreed with each other. An Excel workbook whose sheet is named after the file, shortened to what Excel allows, imports as one table named after the file rather than as `file_sheet`, so a workbook named `quarterly_revenue_by_region_2026.xlsx` no longer imports as a 64-character table. And a damaged Parquet file costs no more than its own size to refuse, where one 473-byte file used to allocate 98 MiB on every import.

One sqly fix comes with it, found by this repository's own atago suite against the new filesql. A Parquet export stages the result in a temporary database and dumps that, and it named the staging table after the result -- which carries whatever name the query gave it, including none. filesql v0.50.0 refuses a table whose name a load would spell differently, and a table named `""` is written to `.parquet`, which a load would name `sheet`, so exporting a result with no table name failed with an error about a table the user never saw. The staging table now carries a name of the export's own; the produced file is renamed to what the caller asked for either way, so that name is never seen.

filesql v0.50.0 also removes `DBBuilder.Build`, which v0.49.0 deprecated and sqly moved off in v1.2.1, so nothing there changes.

Verified with `go build ./...`, `go test ./...`, `make lint` (golangci-lint and go-arch-lint), `make smoke`, and the full atago suite locally (1011 passed, 2 skipped).
