### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v1.3.0](https://github.com/nao1215/sqly/compare/v1.2.2...v1.3.0) (2026-08-29)
 
 ### Bug Fixes
 


### PR DESCRIPTION
Cuts v1.3.0 from what has accumulated since v1.2.2.

A minor rather than a patch because two things are visible to a script. `sqly --dialect mysql --sql "# hello"` is refused as a command line and exits 2, the same as `--sql "-- hello"` has always done, where it used to reach the engine and exit 1: the check for an empty statement reads the session's dialect now and sees the comment for what it is. And the error a rejected query prints carries the line and column of the construct and, where there is one, what to write instead.

The rest is fixes. The statement splitter reads the dialect the script is written in, so a `#` comment, a backslash-escaped quote, a dollar-quoted string, a nested block comment and a tripled quote no longer cut a statement where the dialect has no boundary (#927). filesql v0.52.0 brings a header row with two blank cells that imports, a row of empty cells that survives an Excel export and import, a number around a million that keeps its notation in a text export, a decimal too large for a float64 that keeps its digits, a file wider than 2000 columns that is refused in words rather than by SQLite, an LTSV stream that cannot ask for unbounded memory, and a great deal more of what each dialect's own engine answers.

The CHANGELOG says what each of those means from sqly's side rather than filesql's.