### PR TITLE
chore: update filesql to v0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* filesql is updated to v0.51.0. Nothing an import or an export does changes: the release refuses two things sqly never asks filesql for -- an LTSV dump of a table with no rows, which sqly writes with its own writer, and a dialect handed to a load into a database the caller owns, which sqly does not pass -- and documents what an Excel load costs. sqly stays current with it.
+
 ### Removed
 
 * The winget release pipe, and with it the `winget install nao1215.sqly` instruction. GoReleaser generated the manifests and opened a pull request against microsoft/winget-pkgs on every stable tag, but none of those pull requests were ever merged — six were open, the oldest for twelve days, all past validation and waiting on a volunteer moderator — so the identifier resolves to nothing and the pipe published nothing. The open pull requests are withdrawn, and `winget:` is gone from `.goreleaser.yml` along with the `WINGET_GITHUB_TOKEN` wiring in the release workflow. Windows users install with `go install`, a prebuilt archive from the release page, aqua, or mise.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.28
-	github.com/nao1215/filesql v0.50.0
+	github.com/nao1215/filesql v0.51.0
 	github.com/nao1215/prompt v0.0.19
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE
 github.com/moov-io/iso4217 v0.4.0/go.mod h1:QvQE6pvu9KItHusChPLOJS10EhJnyQpcKHloIqHkQVM=
 github.com/moov-io/wire v0.16.1 h1:JbeIS8JcmJJuxkXVXG6uGt4xYfEwkYk7xKzf5VbP0yQ=
 github.com/moov-io/wire v0.16.1/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
-github.com/nao1215/filesql v0.50.0 h1:21vXnKLy2W0AnULJ2GSAGvW8zMFlSsqqK3m37+m9XII=
-github.com/nao1215/filesql v0.50.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
+github.com/nao1215/filesql v0.51.0 h1:Bu/dcYTUMF1PiDwwiaXQttR21/OZ5+Sx87+5Khh08Yk=
+github.com/nao1215/filesql v0.51.0/go.mod h1:CG00RrOty2HfSVKJASywuUCSCVauBnfH1bc7qbxLz8U=
 github.com/nao1215/prompt v0.0.19 h1:ive/Mh8+9s3K0Mlm43xTl6csTYDfXqctp9DK28PkcJ8=
 github.com/nao1215/prompt v0.0.19/go.mod h1:jcU0SPfCTCBHDQ4Uu0n7ZLrV/+hGXVJ64YRV2aKnqxA=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=


### PR DESCRIPTION
Updates filesql to v0.51.0.

Nothing an import or an export does changes for a sqly user. The release refuses two things sqly never asks filesql for -- an LTSV dump of a table with no rows, which sqly writes with its own writer, and a dialect handed to a load into a database the caller owns, which sqly does not pass -- and documents what an Excel load costs against what the file size suggests. The bump keeps sqly current with it.

No version heading: the changelog entry sits under Unreleased beside the winget removal, so whoever cuts the next release decides what it is called.

Verified with `go build ./...`, `go test ./...`, `make lint` (golangci-lint and go-arch-lint), `make smoke`, and the full atago suite (1011 passed, 2 skipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Updated the data import and export functionality to the latest version.
  - Existing import and export behavior remains unchanged for supported workflows.
  - Improved handling of unsupported edge cases during empty-table LTSV exports and dialect-specific loads.
  - Documented the performance cost associated with loading Excel files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->