### PR TITLE
fix(shell): read the session's own text with the dialect .dialect selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* `.dialect` decides where a statement ends, the way `--dialect` already did. Translation and execution used the dialect `.dialect` had set, while everything that reads the text — where a statement ends, whether the interactive buffer holds a finished one — used the dialect the process started with, so the two halves of one setting disagreed for the rest of the session. `.dialect mysql` followed by `SELECT 1 # note; more` was cut at a semicolon MySQL has commented out, and `more` was run as a statement of its own; the same line under `--dialect mysql` ran correctly. At the prompt the same statement waited on a continuation for a rest that had already been written and never ran. A script is now read as it goes, so a `.dialect` inside one applies to the lines after it.
+
 ### New Features
 
 * Completion reads the statement being typed. A table position — after `FROM`, `JOIN`, `INSERT INTO`, `UPDATE` — offers table names and no longer offers columns, which cannot go there. A `SELECT` list, a `WHERE`, `ON`, `GROUP BY`, `ORDER BY` or `SET` offers the columns of the tables the statement names before the rest of the session's. And `alias.` or `table.` offers that table's columns spelled with the qualifier, resolving the alias from the statement's own `FROM` and `JOIN` clauses. The statement is read with the dialect's own lexical rules, so a keyword inside a string literal or a comment is the text it is.

--- a/e2e/atago/dialect.atago.yaml
+++ b/e2e/atago/dialect.atago.yaml
@@ -692,3 +692,55 @@ scenarios:
       - assert:
           stdout:
             not_contains: "postgresql_cast"
+
+  # Where a statement ends is a question only the dialect answers, and .dialect
+  # answers it for the lines after it. The whole script used to be split by the
+  # dialect the process started with, so "#" -- a comment opener in MySQL --
+  # left "SELECT 1 # note; more" cut at the semicolon and "more" run as a
+  # statement of its own. What --dialect already did, .dialect now does too.
+  - name: ".dialect changes where a later statement ends, like --dialect does"
+    steps:
+      - fixture: &splitting_users
+          file: users.csv
+          content: |
+            id,name
+            1,Alice
+      - run:
+          command: sqly users.csv
+          stdin: |
+            .dialect mysql
+            SELECT CONCAT('SPLIT','_OK') AS s # note; more
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "SPLIT_OK"
+
+  # The same line without the .dialect is read by SQLite's rules, where "#" opens
+  # no comment and is not a token any statement may hold. Without this the
+  # scenario above would pass on a build that ignored the dialect entirely.
+  - name: "without .dialect the same line is read by SQLite's rules"
+    steps:
+      - fixture: *splitting_users
+      - run:
+          command: sqly users.csv
+          stdin: |
+            SELECT CONCAT('SPLIT','_OK') AS s # note; more
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: 'unrecognized token: "#"'
+
+  # A dialect the command would reject changes nothing about how the rest is
+  # read, so the failure is the one .dialect reports and not a mis-split line.
+  - name: ".dialect with an unknown name leaves the reading rules alone"
+    steps:
+      - fixture: *splitting_users
+      - run:
+          command: sqly users.csv
+          stdin: |
+            .dialect nosuch
+            SELECT 1;
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "unknown SQL dialect"

--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -586,6 +586,37 @@ scenarios:
           stdout:
             contains: "nickname"
 
