### PR TITLE
feat(shell): name what a mistyped command, table, or column is a typo of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### New Features
 
-* A mistyped name is answered with the one it is a typo of. An unknown helper command, a table this session does not have, and a column no table has each name the closest thing sqly knows, when there is one within a letter dropped, doubled, mistyped, or two swapped: `.tabels` answers `.tables`, and `SELECT naem` answers `name`. Nothing is offered when no name is that close, and the rest of each message is unchanged.
+* A mistyped name is answered with the one it is a typo of. An unknown helper command, a table this session does not have, and a column no table has each name the closest thing sqly knows, when there is one near enough: `.tabels` answers `.tables`, and `SELECT naem` answers `name`. Nearness is edit distance, where a letter dropped, doubled, mistyped, or two swapped each count as one edit; a name of five characters or more may be two edits away, a shorter one only one, and a name of two characters or fewer is never guessed at. Nothing is offered when no name is that close, and the rest of each message is unchanged.
 
 * Completion reads the statement being typed. A table position — after `FROM`, `JOIN`, `INSERT INTO`, `UPDATE` — offers table names and no longer offers columns, which cannot go there. A `SELECT` list, a `WHERE`, `ON`, `GROUP BY`, `ORDER BY` or `SET` offers the columns of the tables the statement names before the rest of the session's. And `alias.` or `table.` offers that table's columns spelled with the qualifier, resolving the alias from the statement's own `FROM` and `JOIN` clauses. The statement is read with the dialect's own lexical rules, so a keyword inside a string literal or a comment is the text it is.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### New Features
 
+* A mistyped name is answered with the one it is a typo of. An unknown helper command, a table this session does not have, and a column no table has each name the closest thing sqly knows, when there is one within a letter dropped, doubled, mistyped, or two swapped: `.tabels` answers `.tables`, and `SELECT naem` answers `name`. Nothing is offered when no name is that close, and the rest of each message is unchanged.
+
 * Completion reads the statement being typed. A table position — after `FROM`, `JOIN`, `INSERT INTO`, `UPDATE` — offers table names and no longer offers columns, which cannot go there. A `SELECT` list, a `WHERE`, `ON`, `GROUP BY`, `ORDER BY` or `SET` offers the columns of the tables the statement names before the rest of the session's. And `alias.` or `table.` offers that table's columns spelled with the qualifier, resolving the alias from the statement's own `FROM` and `JOIN` clauses. The statement is read with the dialect's own lexical rules, so a keyword inside a string literal or a comment is the text it is.
 
 ### Bug Fixes

--- a/docs_drift_test.go
+++ b/docs_drift_test.go
@@ -2221,7 +2221,7 @@ func TestDocs_QuotedMessagesAreTheOnesTheBinaryPrints(t *testing.T) {
 		},
 		{
 			name:    "the hint that lists the tables a session has",
-			message: `hint: this session has no table "staf". Available tables: ident, staff. sqly derives table names from file names: https://nao1215.github.io/sqly/reference/#table-name-rules`,
+			message: `hint: this session has no table "staf". Did you mean "staff"? Available tables: ident, staff. sqly derives table names from file names: https://nao1215.github.io/sqly/reference/#table-name-rules`,
 			doc:     referencePage,
 			spec:    "e2e/atago/error_hygiene.atago.yaml",
 		},

--- a/e2e/atago/error_hygiene.atago.yaml
+++ b/e2e/atago/error_hygiene.atago.yaml
@@ -86,7 +86,7 @@ scenarios:
               - "no such table"
               # Quoted whole, because website/content/reference.md shows this
               # exact line and a drift test requires both to hold the same string.
-              - 'hint: this session has no table "staf". Available tables: ident, staff. sqly derives table names from file names: https://nao1215.github.io/sqly/reference/#table-name-rules' 
+              - 'hint: this session has no table "staf". Did you mean "staff"? Available tables: ident, staff. sqly derives table names from file names: https://nao1215.github.io/sqly/reference/#table-name-rules' 
 
   - name: says how to get a table when the session has none
     steps:
@@ -109,7 +109,7 @@ scenarios:
           stdout:
             empty: true
           stderr:
-            contains: 'hint: no column "nam". Run .describe TABLE in the shell, or sqly --inspect FILE, to list columns.'
+            contains: 'hint: no column "nam". Did you mean "name"? Run .describe TABLE in the shell, or sqly --inspect FILE, to list columns.'
 
   # The hint is a diagnostic, so it belongs on stderr with the error it explains.
   - name: keeps the hint off stdout and out of the exit code
@@ -217,3 +217,58 @@ scenarios:
           exit_code: 3
           stderr:
             contains: "download the file first and pass its local path"
+
+  # A mistyped name is what a failure most often is, and sqly knows what the
+  # names are: the helper commands are a fixed set, and the tables and columns
+  # are what it just imported. Naming the one a typo is one edit from turns a
+  # message that ends the run into one that finishes the sentence.
+  - name: names the helper command a mistyped one is a typo of
+    steps:
+      - fixture: &typo_users
+          file: users.csv
+          content: |
+            identifier,user_name
+            1,Alice
+      - run:
+          command: sqly users.csv
+          stdin: ".tabels\n"
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: 'Did you mean ".tables"?'
+
+  - name: names the column a mistyped one is a typo of
+    steps:
+      - fixture: *typo_users
+      - run:
+          command: sqly --sql "SELECT user_naem FROM users" users.csv
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: 'Did you mean "user_name"?'
+
+  - name: names the table a mistyped one is a typo of
+    steps:
+      - fixture: *typo_users
+      - run:
+          command: sqly --sql "SELECT 1 FROM uesrs" users.csv
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: 'Did you mean "users"?'
+
+  # A guess at a name nothing resembles is worse than no guess: it sends the
+  # reader after a name that was never the one they wanted. The advice that does
+  # not depend on guessing stays.
+  - name: does not guess at a name nothing resembles
+    steps:
+      - fixture: *typo_users
+      - run:
+          command: sqly --sql "SELECT zzzzzzzz FROM users" users.csv
+      - assert:
+          exit_code: 1
+          stderr:
+            not_contains: "Did you mean"
+      - assert:
+          stderr:
+            contains: ".describe"

--- a/shell/hint.go
+++ b/shell/hint.go
@@ -49,8 +49,7 @@ func (s *Shell) withMissingNameHint(ctx context.Context, err error) error {
 		return fmt.Errorf("%w\n%s", err, hint)
 	}
 	if name, ok := missingName(err.Error(), "no such column: "); ok {
-		hint := fmt.Sprintf("hint: no column %q. Run .describe TABLE in the shell, or sqly --inspect FILE, to list columns.", name)
-		return fmt.Errorf("%w\n%s", err, hint)
+		return fmt.Errorf("%w\n%s", err, s.missingColumnHint(ctx, name))
 	}
 	return err
 }