+  # Whether what has been typed is a finished statement is a question only the
+  # dialect answers. The prompt asked it under the dialect the process started
+  # with, so after ".dialect mysql" a line whose terminator is followed by a "#"
+  # comment -- a comment MySQL has and SQLite does not -- waited on a
+  # continuation for a rest that had already been written, and the statement
+  # never ran.
+  - name: a statement finished under the dialect .dialect selected runs on that Enter
+    steps:
+      - fixture: *capability_people
+      - pty:
+          command: sqly people.csv
+          rows: 30
+          cols: 220
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: ".dialect mysql\r"
+            - expect: "dialect set to mysql"
+            - expect: '\(table\)\$'
+            # CONCAT because "||" is logical OR in MySQL, not concatenation, so
+            # the marker is built by a function the translation carries over.
+            - send: "SELECT CONCAT('RAN','_ON_ENTER') AS r; # a mysql comment\r"
+            - expect: "RAN_ON_ENTER"
+            - expect: '\(table\)\$'
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "RAN_ON_ENTER"
+            not_contains: "...>" # it ran on that Enter rather than buffering
+
   # Editing an earlier line of a buffered statement leaves the screen alone. The
   # renderer erased the block it had drawn by moving up its height, which is
   # where the cursor is only while it sits on the last line; a left arrow

--- a/shell/dialect_scope_test.go
+++ b/shell/dialect_scope_test.go
@@ -1,0 +1,152 @@
+package shell
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/filesql/dialect"
+)
+
+// TestParseScriptFollowsADialectSetInTheScript covers where a script's
+// statements end. A ";" is a terminator only where the dialect says it is, and
+// a script can change the dialect partway through with .dialect. The whole
+// script was split up front by the dialect the process started with, so a
+// statement written for the dialect the script had just selected was cut in the
+// wrong place: with "#" opening a comment in MySQL, "SELECT 1 # note; more" is
+// one statement there and two under SQLite's rules.
+func TestParseScriptFollowsADialectSetInTheScript(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		script  string
+		start   dialect.Dialect
+		wantSQL []string
+	}{
+		{
+			name:    "a hash comment after .dialect mysql does not split the statement",
+			script:  ".dialect mysql\nSELECT 1 # note; more\n",
+			start:   dialect.SQLite,
+			wantSQL: []string{"SELECT 1 # note; more"},
+		},
+		{
+			name:    "the same script under SQLite's rules splits at the semicolon",
+			script:  "SELECT 1 # note; more\n",
+			start:   dialect.SQLite,
+			wantSQL: []string{"SELECT 1 # note", "more"},
+		},
+		{
+			name:    "switching back to sqlite restores SQLite's rules",
+			script:  ".dialect mysql\n.dialect sqlite\nSELECT 1 # note; more\n",
+			start:   dialect.SQLite,
+			wantSQL: []string{"SELECT 1 # note", "more"},
+		},
+		{
+			name:    "a dollar-quoted string survives .dialect postgresql",
+			script:  ".dialect postgresql\nSELECT $$a;b$$ AS s;\n",
+			start:   dialect.SQLite,
+			wantSQL: []string{"SELECT $$a;b$$ AS s"},
+		},
+		{
+			name:    "a dialect name the command would reject leaves the rules alone",
+			script:  ".dialect nosuch\nSELECT 1 # note; more\n",
+			start:   dialect.SQLite,
+			wantSQL: []string{"SELECT 1 # note", "more"},
+		},
+		{
+			name:    "a bare .dialect prints the setting and changes nothing",
+			script:  ".dialect\nSELECT 1 # note; more\n",
+			start:   dialect.SQLite,
+			wantSQL: []string{"SELECT 1 # note", "more"},
+		},
+		{
+			name:    "the dialect the process started with applies before any .dialect",
+			script:  "SELECT 1; # note\n",
+			start:   dialect.MySQL,
+			wantSQL: []string{"SELECT 1"},
+		},
+		{
+			name:    "a .dialect that starts the script applies to every statement after it",
+			script:  ".dialect mysql\nSELECT 1; # note\nSELECT 2; # note\n",
+			start:   dialect.SQLite,
+			wantSQL: []string{"SELECT 1", "SELECT 2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			elements, err := parseScript(tt.script, tt.start)
+			if err != nil {
+				t.Fatalf("parseScript(%q, %v): %v", tt.script, tt.start, err)
+			}
+			var got []string
+			for _, el := range elements {
+				if el.kind == elementSQL {
+					got = append(got, strings.TrimSpace(el.text))
+				}
+			}
+			if len(got) != len(tt.wantSQL) {
+				t.Fatalf("parseScript(%q, %v) SQL elements = %q, want %q", tt.script, tt.start, got, tt.wantSQL)
+			}
+			for i := range got {
+				if got[i] != tt.wantSQL[i] {
+					t.Errorf("statement %d = %q, want %q", i, got[i], tt.wantSQL[i])
+				}
+			}
+		})
+	}
+}
+
+// TestShellDialectFollowsTheDialectCommand covers which dialect the shell reads
+// its own input with. Translation and execution used the dialect .dialect had
+// set, while everything that decides where a statement ends used the one the
+// process started with, so the two could disagree for the whole session.
+func TestShellDialectFollowsTheDialectCommand(t *testing.T) {
+	// Serial: newShell builds an in-memory DB and a temp history path.
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if got := s.dialect(); got != dialect.SQLite {
+		t.Fatalf("a session started without --dialect reads its input as %v, want %v", got, dialect.SQLite)
+	}
+
+	if err := s.commands.dialectCommand(context.Background(), s, []string{"mysql"}); err != nil {
+		t.Fatalf(".dialect mysql: %v", err)
+	}
+	if got := s.dialect(); got != dialect.MySQL {
+		t.Errorf("after .dialect mysql the shell reads its input as %v, want %v", got, dialect.MySQL)
+	}
+}
+
+// TestSQLInputCompleteFollowsTheDialectCommand covers the interactive buffer.
+// The prompt asks the shell whether what has been typed is a finished
+// statement; asking under the startup dialect left "SELECT 1; # note" typed
+// after .dialect mysql waiting on a continuation for a rest that had already
+// been written, because "#" opens no comment in SQLite and the text after the
+// terminator did not look like noise.
+func TestSQLInputCompleteFollowsTheDialectCommand(t *testing.T) {
+	// Serial: newShell builds an in-memory DB and a temp history path.
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	const input = "SELECT 1; # note"
+
+	if sqlInputComplete(input, s.dialect()) {
+		t.Fatalf("%q is unfinished under SQLite's rules, where # opens no comment", input)
+	}
+	if err := s.commands.dialectCommand(context.Background(), s, []string{"mysql"}); err != nil {
+		t.Fatalf(".dialect mysql: %v", err)
+	}
+	if !sqlInputComplete(input, s.dialect()) {
+		t.Errorf("%q is a finished statement under MySQL's rules, but the prompt kept buffering it", input)
+	}
+}

--- a/shell/script.go
+++ b/shell/script.go
@@ -61,6 +61,23 @@ func (e scriptElement) commandName() string {
 	return ""
 }
 
+// dialectSelectedBy reports the dialect a ".dialect NAME" line selects. It
+// answers false for every other line, and for a .dialect the command itself
+// would reject — a bare one, which only prints the setting, one with too many
+// arguments, and an unknown name — so a line that changes nothing when it runs
+// changes nothing about how the script is read either.
+func dialectSelectedBy(line string) (dialect.Dialect, bool) {
+	argv, err := splitArgs(line)
+	if err != nil || len(argv) != 2 || argv[0] != dialectCommand {
+		return dialect.SQLite, false
+	}
+	d, err := dialect.Parse(argv[1])
+	if err != nil {
+		return dialect.SQLite, false
+	}
+	return d, true
+}
+
 // parseScript splits a script into the statements and helper commands it runs.
 //
 // A line is a helper command when it begins with "." and no SQL statement is
@@ -80,6 +97,14 @@ func (e scriptElement) commandName() string {
 // its commands. A helper command sharing a line with SQL is rejected: reading
 // "SELECT 1; .save" as two things depends on knowing where the statement ended,
 // which is exactly what the reader cannot show the writer.
+//
+// d is the dialect the script opens in, not the one it keeps: a ".dialect" the
+// script runs changes how the lines after it are read. Where a statement ends
+// is a question only the dialect answers — "#" opens a comment in MySQL and
+// GoogleSQL, PostgreSQL alone writes a dollar-quoted string — and the whole
+// script used to be split by the dialect the process started with, so a
+// statement written for the dialect the script had just selected was cut where
+// that dialect has no boundary, or run together where it has one.
 func parseScript(script string, d dialect.Dialect) ([]scriptElement, error) {
 	script = strings.TrimPrefix(script, string(utf8BOM))
 
@@ -102,6 +127,12 @@ func parseScript(script string, d dialect.Dialect) ([]scriptElement, error) {
 				elements = append(elements, scriptElement{
 					kind: elementDotCommand, text: trimmed, startLine: lineNo, endLine: lineNo,
 				})
+				// The one helper command that changes how the rest of the script is
+				// read. It is applied here, as the line is parsed, rather than when
+				// the script runs: by then the split has already happened.
+				if selected, ok := dialectSelectedBy(trimmed); ok {
+					d = selected
+				}
 				continue
 			}
 		}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -232,36 +232,42 @@ func NewShell(
 	// Apply the initial SQL dialect from --dialect. Loading always uses SQLite;
 	// only user queries run through ExecSQL are translated.
 	usecases.query.SetDialect(arg.Dialect)
-	return &Shell{
-		argument: arg,
-		config:   cfg,
-		commands: cmds,
-		usecases: usecases,
-		state:    state,
-		files:    defaultFileOps(),
-		newPrompt: func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
-			return prompt.New(
-				prefix,
-				prompt.WithCompleter(completer),
-				prompt.WithMemoryHistory(historySize),
-				prompt.WithTheme(prompt.ThemeNightOwl),
-				prompt.WithMultiline(true),
-				prompt.WithIsComplete(func(input string) bool {
-					return sqlInputComplete(input, arg.Dialect)
-				}),
-				prompt.WithContinuationPrefix(continuationPrefix),
-				prompt.WithWordEscape(),
-				prompt.WithKeyMap(sqlyKeyMap()),
-				prompt.WithPersistentRawMode(),
-			)
-		},
+	shell := &Shell{
+		argument:       arg,
+		config:         cfg,
+		commands:       cmds,
+		usecases:       usecases,
+		state:          state,
+		files:          defaultFileOps(),
 		stdin:          os.Stdin,
 		isTTY:          config.IsInputFromTTY,
 		historyEnabled: true,
 		tableSources:   make(map[string]string),
 		allowRemote:    arg.AllowRemote,
 		httpClient:     newRemoteClient(),
-	}, nil
+	}
+	// The factory closes over the shell rather than over arg, so the question
+	// "is what has been typed a finished statement" is asked of the dialect in
+	// effect now. Closed over arg it was asked of the one --dialect started
+	// with, and a statement typed after .dialect mysql waited on a continuation
+	// for a rest that had already been written.
+	shell.newPrompt = func(prefix string, completer func(prompt.Document) []prompt.Suggestion) (promptSession, error) {
+		return prompt.New(
+			prefix,
+			prompt.WithCompleter(completer),
+			prompt.WithMemoryHistory(historySize),
+			prompt.WithTheme(prompt.ThemeNightOwl),
+			prompt.WithMultiline(true),
+			prompt.WithIsComplete(func(input string) bool {
+				return sqlInputComplete(input, shell.dialect())
+			}),
+			prompt.WithContinuationPrefix(continuationPrefix),
+			prompt.WithWordEscape(),
+			prompt.WithKeyMap(sqlyKeyMap()),
+			prompt.WithPersistentRawMode(),
+		)
+	}
+	return shell, nil
 }
 
 // Run start sqly shell.