@@ -116,6 +115,53 @@ func (s *Shell) missingTableHint(ctx context.Context, missing string) (string, b
 	if len(names) > maxHintedTables {
 		listed = append(names[:maxHintedTables:maxHintedTables], fmt.Sprintf("... (%d total)", len(names)))
 	}
-	return fmt.Sprintf("hint: this session has no table %q. Available tables: %s. sqly derives table names from file names: %s",
-		missing, strings.Join(listed, ", "), tableNameRulesURL), true
+	sentences := []string{fmt.Sprintf("hint: this session has no table %q.", missing)}
+	if guess := didYouMean(missing, names); guess != "" {
+		sentences = append(sentences, guess)
+	}
+	sentences = append(sentences,
+		fmt.Sprintf("Available tables: %s.", strings.Join(listed, ", ")),
+		"sqly derives table names from file names: "+tableNameRulesURL)
+	return strings.Join(sentences, " "), true
+}
+
+// missingColumnHint is what to say about a column the engine could not find.
+//
+// The advice on its own — run .describe — asks the reader to do what the shell
+// can already do: it holds every column of every table it imported, so a name
+// that is one typo from one of them can be named outright. The advice stays for
+// the names that are not, which is when listing the columns is the only answer
+// there is.
+//
+// The columns of every table are searched, in the order the metadata reports
+// them, because the message SQLite gives says which column is missing and not
+// which table was supposed to have it.
+func (s *Shell) missingColumnHint(ctx context.Context, missing string) string {
+	schema := s.schemaForCompletion(ctx)
+	var columns []string
+	for _, table := range schema.tables {
+		columns = append(columns, schema.columns[table]...)
+	}
+
+	sentences := []string{fmt.Sprintf("hint: no column %q.", missing)}
+	if guess := didYouMean(missing, columns); guess != "" {
+		sentences = append(sentences, guess)
+	}
+	sentences = append(sentences, "Run .describe TABLE in the shell, or sqly --inspect FILE, to list columns.")
+	return strings.Join(sentences, " ")
+}
+
+// didYouMean is the sentence naming what a mistyped name is a typo of, or "" when
+// nothing is close enough. A guess at a name nothing resembles is worse than no
+// guess: it sends the reader after a name that was never the one they wanted.
+//
+// It is a sentence of its own rather than a clause, so a message can carry it
+// between what it already said and what it already advised, and so a message
+// that has no guess to offer reads exactly as it did before.
+func didYouMean(missing string, candidates []string) string {
+	nearest, ok := nearestName(missing, candidates)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("Did you mean %q?", nearest)
 }