@@ -874,7 +880,19 @@ func (s *Shell) promptPrefix() string {
 // says where a statement ends: "#" opens a comment in MySQL and GoogleSQL, a
 // backslash escapes a quote there, and PostgreSQL alone writes a dollar-quoted
 // string and nests its block comments.
+//
+// It is the dialect in effect now, not the one --dialect started with. The query
+// usecase holds it because that is what .dialect sets and what translation
+// reads; taking it from the startup flag instead left the two halves of one
+// setting disagreeing for the rest of the session, so a statement was translated
+// as MySQL and split as SQLite.
+//
+// The fallbacks are for a partially built shell in a test: neither is nil in a
+// session the DI container assembled.
 func (s *Shell) dialect() dialect.Dialect {
+	if s.usecases.query != nil {
+		return s.usecases.query.Dialect()
+	}
 	if s.argument == nil {
 		return dialect.SQLite
 	}

--- a/website/content/dialects.md
+++ b/website/content/dialects.md
@@ -24,6 +24,10 @@ current dialect: mysql (available: sqlite, mysql, postgresql, googlesql)
 Both lines go to stderr, so a script that switches dialect still writes only its
 rows to stdout.
 
+The choice also decides where a statement ends, for every line after it: `#`
+opens a comment in MySQL and GoogleSQL, PostgreSQL alone writes a dollar-quoted
+string. In a script, a `.dialect` applies to the lines that follow it.
+
 Loading a file always uses SQLite. Only the query text is translated.
 
 ## This is translation, not emulation


### PR DESCRIPTION
Translation and execution used the dialect `.dialect` had set. Everything that reads the text — where a statement ends, whether the interactive buffer holds a finished one, whether a statement writes or changes the schema — used the dialect the process started with. The two halves of one setting disagreed for the rest of the session.

Where a statement ends is a question only the dialect answers: `#` opens a comment in MySQL and GoogleSQL, PostgreSQL alone writes a dollar-quoted string and nests its block comments. So this failed:

```
$ printf '.dialect mysql\nSELECT 1 # note; more\n' | sqly data.csv
batch statement 3 failed at line 2: "more": ... the MORE statement is not implemented
exit 1
```

while the same line under the startup flag ran correctly:

```
$ printf 'SELECT 1 # note; more\n' | sqly --dialect mysql data.csv
exit 0
```

That difference is what makes this a defect rather than a limit: the same input behaves differently depending on how the dialect was chosen. v1.3.0 made the splitter dialect-aware for `--dialect`; the `.dialect` path was left behind.

At the prompt the statement never ran at all. The prompt asks the shell whether what has been typed is finished, and under SQLite's rules `SELECT 1; # note` is not — the text after the terminator does not look like noise there. After `.dialect mysql` it sat on a `...>` continuation waiting for a rest that had already been written.

## What changed

`Shell.dialect` reports the dialect in effect (the query usecase holds it, which is what `.dialect` sets and what translation reads) rather than the startup flag. The prompt factory closes over the shell instead of over the argument, so the buffer question is asked the same way. And `parseScript` follows a `.dialect` it passes, because a script used to be split whole before its first line ran, so no change to `Shell.dialect` could have reached it.

A `.dialect` the command itself would reject — a bare one, too many arguments, an unknown name — changes nothing about how the script is read, so a line that does nothing when it runs does nothing to the reading either.

## Tests

`shell/dialect_scope_test.go` covers the parse following an in-script `.dialect` (both directions, the rejected forms, and the startup dialect still applying before any `.dialect`), `Shell.dialect` after the command, and the interactive buffer question.

`e2e/atago/dialect.atago.yaml` adds three batch scenarios: `.dialect mysql` making the line run, the same line without it being read by SQLite's rules (so the first cannot pass on a build that ignores the dialect), and an unknown name leaving the rules alone. `e2e/atago/pty.atago.yaml` adds the interactive case, asserting the statement runs on that Enter and no continuation prompt appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `.dialect` now correctly controls statement splitting and comment handling for subsequent script lines and interactive input.
  * Dialect changes take effect immediately during a session, including completion detection.
  * Unknown dialect names now produce a clear error.

* **Documentation**
  * Added guidance on dialect-specific statement termination, comments, and string syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->