--- a/shell/hint_didyoumean_test.go
+++ b/shell/hint_didyoumean_test.go
@@ -1,0 +1,116 @@
+package shell
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestUnknownCommandSuggestsTheNearestOne covers a mistyped dot-command. The
+// name is one of sixteen sqly already knows, so a typo in it has an answer the
+// shell can give rather than leaving the user to run .help and read.
+func TestUnknownCommandSuggestsTheNearestOne(t *testing.T) {
+	// Serial: newShell builds an in-memory DB and a temp history path.
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	tests := []struct {
+		name       string
+		input      string
+		wantSuffix string
+	}{
+		{name: "a swapped pair of letters names the command", input: ".tabels", wantSuffix: `Did you mean ".tables"?`},
+		{name: "a dropped letter names the command", input: ".modee", wantSuffix: `Did you mean ".mode"?`},
+		{name: "a command nothing resembles is not guessed at", input: ".zzzzzzzz", wantSuffix: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := s.dispatch(context.Background(), tt.input)
+			if err == nil {
+				t.Fatalf("dispatch(%q) succeeded, want an unknown-command error", tt.input)
+			}
+			if !strings.Contains(err.Error(), "no such sqly command") {
+				t.Fatalf("dispatch(%q) = %v, want an unknown-command error", tt.input, err)
+			}
+			if tt.wantSuffix == "" {
+				if strings.Contains(err.Error(), "Did you mean") {
+					t.Errorf("dispatch(%q) guessed at a command: %v", tt.input, err)
+				}
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantSuffix) {
+				t.Errorf("dispatch(%q) = %v, want it to contain %q", tt.input, err, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+// TestMissingTableHintSuggestsTheNearestTable covers a mistyped table name. The
+// hint already lists the session's tables, which answers "what is it called" for
+// a small session; naming the one that is a typo away answers it directly, and
+// for a session holding a table per sheet of a workbook the list is truncated
+// and the nearest name may not even be in it.
+func TestMissingTableHintSuggestsTheNearestTable(t *testing.T) {
+	// Serial: newShell builds an in-memory DB and a temp history path.
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	ctx := context.Background()
+	if err := s.commands.importCommand(ctx, s, []string{filepath.Join("testdata", "user.csv")}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	got := s.withMissingNameHint(ctx, errors.New(`SQL logic error: no such table: uesr (1)`))
+	if !strings.Contains(got.Error(), `Did you mean "user"?`) {
+		t.Errorf("hint for a mistyped table = %v, want it to name the table it is a typo of", got)
+	}
+
+	// A name nothing resembles still gets the list, and no guess.
+	got = s.withMissingNameHint(ctx, errors.New(`SQL logic error: no such table: zzzzzzzz (1)`))
+	if strings.Contains(got.Error(), "Did you mean") {
+		t.Errorf("hint guessed at a table nothing resembles: %v", got)
+	}
+	if !strings.Contains(got.Error(), "Available tables") {
+		t.Errorf("hint for an unrecognizable table dropped the list of what is there: %v", got)
+	}
+}
+
+// TestMissingColumnHintNamesTheNearestColumn covers a mistyped column name.
+// The hint used to say only "run .describe", which is a step the shell can take
+// itself: it holds every column of every table it has imported.
+func TestMissingColumnHintNamesTheNearestColumn(t *testing.T) {
+	// Serial: newShell builds an in-memory DB and a temp history path.
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	ctx := context.Background()
+	if err := s.commands.importCommand(ctx, s, []string{filepath.Join("testdata", "user.csv")}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	got := s.withMissingNameHint(ctx, errors.New(`SQL logic error: no such column: idnetifier (1)`))
+	if !strings.Contains(got.Error(), `Did you mean "identifier"?`) {
+		t.Errorf("hint for a mistyped column = %v, want it to name the column it is a typo of", got)
+	}
+
+	// A name nothing resembles keeps the advice that does not depend on guessing.
+	got = s.withMissingNameHint(ctx, errors.New(`SQL logic error: no such column: zzzzzzzz (1)`))
+	if strings.Contains(got.Error(), "Did you mean") {
+		t.Errorf("hint guessed at a column nothing resembles: %v", got)
+	}
+	if !strings.Contains(got.Error(), ".describe") {
+		t.Errorf("hint for an unrecognizable column dropped the advice: %v", got)
+	}
+}

--- a/shell/hint_didyoumean_test.go
+++ b/shell/hint_didyoumean_test.go
@@ -114,3 +114,35 @@ func TestMissingColumnHintNamesTheNearestColumn(t *testing.T) {
 		t.Errorf("hint for an unrecognizable column dropped the advice: %v", got)
 	}
 }
+
+// TestMissingColumnHintSeesAColumnAddedBySQL covers the hint against a warmed
+// completion cache. The hint reads the same cached schema completion does, and
+// that cache is keyed by the table-name set, which an ALTER TABLE ... ADD COLUMN
+// leaves untouched — so a stale cache would have the hint search the columns a
+// table had before the statement ran.
+func TestMissingColumnHintSeesAColumnAddedBySQL(t *testing.T) {
+	// Serial: newShell builds an in-memory DB and a temp history path.
+	s, cleanup, err := newShell(t, []string{"sqly"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	ctx := context.Background()
+	if err := s.exec(ctx, "CREATE TABLE t (alpha)"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	// Warm the cache, so the ALTER below has a stale entry to invalidate.
+	if got := completionTexts(s.getCompletions(ctx, "SELECT alph")); len(got) == 0 {
+		t.Fatal("the column alpha was not completed before the ALTER, so the cache was never warmed")
+	}
+
+	if err := s.exec(ctx, "ALTER TABLE t ADD COLUMN bravo"); err != nil {
+		t.Fatalf("ALTER TABLE: %v", err)
+	}
+
+	got := s.withMissingNameHint(ctx, errors.New(`SQL logic error: no such column: bravoo (1)`))
+	if !strings.Contains(got.Error(), `Did you mean "bravo"?`) {
+		t.Errorf("hint after ALTER TABLE ADD COLUMN = %v, want it to name the column just added", got)
+	}
+}

--- a/shell/nearest.go
+++ b/shell/nearest.go
@@ -1,0 +1,100 @@
+package shell
+
+import "strings"
+
+// nearestName returns the candidate closest to target, when one is close enough
+// to be worth offering as "did you mean". It reports false when nothing is.
+//
+// A typo is usually one slip: a letter dropped, doubled, mistyped, or two
+// letters swapped. The distance is therefore the optimal string alignment
+// variant of Levenshtein, which counts a swap as one edit rather than two —
+// ".tabels" for ".tables" and "naem" for "name" are both swaps, and both are
+// two edits away under plain Levenshtein, which is far enough that the
+// threshold would have to be loose enough to guess wildly at everything else.
+//
+// The comparison ignores case, because SQL identifiers do.
+//
+// Ties go to the first candidate, so the caller decides what wins by the order
+// it passes them in: a column of the table the statement names should be
+// offered before one that merely exists in the session.
+func nearestName(target string, candidates []string) (string, bool) {
+	limit := nearestLimit(len([]rune(target)))
+	if limit == 0 {
+		return "", false
+	}
+
+	best, bestDistance := "", limit+1
+	for _, candidate := range candidates {
+		d := osaDistance(strings.ToLower(target), strings.ToLower(candidate))
+		if d < bestDistance {
+			best, bestDistance = candidate, d
+		}
+	}
+	if bestDistance > limit {
+		return "", false
+	}
+	return best, true
+}
+
+// nearestLimit is how far a candidate may be from a word of n runes and still
+// be offered. A short word turns into another short word in one edit — "id" is
+// one edit from "is", "in", and "a" — so guessing at one says nothing, and the
+// limit for those is no guess at all.
+func nearestLimit(n int) int {
+	switch {
+	case n <= 2:
+		return 0
+	case n <= 4:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// osaDistance is the optimal string alignment distance between a and b: the
+// number of insertions, deletions, substitutions, and swaps of two adjacent
+// runes needed to turn one into the other.
+//
+// It is the restricted edit distance, not the full Damerau-Levenshtein one: a
+// substring is never edited twice, so "ca" to "abc" costs three here and two
+// there. The difference needs two overlapping swaps to appear, which is not a
+// typo anyone makes in one word, and the restricted form needs two rows of
+// memory rather than a full matrix.
+func osaDistance(a, b string) int {
+	ar, br := []rune(a), []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+
+	// prev2, prev and cur are the rows for i-2, i-1 and i of the matrix. Only
+	// three are ever live: prev2 is what a swap looks back at.
+	prev2 := make([]int, len(br)+1)
+	prev := make([]int, len(br)+1)
+	cur := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(ar); i++ {
+		cur[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			cur[j] = min(
+				prev[j]+1,      // delete
+				cur[j-1]+1,     // insert
+				prev[j-1]+cost, // substitute
+			)
+			if i > 1 && j > 1 && ar[i-1] == br[j-2] && ar[i-2] == br[j-1] {
+				cur[j] = min(cur[j], prev2[j-2]+1) // swap two adjacent runes
+			}
+		}
+		prev2, prev, cur = prev, cur, prev2
+	}
+	return prev[len(br)]
+}

--- a/shell/nearest_test.go
+++ b/shell/nearest_test.go
@@ -1,0 +1,197 @@
+package shell
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// TestOSADistance pins the edit distance, including the swap that plain
+// Levenshtein charges twice. A swap is the typo a "did you mean" most needs to
+// catch, so charging it as one edit is what lets the threshold stay tight.
+func TestOSADistance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{name: "identical strings are zero apart", a: "name", b: "name", want: 0},
+		{name: "an empty string is as far as the other is long", a: "", b: "name", want: 4},
+		{name: "both empty are zero apart", a: "", b: "", want: 0},
+		{name: "one substitution is one edit", a: "nome", b: "name", want: 1},
+		{name: "one deletion is one edit", a: "nae", b: "name", want: 1},
+		{name: "one insertion is one edit", a: "namae", b: "name", want: 1},
+		{name: "two adjacent runes swapped is one edit", a: "naem", b: "name", want: 1},
+		{name: "a swap in a longer word is still one edit", a: "tabels", b: "tables", want: 1},
+		{name: "two separate typos are two edits", a: "nmea", b: "name", want: 2},
+		{name: "nothing in common costs the longer length", a: "xyz", b: "name", want: 4},
+		{name: "distance is symmetric", a: "name", b: "naem", want: 1},
+		{name: "multi-byte runes count as one each", a: "日本語", b: "日本", want: 1},
+		{name: "swapped multi-byte runes are one edit", a: "本日語", b: "日本語", want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := osaDistance(tt.a, tt.b); got != tt.want {
+				t.Errorf("osaDistance(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOSADistanceProperties checks the invariants a distance must hold over
+// random pairs: it is symmetric, zero only for equal strings, never longer than
+// the longer string, and never shorter than their difference in length. A
+// distance that breaks one of these would make "did you mean" offer nonsense.
+func TestOSADistanceProperties(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewSource(20260831)) //nolint:gosec // reproducible test input, not security
+	alphabet := []rune("abc日")
+
+	for i := range 3000 {
+		a := randomWord(rng, alphabet, 6)
+		b := randomWord(rng, alphabet, 6)
+
+		d := osaDistance(a, b)
+		switch {
+		case d != osaDistance(b, a):
+			t.Fatalf("case %d: osaDistance(%q, %q) is not symmetric", i, a, b)
+		case (d == 0) != (a == b):
+			t.Fatalf("case %d: osaDistance(%q, %q) = %d, but the strings are %s", i, a, b, d, equalityWord(a == b))
+		case d > max(len([]rune(a)), len([]rune(b))):
+			t.Fatalf("case %d: osaDistance(%q, %q) = %d, longer than the longer string", i, a, b, d)
+		case d < abs(len([]rune(a))-len([]rune(b))):
+			t.Fatalf("case %d: osaDistance(%q, %q) = %d, shorter than their difference in length", i, a, b, d)
+		}
+	}
+}
+
+func randomWord(rng *rand.Rand, alphabet []rune, maxLen int) string {
+	var b strings.Builder
+	for range rng.Intn(maxLen + 1) {
+		b.WriteRune(alphabet[rng.Intn(len(alphabet))])
+	}
+	return b.String()
+}
+
+func equalityWord(equal bool) string {
+	if equal {
+		return "equal"
+	}
+	return "different"
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// TestNearestName covers what is offered and, as much, what is not: a guess at
+// a word nothing resembles is worse than no guess, because it sends the reader
+// after a name that was never the one they wanted.
+func TestNearestName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		target     string
+		candidates []string
+		want       string
+		wantOK     bool
+	}{
+		{
+			name:       "a swapped pair of letters is offered",
+			target:     "naem",
+			candidates: []string{"identifier", "name", "age"},
+			want:       "name",
+			wantOK:     true,
+		},
+		{
+			name:       "a dropped letter is offered",
+			target:     "tabels",
+			candidates: []string{"tables", "schema", "describe"},
+			want:       "tables",
+			wantOK:     true,
+		},
+		{
+			name:       "the match ignores case",
+			target:     "NAEM",
+			candidates: []string{"name"},
+			want:       "name",
+			wantOK:     true,
+		},
+		{
+			name:       "an exact name is its own nearest",
+			target:     "name",
+			candidates: []string{"name", "nome"},
+			want:       "name",
+			wantOK:     true,
+		},
+		{
+			name:       "a word nothing resembles is not guessed at",
+			target:     "zzzzzz",
+			candidates: []string{"name", "age", "city"},
+			wantOK:     false,
+		},
+		{
+			name:       "a word of two runes is too short to guess at",
+			target:     "id",
+			candidates: []string{"is", "in"},
+			wantOK:     false,
+		},
+		{
+			name:       "a short word gets one edit, not two",
+			target:     "namx",
+			candidates: []string{"name"},
+			want:       "name",
+			wantOK:     true,
+		},
+		{
+			name:       "a short word two edits away is not offered",
+			target:     "nmxe",
+			candidates: []string{"name"},
+			wantOK:     false,
+		},
+		{
+			name:       "no candidates means no guess",
+			target:     "name",
+			candidates: nil,
+			wantOK:     false,
+		},
+		{
+			name:       "the closer of two candidates wins",
+			target:     "naem",
+			candidates: []string{"nome", "name"},
+			want:       "name",
+			wantOK:     true,
+		},
+		{
+			name:       "a tie goes to the candidate offered first",
+			target:     "nam",
+			candidates: []string{"name", "nams"},
+			want:       "name",
+			wantOK:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := nearestName(tt.target, tt.candidates)
+			if ok != tt.wantOK {
+				t.Fatalf("nearestName(%q, %v) ok = %v, want %v (got %q)", tt.target, tt.candidates, ok, tt.wantOK, got)
+			}
+			if ok && got != tt.want {
+				t.Errorf("nearestName(%q, %v) = %q, want %q", tt.target, tt.candidates, got, tt.want)
+			}
+		})
+	}
+}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -1432,10 +1432,30 @@ func (s *Shell) dispatch(ctx context.Context, req string) error {
 		if s.commands.hasCmd(argv[0]) {
 			return s.commands[argv[0]].execute(ctx, s, argv[1:])
 		}
-		return errors.New("no such sqly command: " + color.CyanString(req))
+		msg := "no such sqly command: " + color.CyanString(req)
+		if guess := s.nearestCommand(argv[0]); guess != "" {
+			msg += ". " + guess
+		}
+		return errors.New(msg)
 	}
 
 	return s.execSQL(ctx, req)
+}
+
+// nearestCommand names the helper command a mistyped one is a typo of, or is
+// empty when nothing is close enough to offer. The set of names is small and
+// fixed, so a typo in one has an answer the shell can give rather than leaving
+// the reader to run .help and scan it.
+func (s *Shell) nearestCommand(typed string) string {
+	names := make([]string, 0, len(s.commands))
+	for _, c := range s.commands {
+		names = append(names, c.name)
+	}
+	// Sorted, so a typo equally far from two commands names the same one every
+	// time rather than whichever the map happened to yield first.
+	sort.Strings(names)
+
+	return didYouMean(typed, names)
 }
 
 // runScript runs a multi-statement script that prints to stdout.

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -760,10 +760,12 @@ hint: this session has no table "staf". Did you mean "staff"? Available tables: 
 Twenty names are listed; past that the list is cut and the total follows it as
 `... (N total)`. A missing column gets a line of the same kind, pointing at
 `.describe TABLE` and `sqly --inspect FILE`. A mistyped helper command is
-answered the same way. The name offered is the one a typo away — a letter
-dropped, doubled, mistyped, or two swapped — and nothing is offered when no
-name is that close. All are hints, not errors: stdout stays empty and the run
-still exits `1`.
+answered the same way. The name offered is the nearest by edit distance, where a
+letter dropped, doubled, mistyped, or two swapped each count as one edit: a name
+of five characters or more may be two edits away, a shorter one only one, and a
+name of two characters or fewer is never guessed at, being one edit from too much
+to mean anything. Nothing is offered when no name is that close. All are hints,
+not errors: stdout stays empty and the run still exits `1`.
 
 ## Exit codes
 

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -754,13 +754,16 @@ the ones it does, so a name that was derived rather than typed can be checked
 without a second run:
 
 ```text
-hint: this session has no table "staf". Available tables: ident, staff. sqly derives table names from file names: https://nao1215.github.io/sqly/reference/#table-name-rules
+hint: this session has no table "staf". Did you mean "staff"? Available tables: ident, staff. sqly derives table names from file names: https://nao1215.github.io/sqly/reference/#table-name-rules
 ```
 
 Twenty names are listed; past that the list is cut and the total follows it as
 `... (N total)`. A missing column gets a line of the same kind, pointing at
-`.describe TABLE` and `sqly --inspect FILE`. Both are hints, not errors: stdout
-stays empty and the run still exits `1`.
+`.describe TABLE` and `sqly --inspect FILE`. A mistyped helper command is
+answered the same way. The name offered is the one a typo away — a letter
+dropped, doubled, mistyped, or two swapped — and nothing is offered when no
+name is that close. All are hints, not errors: stdout stays empty and the run
+still exits `1`.
 
 ## Exit codes
 


### PR DESCRIPTION
A failure is most often a slip in a name, and sqly knows what the names are: the helper commands are a fixed set of sixteen, and the tables and their columns are what it has just imported. It said none of them.

```
$ printf '.tabels\n' | sqly data.csv
no such sqly command: .tabels

$ sqly --sql "SELECT user_naem FROM users" users.csv
hint: no column "user_naem". Run .describe TABLE in the shell, or sqly --inspect FILE, to list columns.
```

The column hint asks the reader to do what the shell can already do. The table hint does list what is there, which is the right answer for a small session, but it cuts the list at twenty — a session holding a table per sheet of a workbook may not have the name being looked for in it at all.

Each of the three now names the closest thing it knows, when one is close enough:

```
no such sqly command: .tabels. Did you mean ".tables"?
hint: no column "user_naem". Did you mean "user_name"? Run .describe TABLE in the shell, or sqly --inspect FILE, to list columns.
hint: this session has no table "staf". Did you mean "staff"? Available tables: ident, staff. sqly derives table names from file names: ...
```

Nothing is offered when no name is that close, because a guess at a name nothing resembles sends the reader after one that was never the one they wanted.

## Why this distance

The distance is the optimal string alignment variant of Levenshtein, which charges a swap of two adjacent characters as one edit rather than two. A swap is the typo this most needs to catch — `.tabels` for `.tables` and `naem` for `name` are both swaps — and under plain Levenshtein both are two edits away, far enough that the threshold would have to be loose enough to guess wildly at everything else.

Short words get a tighter threshold and words of two characters get none: `id` is one edit from `is`, `in`, and `a`, so a guess there says nothing. The comparison ignores case, because SQL identifiers do, and ties go to the candidate offered first, so the caller decides precedence by the order it passes them in.

## Wording

The suggestion is a sentence of its own, placed between what each message already said and what it already advised. A message with no guess to offer is therefore byte-identical to what it printed before, which is what keeps this from being a change to every error message rather than an addition to three.

`website/content/reference.md` and `e2e/atago/error_hygiene.atago.yaml` quote two of these messages verbatim and a drift test requires the two files to agree; both are updated, and the examples now show the suggestion.

## Tests

`shell/nearest_test.go` covers the distance (substitutions, insertions, deletions, swaps, multi-byte runes) and a property check over random pairs that it stays symmetric, zero only for equal strings, and bounded by the lengths. It also covers what `nearestName` declines to guess at, which is as much of the contract as what it offers.

`shell/hint_didyoumean_test.go` covers the three call sites through the shell, each with a name that gets a suggestion and one that does not. `e2e/atago/error_hygiene.atago.yaml` adds four scenarios against the real binary, including that a name nothing resembles keeps the advice and gets no guess.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Did you mean?” suggestions for mistyped helper commands, table names, and column names.
  - Suggestions recognize common typos, including dropped, doubled, substituted, or swapped letters.
  - No suggestion is shown when no sufficiently close match exists.

- **Documentation**
  - Updated reference documentation and examples to describe typo suggestions.

- **Tests**
  - Added coverage for command, table, and column suggestions, including cases without suitable matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->