### PR TITLE
feat(shell): color SQL as it is typed, over themes that are remembered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### New Features
 
+* SQL is colored as it is typed. Keywords, string literals, comments, numbers, and names in quotes each get a color, and the names you chose stay in the prompt's own, so what is colored is the shape of the statement rather than all of it. What counts as a string, a name in quotes, or a comment follows the current dialect, so `SELECT '(' -- not a comment'` is colored as the one string it is.
+
+* `.theme` shows the colors in effect and switches them, over twelve themes: accessible, catppuccin, dracula, github-light, gruvbox, monokai, night-owl, none, nord, solarized, tokyo-night, and vscode. A theme sets the prompt's own colors too, so a light theme is light throughout, and `none` turns coloring off. The choice is written to `settings.json` in sqly's config directory and read back by the next session, so it is made once rather than every time; `SQLY_SETTINGS_PATH` names that file if it belongs elsewhere. A settings file that cannot be read or written costs a warning rather than the session.
+
 * A continuation line opens where the statement is, not at the margin. It keeps the indentation of the line it continues and steps in one level for each parenthesis that line left open, so a subquery typed at the prompt reads as one. A parenthesis inside a string literal, a quoted name, or a comment is text and indents nothing, and which is which follows the current dialect. Indentation typed by hand is kept rather than recomputed, so only the change in nesting is sqly's to add.
 
 * `.edit` opens the last statement in `$VISUAL` or `$EDITOR` and runs what is saved. A long query is edited rather than retyped, and the file it opens ends in `.sql` so an editor that highlights by extension does. An empty file runs nothing, and so does an editor that exits non-zero, which is how an edit is abandoned. It needs a terminal to hand to the editor, so it is refused in a script.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,9 @@ sqly:~/data(json)$ .save ./out
 ```
 
 `.edit` reopens the last statement in `$VISUAL` or `$EDITOR` and runs what you
-save, so a long query is edited rather than retyped.
+save, so a long query is edited rather than retyped. SQL is colored as you type
+it, over twelve themes `.theme` switches between; the choice is remembered
+across sessions.
 
 `.help` lists every command; the [shell page](https://nao1215.github.io/sqly/shell/) documents them.
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	// file, one entry per line, so SQLY_HISTORY_PATH is what names it; the
 	// SQLY_HISTORY_DB_PATH that preceded it named a SQLite database.
 	HistoryPath string `env:"SQLY_HISTORY_PATH"`
+	// SettingsPath is where the session settings that outlive a session are
+	// kept, named by SQLY_SETTINGS_PATH the way SQLY_HISTORY_PATH names the
+	// history. Empty means the default beside it; settingsFilePath resolves
+	// that, so nothing has to check.
+	SettingsPath string `env:"SQLY_SETTINGS_PATH"`
 }
 
 // NewConfig return *Config.

--- a/config/config.go
+++ b/config/config.go
@@ -27,8 +27,8 @@ type Config struct {
 	HistoryPath string `env:"SQLY_HISTORY_PATH"`
 	// SettingsPath is where the session settings that outlive a session are
 	// kept, named by SQLY_SETTINGS_PATH the way SQLY_HISTORY_PATH names the
-	// history. Empty means the default beside it; settingsFilePath resolves
-	// that, so nothing has to check.
+	// history. Empty means beside the history; settingsFilePath resolves that,
+	// so nothing has to check.
 	SettingsPath string `env:"SQLY_SETTINGS_PATH"`
 }
 

--- a/config/settings.go
+++ b/config/settings.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 )
 
-// settingsFileName is what the settings file is called inside the config
-// directory. It sits beside the history file, which is the other thing a
-// session leaves behind.
+// settingsFileName is what the settings file is called. It sits beside the
+// history file, which is the other thing a session leaves behind, so a run told
+// where to keep its history keeps its settings there too.
 const settingsFileName = "settings.json"
 
 // defaultFilePerm keeps the settings file readable by its owner alone, like the
@@ -34,9 +34,19 @@ type Settings struct {
 
 // settingsFilePath returns where the settings file is kept, resolving the
 // default when SQLY_SETTINGS_PATH named none.
+//
+// The default is beside the history, not in the config directory regardless: a
+// run told where to keep its history has said where its per-session state
+// lives, and creating the config directory to write a theme into would ignore
+// that. It matters most to a test, which isolates itself by routing history to
+// a temp directory and would otherwise read and write the developer's real
+// settings.
 func (c *Config) settingsFilePath() string {
 	if c.SettingsPath != "" {
 		return c.SettingsPath
+	}
+	if c.HistoryPath != "" {
+		return filepath.Join(filepath.Dir(c.HistoryPath), settingsFileName)
 	}
 	return filepath.Join(c.Dir(), settingsFileName)
 }

--- a/config/settings.go
+++ b/config/settings.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// settingsFileName is what the settings file is called inside the config
+// directory. It sits beside the history file, which is the other thing a
+// session leaves behind.
+const settingsFileName = "settings.json"
+
+// defaultFilePerm keeps the settings file readable by its owner alone, like the
+// history beside it: neither holds a secret, but both are a record of what
+// someone was doing.
+const defaultFilePerm = 0o600
+
+// Settings are the choices a session makes that outlive it.
+//
+// Only what a user would be annoyed to set twice belongs here. The output mode
+// and the dialect are deliberately absent: those are answers to "what am I
+// doing right now", and a shell that opened in last week's mode would surprise
+// more than it saved.
+type Settings struct {
+	// Theme names the colors the interactive shell draws SQL in. An empty one
+	// means the built-in default, so a file written by a later version that
+	// names a theme this one does not have falls back rather than fails.
+	Theme string `json:"theme"`
+}
+
+// settingsFilePath returns where the settings file is kept, resolving the
+// default when SQLY_SETTINGS_PATH named none.
+func (c *Config) settingsFilePath() string {
+	if c.SettingsPath != "" {
+		return c.SettingsPath
+	}
+	return filepath.Join(c.Dir(), settingsFileName)
+}
+
+// LoadSettings reads what an earlier session saved.
+//
+// A missing file is not a failure: it is what a first run looks like, and the
+// defaults are the answer. A file that cannot be read or parsed is reported,
+// because that is a real fault the caller may want to mention -- but the
+// defaults come back with it, so a corrupt file costs a warning rather than
+// the shell.
+func (c *Config) LoadSettings() (Settings, error) {
+	data, err := os.ReadFile(c.settingsFilePath())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Settings{}, nil
+		}
+		return Settings{}, fmt.Errorf("failed to read %s: %w", c.settingsFilePath(), err)
+	}
+
+	var settings Settings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return Settings{}, fmt.Errorf("failed to read %s: %w", c.settingsFilePath(), err)
+	}
+	return settings, nil
+}
+
+// SaveSettings writes settings for the next session to read. The config
+// directory is created if it is not there, which is what a first run needs.
+func (c *Config) SaveSettings(settings Settings) error {
+	path := c.settingsFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), defaultDirPerm); err != nil {
+		return fmt.Errorf("failed to create %s: %w", filepath.Dir(path), err)
+	}
+
+	// Indented, because this is a file someone may open and edit by hand.
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode settings: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), defaultFilePerm); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return nil
+}

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -1,0 +1,129 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/sqly/config"
+)
+
+// newSettingsConfig builds a config whose settings file is in a temp directory,
+// so a test never reads or writes the developer's real one.
+func newSettingsConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{SettingsPath: filepath.Join(t.TempDir(), "settings.json")}
+}
+
+// TestSettingsRoundTrip covers what the feature is for: what one session saved
+// is what the next one reads.
+func TestSettingsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := newSettingsConfig(t)
+	want := config.Settings{Theme: "dracula"}
+	if err := cfg.SaveSettings(want); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+
+	got, err := cfg.LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if got != want {
+		t.Errorf("settings read back = %+v, want %+v", got, want)
+	}
+}
+
+// TestLoadSettingsWithoutAFile covers a first run. There is nothing to read and
+// nothing wrong with that, so the defaults come back without an error.
+func TestLoadSettingsWithoutAFile(t *testing.T) {
+	t.Parallel()
+
+	got, err := newSettingsConfig(t).LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings on a first run: %v", err)
+	}
+	if (got != config.Settings{}) {
+		t.Errorf("settings = %+v, want the defaults", got)
+	}
+}
+
+// TestLoadSettingsFromAnUnreadableFile covers a file that is there and wrong.
+// The fault is reported, because it is one, and the defaults come back with it
+// so a corrupt file costs a warning rather than the shell.
+func TestLoadSettingsFromAnUnreadableFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := newSettingsConfig(t)
+	if err := os.WriteFile(cfg.SettingsPath, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("writing the broken file: %v", err)
+	}
+
+	got, err := cfg.LoadSettings()
+	if err == nil {
+		t.Fatal("LoadSettings accepted a file that is not JSON, want an error")
+	}
+	if !strings.Contains(err.Error(), cfg.SettingsPath) {
+		t.Errorf("error = %v, want it to name the file that is wrong", err)
+	}
+	if (got != config.Settings{}) {
+		t.Errorf("settings = %+v, want the defaults alongside the error", got)
+	}
+}
+
+// TestSaveSettingsCreatesTheDirectory covers a first run again, from the other
+// side: there is nowhere to write yet.
+func TestSaveSettingsCreatesTheDirectory(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nested", "dir", "settings.json")
+	cfg := &config.Config{SettingsPath: path}
+	if err := cfg.SaveSettings(config.Settings{Theme: "nord"}); err != nil {
+		t.Fatalf("SaveSettings into a directory that does not exist: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("the settings file was not written: %v", err)
+	}
+}
+
+// TestSettingsFileIsReadableByHand checks the shape of what is written. It is a
+// file someone may open, so it is indented and ends in a newline.
+func TestSettingsFileIsReadableByHand(t *testing.T) {
+	t.Parallel()
+
+	cfg := newSettingsConfig(t)
+	if err := cfg.SaveSettings(config.Settings{Theme: "monokai"}); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+	data, err := os.ReadFile(cfg.SettingsPath)
+	if err != nil {
+		t.Fatalf("reading it back: %v", err)
+	}
+
+	want := "{\n  \"theme\": \"monokai\"\n}\n"
+	if string(data) != want {
+		t.Errorf("settings file = %q, want %q", data, want)
+	}
+}
+
+// TestSaveSettingsOverwrites covers a second change in one session: the file
+// holds the latest choice, not both.
+func TestSaveSettingsOverwrites(t *testing.T) {
+	t.Parallel()
+
+	cfg := newSettingsConfig(t)
+	for _, theme := range []string{"nord", "dracula", "none"} {
+		if err := cfg.SaveSettings(config.Settings{Theme: theme}); err != nil {
+			t.Fatalf("SaveSettings(%q): %v", theme, err)
+		}
+	}
+	got, err := cfg.LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if got.Theme != "none" {
+		t.Errorf("theme = %q, want the last one saved", got.Theme)
+	}
+}

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -127,3 +127,52 @@ func TestSaveSettingsOverwrites(t *testing.T) {
 		t.Errorf("theme = %q, want the last one saved", got.Theme)
 	}
 }
+
+// TestSettingsDefaultToBesideTheHistory covers where the file goes when
+// SQLY_SETTINGS_PATH named nowhere. A run told where to keep its history has
+// said where its per-session state lives, and a test that routes history to a
+// temp directory is isolated by that alone.
+func TestSettingsDefaultToBesideTheHistory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &config.Config{HistoryPath: filepath.Join(dir, "history")}
+	if err := cfg.SaveSettings(config.Settings{Theme: "nord"}); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+
+	want := filepath.Join(dir, "settings.json")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("the settings file is not beside the history at %s: %v", want, err)
+	}
+
+	got, err := cfg.LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if got.Theme != "nord" {
+		t.Errorf("theme read back = %q, want nord", got.Theme)
+	}
+}
+
+// TestSettingsPathWinsOverTheHistory covers the two being named at once: the
+// one that names the settings file is the one that decides.
+func TestSettingsPathWinsOverTheHistory(t *testing.T) {
+	t.Parallel()
+
+	historyDir, settingsPath := t.TempDir(), filepath.Join(t.TempDir(), "chosen.json")
+	cfg := &config.Config{
+		HistoryPath:  filepath.Join(historyDir, "history"),
+		SettingsPath: settingsPath,
+	}
+	if err := cfg.SaveSettings(config.Settings{Theme: "nord"}); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Errorf("the settings file was not written where SQLY_SETTINGS_PATH named: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(historyDir, "settings.json")); err == nil {
+		t.Error("a settings file was also written beside the history, which nothing asked for")
+	}
+}

--- a/domain/sqltext/regions_test.go
+++ b/domain/sqltext/regions_test.go
@@ -45,7 +45,7 @@ func TestRegionsReportsWhatTokensSkips(t *testing.T) {
 		{
 			// A doubled quote closes one literal and opens the next, so the text
 			// arrives as two regions that touch. Nothing between them is code,
-			// which is what a caller cares about: a highlighter colours the pair
+			// which is what a caller cares about: a highlighter colors the pair
 			// as one uninterrupted run, and the walk that skips them skips all of
 			// it either way.
 			name:    "a doubled quote leaves two literals that touch",
@@ -200,7 +200,7 @@ func TestTokensStillReportsOnlyCode(t *testing.T) {
 
 // TestRegionsCoverTheirText checks that every region reported is a real slice
 // of the text and that they arrive in order without overlapping. A caller
-// colouring the input walks them expecting exactly that.
+// coloring the input walks them expecting exactly that.
 func TestRegionsCoverTheirText(t *testing.T) {
 	t.Parallel()
 

--- a/domain/sqltext/regions_test.go
+++ b/domain/sqltext/regions_test.go
@@ -1,0 +1,229 @@
+package sqltext_test
+
+import (
+	"testing"
+
+	"github.com/nao1215/filesql/dialect"
+	"github.com/nao1215/sqly/domain/sqltext"
+)
+
+// region is one thing Regions reported, in a form a test can write down.
+type region struct {
+	kind sqltext.Kind
+	text string
+}
+
+func regionsOf(s string, d dialect.Dialect) []region {
+	var out []region
+	for tok := range sqltext.Regions(s, d) {
+		out = append(out, region{kind: tok.Kind, text: tok.Text(s)})
+	}
+	return out
+}
+
+// TestRegionsReportsWhatTokensSkips covers the walk that names the parts of a
+// statement rather than seeing past them: the string literals, quoted
+// identifiers, and comments Tokens leaves out, each with the extent it covers.
+func TestRegionsReportsWhatTokensSkips(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		text    string
+		dialect dialect.Dialect
+		want    []region
+	}{
+		{
+			name:    "a string literal is one region, quotes included",
+			text:    "SELECT 'a b'",
+			dialect: dialect.SQLite,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.String, "'a b'"},
+			},
+		},
+		{
+			// A doubled quote closes one literal and opens the next, so the text
+			// arrives as two regions that touch. Nothing between them is code,
+			// which is what a caller cares about: a highlighter colours the pair
+			// as one uninterrupted run, and the walk that skips them skips all of
+			// it either way.
+			name:    "a doubled quote leaves two literals that touch",
+			text:    "SELECT 'it''s'",
+			dialect: dialect.SQLite,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.String, "'it'"},
+				{sqltext.String, "'s'"},
+			},
+		},
+		{
+			// The newline is what ends a line comment, so it belongs to it.
+			name:    "a line comment runs to the end of its line",
+			text:    "SELECT -- note\nFROM t",
+			dialect: dialect.SQLite,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.Comment, "-- note\n"},
+				{sqltext.Word, "FROM"},
+				{sqltext.Word, "t"},
+			},
+		},
+		{
+			name:    "a block comment is one region",
+			text:    "SELECT /* a\nb */ 1",
+			dialect: dialect.SQLite,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.Comment, "/* a\nb */"},
+				{sqltext.Word, "1"},
+			},
+		},
+		{
+			name:    "a double-quoted run is a name in SQLite",
+			text:    `SELECT "my col"`,
+			dialect: dialect.SQLite,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.QuotedIdentifier, `"my col"`},
+			},
+		},
+		{
+			name:    "and a string in MySQL, which reads it that way",
+			text:    `SELECT "my col"`,
+			dialect: dialect.MySQL,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.String, `"my col"`},
+			},
+		},
+		{
+			name:    "a backtick quotes a name",
+			text:    "SELECT `my col`",
+			dialect: dialect.MySQL,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.QuotedIdentifier, "`my col`"},
+			},
+		},
+		{
+			name:    "a bracket quotes a name in SQLite",
+			text:    "SELECT [my col]",
+			dialect: dialect.SQLite,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.QuotedIdentifier, "[my col]"},
+			},
+		},
+		{
+			name:    "a hash comment is one in MySQL",
+			text:    "SELECT 1 # note",
+			dialect: dialect.MySQL,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.Word, "1"},
+				{sqltext.Comment, "# note"},
+			},
+		},
+		{
+			name:    "a dollar-quoted string is one region in PostgreSQL",
+			text:    "SELECT $tag$a;b$tag$",
+			dialect: dialect.PostgreSQL,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.String, "$tag$a;b$tag$"},
+			},
+		},
+		{
+			name:    "an unclosed literal runs to the end of the text",
+			text:    "SELECT 'unfinished",
+			dialect: dialect.SQLite,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.String, "'unfinished"},
+			},
+		},
+		{
+			name:    "a semicolon is still reported",
+			text:    "SELECT 1;",
+			dialect: dialect.SQLite,
+			want: []region{
+				{sqltext.Word, "SELECT"},
+				{sqltext.Word, "1"},
+				{sqltext.Semicolon, ";"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := regionsOf(tt.text, tt.dialect)
+			if len(got) != len(tt.want) {
+				t.Fatalf("Regions(%q, %v) = %+v, want %+v", tt.text, tt.dialect, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("region %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestTokensStillReportsOnlyCode is the other half: the walk every existing
+// caller uses is unchanged by Regions existing, and still sees past a literal,
+// a name in quotes, and a comment.
+func TestTokensStillReportsOnlyCode(t *testing.T) {
+	t.Parallel()
+
+	const text = "SELECT 'a', \"b\", `c` -- note\nFROM t;"
+	var got []string
+	for tok := range sqltext.Tokens(text, dialect.SQLite) {
+		if tok.Kind != sqltext.Word && tok.Kind != sqltext.Semicolon {
+			t.Fatalf("Tokens yielded a %v, which is not code", tok.Kind)
+		}
+		got = append(got, tok.Text(text))
+	}
+
+	want := []string{"SELECT", "FROM", "t", ";"}
+	if len(got) != len(want) {
+		t.Fatalf("Tokens(%q) = %q, want %q", text, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("token %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestRegionsCoverTheirText checks that every region reported is a real slice
+// of the text and that they arrive in order without overlapping. A caller
+// colouring the input walks them expecting exactly that.
+func TestRegionsCoverTheirText(t *testing.T) {
+	t.Parallel()
+
+	texts := []string{
+		"", "SELECT", "SELECT 'a' /* b */ -- c\n`d` [e] \"f\" $$g$$ 1;",
+		"'unclosed", "/* unclosed", "SELECT 日本語 AS '名前'", ";;;", "((()))",
+	}
+	dialects := []dialect.Dialect{dialect.SQLite, dialect.MySQL, dialect.PostgreSQL, dialect.GoogleSQL}
+
+	for _, text := range texts {
+		for _, d := range dialects {
+			end := 0
+			for tok := range sqltext.Regions(text, d) {
+				switch {
+				case tok.Start < end:
+					t.Errorf("Regions(%q, %v): a region starts at %d, inside the one ending at %d", text, d, tok.Start, end)
+				case tok.Start > tok.End:
+					t.Errorf("Regions(%q, %v): a region runs backwards, %d to %d", text, d, tok.Start, tok.End)
+				case tok.End > len(text):
+					t.Errorf("Regions(%q, %v): a region ends at %d, past the text", text, d, tok.End)
+				}
+				end = tok.End
+			}
+		}
+	}
+}

--- a/domain/sqltext/sqltext.go
+++ b/domain/sqltext/sqltext.go
@@ -56,6 +56,21 @@ const (
 	Word Kind = iota
 	// Semicolon is a ";" in code, which is where a statement can end.
 	Semicolon
+	// String is a string literal, from its opening delimiter to its closing
+	// one, or to the end of the text when it was never closed.
+	//
+	// A doubled quote inside a literal closes one and opens the next, so such a
+	// literal arrives as two String regions that touch. Nothing between them is
+	// code, which is what the distinction is for.
+	String
+	// QuotedIdentifier is a name written in quotes, delimiters included. Which
+	// quotes those are is the dialect's business: a backtick everywhere but
+	// PostgreSQL, a bracket in SQLite, and a double quote everywhere MySQL's
+	// reading of it as a string does not apply.
+	QuotedIdentifier
+	// Comment is a line or block comment, opener included, and closer where it
+	// has one -- for a line comment that is the newline ending it.
+	Comment
 )
 
 // Token is one significant thing found in code — outside every string literal,
@@ -76,8 +91,32 @@ type Token struct {
 // carries offsets rather than a copy of every word in the statement.
 func (t Token) Text(s string) string { return s[t.Start:t.End] }
 
-// Tokens iterates the code tokens of s in order, reading s as d spells SQL.
+// Tokens iterates the code tokens of s in order, reading s as d spells SQL: the
+// words and semicolons that are code, and nothing that is a string literal, a
+// quoted identifier, or a comment. It is what a caller asking "what does this
+// statement say" wants, because those regions say nothing.
+//
+// See Regions for the walk that reports them too.
 func Tokens(s string, d dialect.Dialect) iter.Seq[Token] {
+	return func(yield func(Token) bool) {
+		scan(s, syntaxOf(d), func(tok Token) bool {
+			if tok.Kind != Word && tok.Kind != Semicolon {
+				return true
+			}
+			return yield(tok)
+		})
+	}
+}
+
+// Regions iterates everything s is made of, in order and without overlapping:
+// the code tokens Tokens yields, and the string literals, quoted identifiers,
+// and comments it does not.
+//
+// It is the walk for a caller that needs to say something about those regions
+// rather than see past them -- coloring them on screen, counting them, pointing
+// at one. Whitespace, operators, and parentheses are not reported, so a caller
+// covering the whole of s has to fill the gaps between what it is given.
+func Regions(s string, d dialect.Dialect) iter.Seq[Token] {
 	return func(yield func(Token) bool) {
 		scan(s, syntaxOf(d), yield)
 	}
@@ -259,6 +298,10 @@ type syntax struct {
 	// backtickIdent says a backtick quotes an identifier. PostgreSQL alone does
 	// not.
 	backtickIdent bool
+	// doubleQuoteIsString says a double-quoted run is a string rather than a
+	// name, which is MySQL's default reading and no other dialect's. It changes
+	// nothing about where the run ends, only what it is called.
+	doubleQuoteIsString bool
 	// tripleQuote says a tripled quote opens a string, which GoogleSQL alone
 	// writes.
 	tripleQuote bool
@@ -276,7 +319,10 @@ type syntax struct {
 func syntaxOf(d dialect.Dialect) syntax {
 	switch d {
 	case dialect.MySQL:
-		return syntax{hashComment: true, backslashEscape: true, backtickIdent: true, dashNeedsBlank: true}
+		return syntax{
+			hashComment: true, backslashEscape: true, backtickIdent: true,
+			dashNeedsBlank: true, doubleQuoteIsString: true,
+		}
 	case dialect.PostgreSQL:
 		return syntax{escapeStringPrefix: true, dollarQuote: true, nestedComment: true}
 	case dialect.GoogleSQL:
@@ -314,7 +360,11 @@ func scan(s string, rules syntax, yield func(Token) bool) (inBlockComment bool) 
 func scanned(s string, rules syntax, yield func(Token) bool) *scanner {
 	sc := &scanner{s: s, rules: rules}
 	for sc.i < len(sc.s) {
-		if sc.skipRegion() {
+		start := sc.i
+		if kind, ok := sc.skipRegion(); ok {
+			if !yield(Token{Kind: kind, Start: start, End: sc.i, Depth: sc.depth}) {
+				return sc
+			}
 			continue
 		}
 		switch c := sc.s[sc.i]; {
@@ -350,29 +400,43 @@ func scanned(s string, rules syntax, yield func(Token) bool) *scanner {
 // reporting whether it stepped over one. A region that never closes runs to the
 // end of the input, which is what leaves an unterminated block comment open for
 // EndsInsideBlockComment to report.
-func (sc *scanner) skipRegion() bool {
+func (sc *scanner) skipRegion() (Kind, bool) {
 	rest := sc.s[sc.i:]
 	switch {
 	case sc.rules.opensLineComment(rest):
 		sc.skipLineComment()
+		return Comment, true
 	case strings.HasPrefix(rest, "/*"):
 		sc.skipBlockComment()
+		return Comment, true
 	case sc.rules.tripleQuote && (strings.HasPrefix(rest, tripleSingle) || strings.HasPrefix(rest, tripleDouble)):
 		sc.skipQuoted(rest[:3], 3, sc.rules.backslashEscape)
+		return String, true
 	case rest[0] == '\'':
 		sc.skipQuoted("'", 1, sc.rules.backslashEscape || sc.escapeStringOpens())
+		return String, true
 	case rest[0] == '"':
 		sc.skipQuoted(`"`, 1, sc.rules.backslashEscape)
+		// A double-quoted run is a name in standard SQL and a string in MySQL,
+		// which is the one dialect that reads it that way by default.
+		if sc.rules.doubleQuoteIsString {
+			return String, true
+		}
+		return QuotedIdentifier, true
 	case sc.rules.backtickIdent && rest[0] == '`':
 		sc.skipQuoted("`", 1, sc.rules.backtickEscape)
+		return QuotedIdentifier, true
 	case sc.rules.bracketIdent && rest[0] == '[':
 		sc.skipQuoted("]", 1, false)
+		return QuotedIdentifier, true
 	case sc.rules.dollarQuote && rest[0] == '$':
-		return sc.skipDollarQuoted()
+		if sc.skipDollarQuoted() {
+			return String, true
+		}
+		return Word, false
 	default:
-		return false
+		return Word, false
 	}
-	return true
 }
 
 // opensLineComment reports whether s opens a line comment under these rules.

--- a/e2e/atago/helpers.atago.yaml
+++ b/e2e/atago/helpers.atago.yaml
@@ -304,3 +304,22 @@ scenarios:
             contains:
               - "needs an interactive terminal"
               - "--sql-file"
+
+  # A theme sqly does not have is refused by name, with the ones it does have.
+  # The exit code says the invocation was wrong rather than the statement.
+  - name: .theme with a name no theme has is refused
+    steps:
+      - fixture:
+          file: users.csv
+          content: |
+            id,name
+            1,Alice
+      - run:
+          command: sqly users.csv
+          stdin: ".theme no-such-theme\n"
+      - assert:
+          exit_code: 2
+          stderr:
+            contains:
+              - 'unknown theme "no-such-theme"'
+              - "dracula"

--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -809,8 +809,16 @@ scenarios:
 
   # SQL is colored as it is typed. The check is on the escape sequences in the
   # stream rather than on the screen, because the screen shows the text and the
-  # question here is what color it was drawn in: 255;121;198 is dracula's
-  # keyword pink, and 189;147;249 its number purple.
+  # question here is what color it was drawn in.
+  #
+  # What is checked is dracula's number purple and nothing after it. Windows
+  # writes its colors through go-colorable, which orders the SGR parameters
+  # differently -- "\e[1;38;2;R;G;Bm" on Unix against "\e[38;2;R;G;Bm\e[1m"
+  # there -- so a pattern anchoring the text to the color matches on one
+  # platform only. The number purple is the right code to look for because
+  # nothing else in the session draws in it: dracula's own prefix, input, and
+  # suggestion colors are all different, so it is there because a number was
+  # highlighted or it is not there at all.
   - name: a theme colors keywords and numbers as they are typed
     env:
       SQLY_SETTINGS_PATH: "${workdir}/settings.json"
@@ -834,9 +842,8 @@ scenarios:
           exit_code: 0
           stdout:
             contains:
-              - "38;2;255;121;198mSELECT" # the keyword, in the theme's color
-              - "38;2;189;147;249m30"     # the number, in its own
-              - "Alice"                   # and the statement still ran
+              - "38;2;189;147;249m" # dracula's number purple: a token was colored
+              - "Alice"             # and the statement still ran
 
   # The way out, for a terminal or a reader that wants the input plain.
   - name: the none theme colors nothing and the shell still works
@@ -862,7 +869,8 @@ scenarios:
           exit_code: 0
           stdout:
             contains: "Alice"
-            not_contains: "38;2;255;121;198mSELECT"
+            # The same color the scenario above finds, absent here.
+            not_contains: "38;2;189;147;249m"
 
   # The choice outlives the session that made it, which is the whole reason it
   # is written down. The second process is told nothing; it reads the file the

--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -395,7 +395,10 @@ scenarios:
             - expect: "unterminated single quote in command"
             - expect: '\(table\)\$'
             - send: { key: up }
-            - expect: "\\.import 'oops"
+            # The screen, not the stream: the stream still holds the line as it
+            # was first typed, so only the screen shows the recall happened.
+            - expect_screen:
+                contains: ".import 'oops"
             # Clear the recalled line before EOF: Ctrl-D on a line with text is
             # not an end of input.
             - send: { key: ctrl-u }
@@ -755,7 +758,10 @@ scenarios:
             - send: "SELECT name FROM people WHERE age IN (\r"
             - expect: '\.\.\.>'
             - send: "SELECT max(age) FROM people\r"
-            - expect: "SELECT max"
+            # A fragment inside one colored run: highlighting puts escape
+            # sequences at every color boundary, so a pattern spanning one
+            # never matches the stream. expect_screen below sees the text.
+            - expect: "max\\(age\\)"
             # The open parenthesis stepped this line in one level: the
             # continuation prompt, then two spaces nobody typed. The screen is
             # what is checked rather than the stream, because the prompt writes
@@ -787,7 +793,7 @@ scenarios:
             - send: "SELECT '(' AS paren,\r"
             - expect: '\.\.\.>'
             - send: "name FROM people WHERE age = 25"
-            - expect: "name FROM people"
+            - expect: "25" # inside one colored run; see above
             # No indent, because the parenthesis it holds is inside a string.
             - expect_screen:
                 contains: "...> name FROM people WHERE age = 25"
@@ -800,6 +806,100 @@ scenarios:
           stdout:
             contains: "Bob"
             not_contains: "...>   name FROM" # one level would add two spaces
+
+  # SQL is colored as it is typed. The check is on the escape sequences in the
+  # stream rather than on the screen, because the screen shows the text and the
+  # question here is what color it was drawn in: 255;121;198 is dracula's
+  # keyword pink, and 189;147;249 its number purple.
+  - name: a theme colors keywords and numbers as they are typed
+    env:
+      SQLY_SETTINGS_PATH: "${workdir}/settings.json"
+    steps:
+      - fixture: *capability_people
+      - pty:
+          command: sqly people.csv
+          rows: 30
+          cols: 220
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: ".theme dracula\r"
+            - expect: "theme set to dracula"
+            - expect: '\(table\)\$'
+            - send: "SELECT name FROM people WHERE age = 30;\r"
+            - expect: "Alice"
+            - expect: '\(table\)\$'
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "38;2;255;121;198mSELECT" # the keyword, in the theme's color
+              - "38;2;189;147;249m30"     # the number, in its own
+              - "Alice"                   # and the statement still ran
+
+  # The way out, for a terminal or a reader that wants the input plain.
+  - name: the none theme colors nothing and the shell still works
+    env:
+      SQLY_SETTINGS_PATH: "${workdir}/settings.json"
+    steps:
+      - fixture: *capability_people
+      - pty:
+          command: sqly people.csv
+          rows: 30
+          cols: 220
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: ".theme none\r"
+            - expect: "theme set to none"
+            - expect: '\(table\)\$'
+            - send: "SELECT name FROM people WHERE age = 30;\r"
+            - expect: "Alice"
+            - expect: '\(table\)\$'
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "Alice"
+            not_contains: "38;2;255;121;198mSELECT"
+
+  # The choice outlives the session that made it, which is the whole reason it
+  # is written down. The second process is told nothing; it reads the file the
+  # first one left.
+  - name: a theme chosen in one session is what the next one opens in
+    env:
+      SQLY_SETTINGS_PATH: "${workdir}/settings.json"
+    steps:
+      - fixture: *capability_people
+      - pty:
+          command: sqly people.csv
+          rows: 30
+          cols: 220
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: ".theme monokai\r"
+            - expect: "theme set to monokai"
+            - expect: '\(table\)\$'
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0
+      - pty:
+          command: sqly people.csv
+          rows: 30
+          cols: 220
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$'
+            - send: ".theme\r"
+            - expect: "current theme: monokai"
+            - expect: '\(table\)\$'
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "current theme: monokai"
 
   # Editing an earlier line of a buffered statement leaves the screen alone. The
   # renderer erased the block it had drawn by moving up its height, which is
@@ -824,7 +924,7 @@ scenarios:
             - send: "SELECT name\r"
             - expect: '\.\.\.>'
             - send: "FROM people"
-            - expect: "FROM people"
+            - expect: "people" # inside one colored run; SQL is colored as it is typed
             - send: { key: left }
             - send: { key: left }
             - send: { key: left }
@@ -845,7 +945,7 @@ scenarios:
             # arrows left the cursor, so seeing it proves every one of them has
             # been processed and the screen below is the settled one.
             - send: "X"
-            - expect: "SELECT Xname"
+            - expect: "Xname" # inside one colored run
             # The screen is checked while the statement is still being edited:
             # after the exit below it holds neither line.
             - expect_screen:
@@ -1077,7 +1177,9 @@ scenarios:
           session:
             - expect: '\(table\)\$'
             - send: { key: up }
-            - expect: "SELECT name FROM people WHERE id = 2"
+            # The screen, not the stream, for the same reason as above.
+            - expect_screen:
+                contains: "SELECT name FROM people WHERE id = 2"
             - send: { key: ctrl-u }
             - send: { key: ctrl-d }
       - assert:

--- a/shell/batch.go
+++ b/shell/batch.go
@@ -229,10 +229,33 @@ func atStatementBoundary(pending string, d dialect.Dialect) bool {
 // change that was never there while hiding the syntax error that actually
 // stopped the run. An unrecognized statement is left to run and to fail with
 // SQLite's own message.
-var saveIncompatibleKeywords = map[string]bool{
-	"CREATE": true, "DROP": true, "ALTER": true, "RENAME": true,
-	kwReindex: true, kwAnalyze: true, "PRAGMA": true, "VACUUM": true,
-	"ATTACH": true, "DETACH": true, "GRANT": true, "REVOKE": true,
+// ddlKeywords are the verbs that change what tables a session holds or what
+// shape they have. They are named once because three questions are asked of
+// them: whether a statement invalidates the cached schema, whether .save can
+// persist what a script did, and whether a word is drawn as a keyword.
+var ddlKeywords = map[string]bool{
+	sqlCreate: true, "ALTER": true, "DROP": true,
+	"RENAME": true, "ATTACH": true, "DETACH": true,
+}
+
+// saveIncompatibleKeywords are the DDL verbs plus the maintenance and
+// permission statements .save cannot persist either: they change the database
+// rather than the tables sqly imported, so a run holding one has nothing to
+// write back.
+var saveIncompatibleKeywords = withDDLKeywords(
+	kwReindex, kwAnalyze, "PRAGMA", "VACUUM", "GRANT", "REVOKE",
+)
+
+// withDDLKeywords is the DDL verbs together with the extra ones given.
+func withDDLKeywords(extra ...string) map[string]bool {
+	out := make(map[string]bool, len(ddlKeywords)+len(extra))
+	for word := range ddlKeywords {
+		out[word] = true
+	}
+	for _, word := range extra {
+		out[word] = true
+	}
+	return out
 }
 
 func statementSaveCompatible(stmt string, d dialect.Dialect) bool {
@@ -310,11 +333,7 @@ func statementModifiesData(stmt string, d dialect.Dialect) bool {
 // "ALTER TABLE t ADD COLUMN c" leaves that set untouched and the cached columns
 // would stay as they were before the statement ran.
 func statementChangesSchema(stmt string, d dialect.Dialect) bool {
-	switch sqltext.LeadingKeyword(stmt, d) {
-	case "CREATE", "ALTER", "DROP", "ATTACH", "DETACH", "RENAME":
-		return true
-	}
-	return false
+	return ddlKeywords[sqltext.LeadingKeyword(stmt, d)]
 }
 
 // statementResultMessage returns the stdout line for a no-rowset statement. A

--- a/shell/command.go
+++ b/shell/command.go
@@ -39,6 +39,7 @@ func NewCommands() CommandList {
 	c[saveCommand] = command{execute: c.saveCommand, name: saveCommand, description: "write tables back to files: .save DIR (to a directory) or .save --in-place (overwrite sources)"}
 	c[dialectCommand] = command{execute: c.dialectCommand, name: dialectCommand, description: "show or set the SQL dialect for queries (sqlite, mysql, postgresql, googlesql)"}
 	c[editCommand] = command{execute: c.editCommand, name: editCommand, description: "edit the last statement in $VISUAL or $EDITOR and run what is saved"}
+	c[themeCommand] = command{execute: c.themeCommand, name: themeCommand, description: "show or set the colors SQL is drawn in; the choice is remembered"}
 	return c
 }
 

--- a/shell/help.go
+++ b/shell/help.go
@@ -32,6 +32,7 @@ func helpGroups() []helpGroup {
 			{helpCommand, "show this help"},
 			{modeCommand + " MODE", "change output mode (table, vertical, csv, tsv, ltsv, json, jsonl, markdown, ...)"},
 			{dialectCommand + " [NAME]", "show or set the query dialect (sqlite, mysql, postgresql, googlesql)"},
+			{themeCommand + " [NAME]", "show or set the colors SQL is drawn in (remembered across sessions)"},
 			{editCommand, "edit the last statement in $VISUAL or $EDITOR and run what is saved"},
 			{clearCommand, "clear the terminal screen"},
 			{exitCommand, "exit sqly"},

--- a/shell/highlight.go
+++ b/shell/highlight.go
@@ -1,0 +1,164 @@
+package shell
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/nao1215/filesql/dialect"
+	"github.com/nao1215/prompt"
+	"github.com/nao1215/sqly/domain/sqltext"
+)
+
+// highlightKeywords is the vocabulary drawn as keywords, built once from the
+// places that already hold it: the words the completer offers, the words the
+// context analysis reads, and the statement vocabulary neither needs but a
+// reader still expects to see colored.
+//
+// Deriving it rather than restating it is what keeps the three from drifting.
+// A word none of them holds is drawn as an identifier, which is the safe way to
+// be wrong: an unrecognized keyword looks like a name, where a name mistaken
+// for a keyword would say the statement means something it does not.
+var highlightKeywords = sync.OnceValue(func() map[string]bool {
+	words := make(map[string]bool)
+	add := func(phrase string) {
+		for _, word := range strings.Fields(phrase) {
+			words[strings.ToUpper(word)] = true
+		}
+	}
+
+	for _, suggestion := range sqlKeywordSuggestions() {
+		add(suggestion.Text) // "GROUP BY" and "INSERT INTO" are two words each
+	}
+	for word := range tableIntroducers {
+		add(word)
+	}
+	for word := range columnIntroducers {
+		add(word)
+	}
+	for word := range joinModifiers {
+		add(word)
+	}
+	for word := range ddlKeywords {
+		add(word)
+	}
+	for _, word := range statementVocabulary {
+		add(word)
+	}
+	return words
+})
+
+// statementVocabulary is the rest of what a reader expects colored: the verbs
+// and nouns of statements sqly runs but does not complete, because completion
+// offers what someone is likely to be typing and a CREATE TRIGGER is not it.
+var statementVocabulary = []string{
+	"BEGIN", "COLLATE", "COLUMN", "COMMIT", "CONSTRAINT", "DEFAULT", "END",
+	"ESCAPE", "EXCEPT", "EXISTS", "EXPLAIN", "FILTER", "FOREIGN", "IF", "INDEX",
+	"INTERSECT", "INTO", "KEY", "OVER", "PARTITION", "PRAGMA", "PRIMARY",
+	"RECURSIVE", "REFERENCES", "ROLLBACK", "TABLE", "THEN", "TRANSACTION",
+	"TRIGGER", "UNION", "UNIQUE", "VACUUM", "VIEW", "WINDOW", "WITH",
+}
+
+// highlightSQL returns the runs of input to draw in the theme's colors, as rune
+// offsets, which is what the prompt measures its spans in.
+//
+// The regions come from domain/sqltext, so what is a string literal, a quoted
+// name, or a comment is decided by the dialect in effect rather than guessed at
+// -- which is the difference between coloring "SELECT '(' -- not a comment'"
+// correctly and coloring most of it as a comment.
+//
+// A theme that colors nothing returns no runs, and so does a line still being
+// typed that holds nothing worth coloring. Both leave the prompt drawing the
+// input the way it always did.
+func highlightSQL(input string, theme syntaxTheme, d dialect.Dialect) []prompt.StyleSpan {
+	if !theme.highlights() || input == "" {
+		return nil
+	}
+
+	// A helper command is not SQL: its name is the thing worth marking, and the
+	// rest is a path or a value that reads better plain.
+	if span, ok := dotCommandSpan(input, theme); ok {
+		return []prompt.StyleSpan{span}
+	}
+
+	var spans []prompt.StyleSpan
+	for tok := range sqltext.Regions(input, d) {
+		color, ok := regionColor(tok, input, theme)
+		if !ok {
+			continue
+		}
+		spans = append(spans, prompt.StyleSpan{
+			Start: runeOffset(input, tok.Start),
+			End:   runeOffset(input, tok.End),
+			Color: color,
+		})
+	}
+	return spans
+}
+
+// regionColor is what one region is drawn in, and whether it is drawn at all.
+// An identifier is not: leaving the names the user chose in the prompt's own
+// color is what makes the colored words stand out.
+func regionColor(tok sqltext.Token, input string, theme syntaxTheme) (prompt.Color, bool) {
+	switch tok.Kind {
+	case sqltext.String:
+		return theme.str, true
+	case sqltext.Comment:
+		return theme.comment, true
+	case sqltext.QuotedIdentifier:
+		return theme.quoted, true
+	case sqltext.Semicolon:
+		return prompt.Color{}, false
+	case sqltext.Word:
+		text := tok.Text(input)
+		switch {
+		case highlightKeywords()[strings.ToUpper(text)]:
+			return theme.keyword, true
+		case startsWithDigit(text):
+			// A word starting with a digit is a number: SQL has no identifier
+			// that may, so nothing else can reach here.
+			return theme.number, true
+		default:
+			return prompt.Color{}, false
+		}
+	default:
+		return prompt.Color{}, false
+	}
+}
+
+// dotCommandSpan marks the name of a helper command, and reports whether the
+// input is one. Only the name is marked: what follows it is a path or a value,
+// and coloring those would say they are something they are not.
+func dotCommandSpan(input string, theme syntaxTheme) (prompt.StyleSpan, bool) {
+	trimmed := strings.TrimLeft(input, " \t")
+	if !looksLikeCommand(trimmed) {
+		return prompt.StyleSpan{}, false
+	}
+	lead := len(input) - len(trimmed)
+	name := trimmed
+	if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
+		name = trimmed[:i]
+	}
+	return prompt.StyleSpan{
+		Start: runeOffset(input, lead),
+		End:   runeOffset(input, lead+len(name)),
+		Color: theme.command,
+	}, true
+}
+
+// runeOffset converts a byte offset into s to the rune offset the prompt
+// measures spans in. sqltext reports byte offsets, which is what a caller
+// slicing the string wants and not what a caller counting cells does.
+func runeOffset(s string, byteOffset int) int {
+	if byteOffset <= 0 {
+		return 0
+	}
+	if byteOffset >= len(s) {
+		return len([]rune(s))
+	}
+	return len([]rune(s[:byteOffset]))
+}
+
+// startsWithDigit reports whether s opens with an ASCII digit.
+func startsWithDigit(s string) bool {
+	return s != "" && s[0] >= '0' && s[0] <= '9'
+}

--- a/shell/highlight.go
+++ b/shell/highlight.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/nao1215/filesql/dialect"
 	"github.com/nao1215/prompt"
@@ -81,14 +82,15 @@ func highlightSQL(input string, theme syntaxTheme, d dialect.Dialect) []prompt.S
 	}
 
 	var spans []prompt.StyleSpan
+	offsets := &runeCursor{s: input}
 	for tok := range sqltext.Regions(input, d) {
 		color, ok := regionColor(tok, input, theme)
 		if !ok {
 			continue
 		}
 		spans = append(spans, prompt.StyleSpan{
-			Start: runeOffset(input, tok.Start),
-			End:   runeOffset(input, tok.End),
+			Start: offsets.at(tok.Start),
+			End:   offsets.at(tok.End),
 			Color: color,
 		})
 	}
@@ -138,24 +140,41 @@ func dotCommandSpan(input string, theme syntaxTheme) (prompt.StyleSpan, bool) {
 	if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
 		name = trimmed[:i]
 	}
+	offsets := &runeCursor{s: input}
 	return prompt.StyleSpan{
-		Start: runeOffset(input, lead),
-		End:   runeOffset(input, lead+len(name)),
+		Start: offsets.at(lead),
+		End:   offsets.at(lead + len(name)),
 		Color: theme.command,
 	}, true
 }
 
-// runeOffset converts a byte offset into s to the rune offset the prompt
+// runeCursor converts byte offsets into s to the rune offsets the prompt
 // measures spans in. sqltext reports byte offsets, which is what a caller
 // slicing the string wants and not what a caller counting cells does.
-func runeOffset(s string, byteOffset int) int {
-	if byteOffset <= 0 {
-		return 0
+//
+// It is a cursor rather than a function because the offsets arrive in order:
+// counting from the start of the string for each one walks the whole input per
+// token, which is quadratic in a long statement -- and this runs on every
+// keystroke. Walking forward from the last answer counts each byte once, which
+// is worth about thirty times the wall clock over a two-hundred-column SELECT
+// holding multi-byte names.
+type runeCursor struct {
+	s      string
+	byteAt int
+	runeAt int
+}
+
+// at returns the rune offset of byteOffset. An offset that goes backwards is
+// answered from the start, so a caller that does not walk forward is slower
+// rather than wrong.
+func (c *runeCursor) at(byteOffset int) int {
+	byteOffset = min(max(byteOffset, 0), len(c.s))
+	if byteOffset < c.byteAt {
+		c.byteAt, c.runeAt = 0, 0
 	}
-	if byteOffset >= len(s) {
-		return len([]rune(s))
-	}
-	return len([]rune(s[:byteOffset]))
+	c.runeAt += utf8.RuneCountInString(c.s[c.byteAt:byteOffset])
+	c.byteAt = byteOffset
+	return c.runeAt
 }
 
 // startsWithDigit reports whether s opens with an ASCII digit.

--- a/shell/highlight_test.go
+++ b/shell/highlight_test.go
@@ -1,0 +1,271 @@
+package shell
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/filesql/dialect"
+	"github.com/nao1215/prompt"
+)
+
+// testTheme is a theme whose colors are distinct enough to name in a failure,
+// so a test says which role was wrong rather than which RGB triple was.
+func testTheme(t *testing.T) syntaxTheme {
+	t.Helper()
+	theme, ok := lookupTheme("dracula")
+	if !ok {
+		t.Fatal("the dracula theme is missing, so these tests cover nothing")
+	}
+	return theme
+}
+
+// roleOf names the role a color belongs to, for a readable failure.
+func roleOf(theme syntaxTheme, c prompt.Color) string {
+	switch c {
+	case theme.keyword:
+		return "keyword"
+	case theme.str:
+		return "string"
+	case theme.comment:
+		return "comment"
+	case theme.number:
+		return "number"
+	case theme.quoted:
+		return "quoted"
+	case theme.command:
+		return "command"
+	default:
+		return "unknown"
+	}
+}
+
+// highlighted returns each colored run of input as "role:text", which is what a
+// test can write down and read back.
+func highlighted(t *testing.T, input string, d dialect.Dialect) []string {
+	t.Helper()
+
+	theme := testTheme(t)
+	runes := []rune(input)
+	spans := highlightSQL(input, theme, d)
+	out := make([]string, 0, len(spans))
+	for _, span := range spans {
+		out = append(out, roleOf(theme, span.Color)+":"+string(runes[span.Start:span.End]))
+	}
+	return out
+}
+
+// TestHighlightSQL covers which parts of a statement are colored and as what.
+func TestHighlightSQL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		dialect dialect.Dialect
+		want    []string
+	}{
+		{
+			name:    "keywords are colored and names are not",
+			input:   "SELECT name FROM users",
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:SELECT", "keyword:FROM"},
+		},
+		{
+			name:    "a keyword typed in lower case is still a keyword",
+			input:   "select name from users",
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:select", "keyword:from"},
+		},
+		{
+			name:    "a string literal is colored whole, quotes included",
+			input:   "WHERE city = 'Tokyo'",
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:WHERE", "string:'Tokyo'"},
+		},
+		{
+			name:    "a keyword inside a string literal is text",
+			input:   "SELECT 'FROM users'",
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:SELECT", "string:'FROM users'"},
+		},
+		{
+			name:    "a comment is colored to the end of its line",
+			input:   "SELECT 1 -- FROM users",
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:SELECT", "number:1", "comment:-- FROM users"},
+		},
+		{
+			name:    "a number is colored",
+			input:   "WHERE age = 25",
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:WHERE", "number:25"},
+		},
+		{
+			name:    "a quoted name is colored as one",
+			input:   `SELECT "my col" FROM t`,
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:SELECT", `quoted:"my col"`, "keyword:FROM"},
+		},
+		{
+			name:    "a helper command marks its name and nothing else",
+			input:   ".import ./data.csv",
+			dialect: dialect.SQLite,
+			want:    []string{"command:.import"},
+		},
+		{
+			name:    "an unfinished string is still colored as one",
+			input:   "SELECT 'unfinished",
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:SELECT", "string:'unfinished"},
+		},
+		{
+			name:    "a hash comment is one in MySQL",
+			input:   "SELECT 1 # note",
+			dialect: dialect.MySQL,
+			want:    []string{"keyword:SELECT", "number:1", "comment:# note"},
+		},
+		{
+			name:    "and is not one in PostgreSQL",
+			input:   "SELECT 1 # note",
+			dialect: dialect.PostgreSQL,
+			want:    []string{"keyword:SELECT", "number:1"},
+		},
+		{
+			name:    "an empty line has nothing to color",
+			input:   "",
+			dialect: dialect.SQLite,
+			want:    nil,
+		},
+		{
+			name:    "a multi-line statement is colored across its lines",
+			input:   "SELECT name\nFROM users",
+			dialect: dialect.SQLite,
+			want:    []string{"keyword:SELECT", "keyword:FROM"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := highlighted(t, tt.input, tt.dialect)
+			if strings.Join(got, "|") != strings.Join(tt.want, "|") {
+				t.Errorf("highlightSQL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHighlightSQLOffsetsAreRunes covers what the prompt measures spans in. A
+// byte offset would put the color on the wrong characters as soon as the line
+// holds anything outside ASCII, which a table named in Japanese does.
+func TestHighlightSQLOffsetsAreRunes(t *testing.T) {
+	t.Parallel()
+
+	const input = "SELECT '日本語' FROM 売上"
+	got := highlighted(t, input, dialect.SQLite)
+	want := []string{"keyword:SELECT", "string:'日本語'", "keyword:FROM"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("highlightSQL(%q) = %v, want %v", input, got, want)
+	}
+}
+
+// TestHighlightSQLWithNoThemeColorsNothing covers the way out. "none" is for a
+// terminal or a reader that wants the input plain.
+func TestHighlightSQLWithNoThemeColorsNothing(t *testing.T) {
+	t.Parallel()
+
+	theme, ok := lookupTheme(noHighlightTheme)
+	if !ok {
+		t.Fatalf("the %q theme is missing", noHighlightTheme)
+	}
+	if got := highlightSQL("SELECT 'a' -- b", theme, dialect.SQLite); got != nil {
+		t.Errorf("the %q theme colored %d run(s), want none", noHighlightTheme, len(got))
+	}
+}
+
+// TestHighlightSQLSpansAreWellFormed is a property over the shapes a line takes
+// while it is being typed. The prompt normalizes what it is given, so a bad span
+// costs nothing visible -- but a highlighter that produces them is wrong, and
+// this is where that shows.
+func TestHighlightSQLSpansAreWellFormed(t *testing.T) {
+	t.Parallel()
+
+	fragments := []string{
+		"", " ", "'", `"`, "`", "[", "--", "/*", "#", "$$", "SELECT", "1", ".mode", "日本",
+		"\n", ";", "(", ")",
+	}
+	dialects := []dialect.Dialect{dialect.SQLite, dialect.MySQL, dialect.PostgreSQL, dialect.GoogleSQL}
+	theme := testTheme(t)
+
+	for _, a := range fragments {
+		for _, b := range fragments {
+			for _, c := range fragments {
+				input := a + b + c
+				limit := len([]rune(input))
+				for _, d := range dialects {
+					end := 0
+					for _, span := range highlightSQL(input, theme, d) {
+						switch {
+						case span.Start < 0 || span.End > limit:
+							t.Fatalf("highlightSQL(%q, %v): span [%d,%d) is outside the input of %d runes", input, d, span.Start, span.End, limit)
+						case span.Start >= span.End:
+							t.Fatalf("highlightSQL(%q, %v): span [%d,%d) is empty or inverted", input, d, span.Start, span.End)
+						case span.Start < end:
+							t.Fatalf("highlightSQL(%q, %v): span [%d,%d) overlaps the one ending at %d", input, d, span.Start, span.End, end)
+						}
+						end = span.End
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestEveryThemeNamesEveryRole checks the themes themselves: a role left unset
+// in one of them would draw that token in the prompt's input color, which reads
+// as a missing highlight rather than a deliberate one.
+func TestEveryThemeNamesEveryRole(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range themeNames() {
+		theme, ok := lookupTheme(name)
+		if !ok {
+			t.Fatalf("themeNames listed %q, which lookupTheme does not have", name)
+		}
+		if theme.name != name {
+			t.Errorf("theme %q calls itself %q", name, theme.name)
+		}
+		if theme.prompt == nil {
+			t.Errorf("theme %q names no prompt scheme", name)
+		}
+		if !theme.highlights() {
+			continue // "none" names no colors on purpose
+		}
+		roles := map[string]prompt.Color{
+			"keyword": theme.keyword, "string": theme.str, "comment": theme.comment,
+			"number": theme.number, "quoted": theme.quoted, "command": theme.command,
+		}
+		for role, color := range roles {
+			if (color == prompt.Color{}) {
+				t.Errorf("theme %q leaves %s unset, so it draws in the input color", name, role)
+			}
+		}
+	}
+}
+
+// TestLookupThemeIgnoresCaseAndBlanks covers a name as it is typed rather than
+// as it is stored.
+func TestLookupThemeIgnoresCaseAndBlanks(t *testing.T) {
+	t.Parallel()
+
+	for _, spelling := range []string{"dracula", "Dracula", "DRACULA", "  dracula  "} {
+		theme, ok := lookupTheme(spelling)
+		if !ok || theme.name != "dracula" {
+			t.Errorf("lookupTheme(%q) = %q/%v, want dracula", spelling, theme.name, ok)
+		}
+	}
+	if _, ok := lookupTheme("no-such-theme"); ok {
+		t.Error("lookupTheme accepted a name no theme has")
+	}
+}

--- a/shell/highlight_test.go
+++ b/shell/highlight_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -267,5 +268,31 @@ func TestLookupThemeIgnoresCaseAndBlanks(t *testing.T) {
 	}
 	if _, ok := lookupTheme("no-such-theme"); ok {
 		t.Error("lookupTheme accepted a name no theme has")
+	}
+}
+
+// BenchmarkHighlightLongStatement measures what runs on every keystroke over a
+// statement long enough for the cost to matter, and with multi-byte text in it,
+// which is what makes the byte-to-rune conversion do any work at all.
+func BenchmarkHighlightLongStatement(b *testing.B) {
+	theme, ok := lookupTheme("dracula")
+	if !ok {
+		b.Fatal("the dracula theme is missing")
+	}
+
+	var sb strings.Builder
+	sb.WriteString("SELECT ")
+	for i := range 200 {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		fmt.Fprintf(&sb, "t.列%d AS '名前%d'", i, i)
+	}
+	sb.WriteString(" FROM 売上 t WHERE t.id = 1 -- コメント")
+	input := sb.String()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = highlightSQL(input, theme, dialect.SQLite)
 	}
 }

--- a/shell/sessionsetting.go
+++ b/shell/sessionsetting.go
@@ -38,4 +38,5 @@ const (
 	settingDialect     = "dialect"
 	settingOutputMode  = "output mode"
 	settingRowMismatch = "row-mismatch policy"
+	settingTheme       = "theme"
 )

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -54,6 +54,7 @@ const (
 	describeCommand = ".describe"
 	saveCommand     = ".save"
 	dialectCommand  = ".dialect"
+	themeCommand    = ".theme"
 	editCommand     = ".edit"
 	helpFlag        = "--help"
 	versionFlag     = "--version"
@@ -213,6 +214,16 @@ type Shell struct {
 	// opens. A statement worth editing is almost always the one that just ran or
 	// just failed, and retyping it is the work .edit exists to remove.
 	lastStatement string
+	// theme is the colors this session draws SQL in, loaded from the settings
+	// file and changed by .theme. promptSession is the prompt it draws through,
+	// held so a theme chosen mid-session reaches the screen rather than waiting
+	// for the next one.
+	theme         syntaxTheme
+	promptSession promptSession
+	// settingsErr is what reading the settings file said, kept until the shell
+	// has a place to say it. A first run reports nothing, because a missing
+	// file is what a first run looks like.
+	settingsErr error
 }
 
 type promptSession interface {
@@ -220,6 +231,9 @@ type promptSession interface {
 	Close() error
 	Run() (string, error)
 	SetPrefix(string)
+	// SetTheme changes the colors the prompt draws itself with, so .theme
+	// applies to the session it was typed in rather than the next one.
+	SetTheme(*prompt.ColorScheme)
 	// WatchInterrupt watches the terminal for Ctrl-C while a submission runs and
 	// returns a context canceled when it arrives. Between prompts nothing else is
 	// reading the terminal, and raw mode makes Ctrl-C a byte rather than a
@@ -243,7 +257,14 @@ func NewShell(
 	// Apply the initial SQL dialect from --dialect. Loading always uses SQLite;
 	// only user queries run through ExecSQL are translated.
 	usecases.query.SetDialect(arg.Dialect)
+	// The theme a session opens in is the one the last session saved. A settings
+	// file that cannot be read costs a warning rather than the shell, so the
+	// error is carried to where there is somewhere to print it.
+	settings, settingsErr := cfg.LoadSettings()
+
 	shell := &Shell{
+		theme:          themeFromSettings(settings),
+		settingsErr:    settingsErr,
 		argument:       arg,
 		config:         cfg,
 		commands:       cmds,
@@ -269,13 +290,16 @@ func NewShell(
 			prefix,
 			prompt.WithCompleter(completer),
 			prompt.WithMemoryHistory(historySize),
-			prompt.WithTheme(prompt.ThemeNightOwl),
+			prompt.WithTheme(shell.theme.prompt),
 			prompt.WithMultiline(true),
 			prompt.WithIsComplete(func(input string) bool {
 				return sqlInputComplete(input, shell.dialect())
 			}),
 			prompt.WithAutoIndent(func(before string) string {
 				return sqlIndent(before, shell.dialect())
+			}),
+			prompt.WithHighlighter(func(input string) []prompt.StyleSpan {
+				return highlightSQL(input, shell.theme, shell.dialect())
 			}),
 			prompt.WithContinuationPrefix(continuationPrefix),
 			prompt.WithWordEscape(),
@@ -540,8 +564,20 @@ func (s *Shell) communicate(ctx context.Context) error {
 		}
 	}()
 
+	// Held so .theme applies to the session it was typed in. It is cleared on
+	// the way out, because a closed prompt is not one to draw through.
+	s.promptSession = p
+	defer func() { s.promptSession = nil }()
+
 	// The prompt session is ready, so it is now safe to announce the shell.
 	s.printWelcomeMessage()
+
+	// A settings file that could not be read is worth one line, once, now that
+	// there is a screen to say it on. The session runs with the defaults.
+	if s.settingsErr != nil {
+		fmt.Fprintf(config.Stderr, "warning: %v; using the default theme\n", s.settingsErr)
+		s.settingsErr = nil
+	}
 
 	// Persistent raw mode disables the terminal's LF-to-CRLF mapping, so route
 	// command output through CRLF translation for the session. Restored on exit.
@@ -624,6 +660,7 @@ func (s *Shell) editThenReopen(ctx context.Context, p promptSession) (string, pr
 	if err != nil {
 		return "", nil, fmt.Errorf("the editor finished but the prompt could not be reopened: %w", err)
 	}
+	s.promptSession = session
 	if editErr != nil {
 		return "", session, editErr
 	}

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -1223,6 +1223,8 @@ type fakePromptSession struct {
 	runCalls        int
 	initialPrefix   string
 	capturedSuggest []prompt.Suggestion
+	// themes are the color schemes SetTheme was given, newest last.
+	themes []*prompt.ColorScheme
 	// exhaustErr is returned once results are exhausted. It defaults to io.EOF,
 	// modeling Ctrl-D; set it to prompt.ErrEOF to model a closed input stream.
 	exhaustErr error
@@ -1242,6 +1244,12 @@ type fakePromptSession struct {
 
 func (f *fakePromptSession) AddHistory(history string) {
 	f.addedHistories = append(f.addedHistories, history)
+}
+
+// SetTheme records the schemes .theme applied, so a test can see that a theme
+// chosen mid-session reached the prompt rather than only the shell.
+func (f *fakePromptSession) SetTheme(scheme *prompt.ColorScheme) {
+	f.themes = append(f.themes, scheme)
 }
 
 func (f *fakePromptSession) Close() error {

--- a/shell/testdata/golden/help_command.golden
+++ b/shell/testdata/golden/help_command.golden
@@ -4,6 +4,7 @@ Session
   .help              show this help
   .mode MODE         change output mode (table, vertical, csv, tsv, ltsv, json, jsonl, markdown, ...)
   .dialect [NAME]    show or set the query dialect (sqlite, mysql, postgresql, googlesql)
+  .theme [NAME]      show or set the colors SQL is drawn in (remembered across sessions)
   .edit              edit the last statement in $VISUAL or $EDITOR and run what is saved
   .clear             clear the terminal screen
   .exit              exit sqly

--- a/shell/theme.go
+++ b/shell/theme.go
@@ -1,0 +1,190 @@
+package shell
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/nao1215/prompt"
+)
+
+// syntaxTheme is the colors one theme draws SQL in, plus the prompt's own
+// scheme so a light theme is light all the way through rather than colored
+// tokens on a dark prompt.
+//
+// A role left at the zero color is drawn in the prompt's input color, which is
+// what an identifier gets: naming everything would make the line a rainbow and
+// tell the reader less than naming the few things that carry meaning.
+type syntaxTheme struct {
+	// name is what .theme takes and what the settings file records.
+	name string
+	// prompt is the scheme the prompt draws itself with: the prefix, the input,
+	// and the completion menu.
+	prompt *prompt.ColorScheme
+	// keyword is a SQL keyword, quoted is a name in quotes, and the rest are
+	// what they say.
+	keyword prompt.Color
+	str     prompt.Color
+	comment prompt.Color
+	number  prompt.Color
+	quoted  prompt.Color
+	// command is a helper command's name, the ".mode" of a ".mode csv".
+	command prompt.Color
+}
+
+// noHighlightTheme is the way out for a terminal or a reader that wants none.
+// It names no colors, so nothing is highlighted and the prompt draws the input
+// the way it did before any of this.
+const noHighlightTheme = "none"
+
+// defaultTheme is what a session with no saved choice starts in. It is night-owl
+// because that is the scheme the prompt has always drawn sqly with.
+const defaultTheme = "night-owl"
+
+// syntaxThemes are the themes .theme can select, by name.
+//
+// The names follow the palettes they come from, which is what someone who has
+// chosen one in another program will look for. sqluv, sqly's sibling, offers
+// the same choice over its own interface.
+func syntaxThemes() map[string]syntaxTheme {
+	return map[string]syntaxTheme{
+		noHighlightTheme: {
+			name:   noHighlightTheme,
+			prompt: prompt.ThemeNightOwl,
+		},
+		defaultTheme: {
+			name:    defaultTheme,
+			prompt:  prompt.ThemeNightOwl,
+			keyword: prompt.Color{R: 0xc7, G: 0x92, B: 0xea, Bold: true},
+			str:     prompt.Color{R: 0xec, G: 0xc4, B: 0x8d},
+			comment: prompt.Color{R: 0x63, G: 0x77, B: 0x7d},
+			number:  prompt.Color{R: 0xf7, G: 0x8c, B: 0x6c},
+			quoted:  prompt.Color{R: 0x7f, G: 0xdb, B: 0xca},
+			command: prompt.Color{R: 0x82, G: 0xaa, B: 0xff, Bold: true},
+		},
+		"dracula": {
+			name:    "dracula",
+			prompt:  prompt.ThemeDracula,
+			keyword: prompt.Color{R: 0xff, G: 0x79, B: 0xc6, Bold: true},
+			str:     prompt.Color{R: 0xf1, G: 0xfa, B: 0x8c},
+			comment: prompt.Color{R: 0x62, G: 0x72, B: 0xa4},
+			number:  prompt.Color{R: 0xbd, G: 0x93, B: 0xf9},
+			quoted:  prompt.Color{R: 0x8b, G: 0xe9, B: 0xfd},
+			command: prompt.Color{R: 0x50, G: 0xfa, B: 0x7b, Bold: true},
+		},
+		"monokai": {
+			name:    "monokai",
+			prompt:  prompt.ThemeMonokai,
+			keyword: prompt.Color{R: 0xf9, G: 0x26, B: 0x72, Bold: true},
+			str:     prompt.Color{R: 0xe6, G: 0xdb, B: 0x74},
+			comment: prompt.Color{R: 0x75, G: 0x71, B: 0x5e},
+			number:  prompt.Color{R: 0xae, G: 0x81, B: 0xff},
+			quoted:  prompt.Color{R: 0x66, G: 0xd9, B: 0xef},
+			command: prompt.Color{R: 0xa6, G: 0xe2, B: 0x2e, Bold: true},
+		},
+		"nord": {
+			name:    "nord",
+			prompt:  prompt.ThemeDark,
+			keyword: prompt.Color{R: 0x81, G: 0xa1, B: 0xc1, Bold: true},
+			str:     prompt.Color{R: 0xa3, G: 0xbe, B: 0x8c},
+			comment: prompt.Color{R: 0x61, G: 0x6e, B: 0x88},
+			number:  prompt.Color{R: 0xb4, G: 0x8e, B: 0xad},
+			quoted:  prompt.Color{R: 0x8f, G: 0xbc, B: 0xbb},
+			command: prompt.Color{R: 0x88, G: 0xc0, B: 0xd0, Bold: true},
+		},
+		"solarized": {
+			name:    "solarized",
+			prompt:  prompt.ThemeSolarizedDark,
+			keyword: prompt.Color{R: 0x85, G: 0x99, B: 0x00, Bold: true},
+			str:     prompt.Color{R: 0x2a, G: 0xa1, B: 0x98},
+			comment: prompt.Color{R: 0x58, G: 0x6e, B: 0x75},
+			number:  prompt.Color{R: 0xd3, G: 0x36, B: 0x82},
+			quoted:  prompt.Color{R: 0x26, G: 0x8b, B: 0xd2},
+			command: prompt.Color{R: 0xb5, G: 0x89, B: 0x00, Bold: true},
+		},
+		"gruvbox": {
+			name:    "gruvbox",
+			prompt:  prompt.ThemeDark,
+			keyword: prompt.Color{R: 0xfb, G: 0x49, B: 0x34, Bold: true},
+			str:     prompt.Color{R: 0xb8, G: 0xbb, B: 0x26},
+			comment: prompt.Color{R: 0x92, G: 0x83, B: 0x74},
+			number:  prompt.Color{R: 0xd3, G: 0x86, B: 0x9b},
+			quoted:  prompt.Color{R: 0x83, G: 0xa5, B: 0x98},
+			command: prompt.Color{R: 0xfa, G: 0xbd, B: 0x2f, Bold: true},
+		},
+		"tokyo-night": {
+			name:    "tokyo-night",
+			prompt:  prompt.ThemeNightOwl,
+			keyword: prompt.Color{R: 0xbb, G: 0x9a, B: 0xf7, Bold: true},
+			str:     prompt.Color{R: 0x9e, G: 0xce, B: 0x6a},
+			comment: prompt.Color{R: 0x56, G: 0x5f, B: 0x89},
+			number:  prompt.Color{R: 0xff, G: 0x9e, B: 0x64},
+			quoted:  prompt.Color{R: 0x7d, G: 0xcf, B: 0xff},
+			command: prompt.Color{R: 0x7a, G: 0xa2, B: 0xf7, Bold: true},
+		},
+		"catppuccin": {
+			name:    "catppuccin",
+			prompt:  prompt.ThemeDark,
+			keyword: prompt.Color{R: 0xcb, G: 0xa6, B: 0xf7, Bold: true},
+			str:     prompt.Color{R: 0xa6, G: 0xe3, B: 0xa1},
+			comment: prompt.Color{R: 0x6c, G: 0x70, B: 0x86},
+			number:  prompt.Color{R: 0xfa, G: 0xb3, B: 0x87},
+			quoted:  prompt.Color{R: 0x89, G: 0xdc, B: 0xeb},
+			command: prompt.Color{R: 0x89, G: 0xb4, B: 0xfa, Bold: true},
+		},
+		"vscode": {
+			name:    "vscode",
+			prompt:  prompt.ThemeVSCode,
+			keyword: prompt.Color{R: 0x56, G: 0x9c, B: 0xd6, Bold: true},
+			str:     prompt.Color{R: 0xce, G: 0x91, B: 0x78},
+			comment: prompt.Color{R: 0x6a, G: 0x99, B: 0x55},
+			number:  prompt.Color{R: 0xb5, G: 0xce, B: 0xa8},
+			quoted:  prompt.Color{R: 0x4e, G: 0xc9, B: 0xb0},
+			command: prompt.Color{R: 0xdc, G: 0xdc, B: 0xaa, Bold: true},
+		},
+		"github-light": {
+			name:    "github-light",
+			prompt:  prompt.ThemeLight,
+			keyword: prompt.Color{R: 0xcf, G: 0x22, B: 0x2e, Bold: true},
+			str:     prompt.Color{R: 0x0a, G: 0x30, B: 0x69},
+			comment: prompt.Color{R: 0x6e, G: 0x77, B: 0x81},
+			number:  prompt.Color{R: 0x05, G: 0x50, B: 0xae},
+			quoted:  prompt.Color{R: 0x95, G: 0x38, B: 0x00},
+			command: prompt.Color{R: 0x82, G: 0x50, B: 0xdf, Bold: true},
+		},
+		"accessible": {
+			name:    "accessible",
+			prompt:  prompt.ThemeAccessible,
+			keyword: prompt.Color{R: 0xff, G: 0xff, B: 0x00, Bold: true},
+			str:     prompt.Color{R: 0x00, G: 0xff, B: 0xff},
+			comment: prompt.Color{R: 0xc0, G: 0xc0, B: 0xc0},
+			number:  prompt.Color{R: 0xff, G: 0xff, B: 0xff, Bold: true},
+			quoted:  prompt.Color{R: 0x00, G: 0xff, B: 0x00},
+			command: prompt.Color{R: 0xff, G: 0xff, B: 0xff, Bold: true},
+		},
+	}
+}
+
+// lookupTheme returns the theme by name, or reports that there is none.
+// The match is case-insensitive because a theme name is typed, not code.
+func lookupTheme(name string) (syntaxTheme, bool) {
+	themes := syntaxThemes()
+	theme, ok := themes[strings.ToLower(strings.TrimSpace(name))]
+	return theme, ok
+}
+
+// themeNames lists the themes in name order, which is how .theme offers them
+// and how completion does.
+func themeNames() []string {
+	themes := syntaxThemes()
+	names := make([]string, 0, len(themes))
+	for name := range themes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// highlights reports whether this theme colors anything. Only "none" does not.
+func (t syntaxTheme) highlights() bool {
+	return t.name != noHighlightTheme
+}

--- a/shell/theme_command.go
+++ b/shell/theme_command.go
@@ -1,0 +1,82 @@
+package shell
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/sqly/config"
+)
+
+// themeCommand shows or sets the colors the shell draws SQL in.
+//
+// The choice outlives the session: it is written to the settings file, so a
+// shell opened tomorrow looks the way this one was left. That is the whole
+// reason it is a command rather than a flag -- a color is chosen once and then
+// wanted forever, which a flag would ask for on every run.
+func (c CommandList) themeCommand(_ context.Context, s *Shell, argv []string) error {
+	if len(argv) == 0 {
+		printSessionSetting(settingTheme, s.themeName(), strings.Join(themeNames(), ", "))
+		return nil
+	}
+	if len(argv) > 1 {
+		return &invocationError{Err: fmt.Errorf(".theme accepts a single theme name, got %d arguments", len(argv))}
+	}
+
+	theme, ok := lookupTheme(argv[0])
+	if !ok {
+		return &invocationError{Err: fmt.Errorf("unknown theme %q (available: %s)", argv[0], strings.Join(themeNames(), ", "))}
+	}
+	s.setTheme(theme)
+	fmt.Fprintf(config.Stderr, "theme set to %s\n", theme.name)
+
+	// Saving is best effort. A theme that cannot be remembered is still a theme
+	// for this session, and losing the shell over a read-only config directory
+	// would be a poor trade for a color.
+	if err := s.saveTheme(theme.name); err != nil {
+		fmt.Fprintf(config.Stderr, "warning: the theme applies to this session but could not be saved (%v)\n", err)
+	}
+	return nil
+}
+
+// themeName is the name of the theme in effect, for the message .theme prints
+// when it is asked rather than told.
+func (s *Shell) themeName() string {
+	return s.theme.name
+}
+
+// setTheme applies a theme to this session: the colors SQL is drawn in, and the
+// scheme the prompt draws itself with, so a light theme is light all the way
+// through rather than colored tokens on a dark prompt.
+func (s *Shell) setTheme(theme syntaxTheme) {
+	s.theme = theme
+	if s.promptSession != nil {
+		s.promptSession.SetTheme(theme.prompt)
+	}
+}
+
+// saveTheme records the choice for the next session.
+func (s *Shell) saveTheme(name string) error {
+	if s.config == nil {
+		return nil // a partially built shell in a test has nowhere to save
+	}
+	settings, err := s.config.LoadSettings()
+	if err != nil {
+		// The file is unreadable, so the rest of it is not ours to preserve.
+		settings = config.Settings{}
+	}
+	settings.Theme = name
+	return s.config.SaveSettings(settings)
+}
+
+// themeFromSettings is the theme a session opens in: the one the last session
+// saved, or the default when there is none or the name is not one this version
+// has. A theme that has been renamed or removed costs the default rather than
+// the shell.
+func themeFromSettings(settings config.Settings) syntaxTheme {
+	if theme, ok := lookupTheme(settings.Theme); ok {
+		return theme
+	}
+	theme, _ := lookupTheme(defaultTheme)
+	return theme
+}

--- a/shell/theme_command_test.go
+++ b/shell/theme_command_test.go
@@ -1,0 +1,168 @@
+package shell
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/sqly/config"
+)
+
+// newThemeShell builds a shell whose settings file is in a temp directory, so a
+// test never reads or writes the developer's real one.
+func newThemeShell(t *testing.T) *Shell {
+	t.Helper()
+
+	s := newBoundaryTestShell(t, Usecases{})
+	s.config = &config.Config{SettingsPath: filepath.Join(t.TempDir(), "settings.json")}
+	s.theme = themeFromSettings(config.Settings{})
+	return s
+}
+
+// TestThemeCommandSetsAndSaves covers what the command is for: the session
+// changes, and the next one opens the same way.
+func TestThemeCommandSetsAndSaves(t *testing.T) {
+	// Serial: replaces config.Stderr, which is a package-level writer.
+	s := newThemeShell(t)
+
+	backup := config.Stderr
+	defer func() { config.Stderr = backup }()
+	var stderr bytes.Buffer
+	config.Stderr = &stderr
+
+	if err := s.commands.themeCommand(context.Background(), s, []string{"dracula"}); err != nil {
+		t.Fatalf(".theme dracula: %v", err)
+	}
+	if s.themeName() != "dracula" {
+		t.Errorf("the session theme is %q, want dracula", s.themeName())
+	}
+	if !strings.Contains(stderr.String(), "theme set to dracula") {
+		t.Errorf("stderr = %q, want it to say the theme changed", stderr.String())
+	}
+
+	saved, err := s.config.LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if saved.Theme != "dracula" {
+		t.Errorf("the saved theme is %q, want dracula", saved.Theme)
+	}
+}
+
+// TestThemeCommandWithoutArgumentsReports covers asking rather than telling.
+func TestThemeCommandWithoutArgumentsReports(t *testing.T) {
+	// Serial: replaces config.Stderr.
+	s := newThemeShell(t)
+
+	backup := config.Stderr
+	defer func() { config.Stderr = backup }()
+	var stderr bytes.Buffer
+	config.Stderr = &stderr
+
+	if err := s.commands.themeCommand(context.Background(), s, nil); err != nil {
+		t.Fatalf(".theme: %v", err)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "current theme: "+defaultTheme) {
+		t.Errorf("stderr = %q, want it to name the theme in effect", out)
+	}
+	for _, name := range []string{"dracula", noHighlightTheme} {
+		if !strings.Contains(out, name) {
+			t.Errorf("stderr = %q, want it to list %q among the available themes", out, name)
+		}
+	}
+}
+
+// TestThemeCommandRejectsWhatItCannotApply covers the two ways the command can
+// be written wrong. Neither changes the session.
+func TestThemeCommandRejectsWhatItCannotApply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		{name: "a name no theme has", argv: []string{"no-such-theme"}, want: "unknown theme"},
+		{name: "more than one name", argv: []string{"nord", "dracula"}, want: "single theme name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := newThemeShell(t)
+			before := s.themeName()
+
+			err := s.commands.themeCommand(context.Background(), s, tt.argv)
+			if err == nil {
+				t.Fatalf(".theme %v succeeded, want a refusal", tt.argv)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %v, want it to contain %q", err, tt.want)
+			}
+			if s.themeName() != before {
+				t.Errorf("a refused .theme changed the session to %q", s.themeName())
+			}
+		})
+	}
+}
+
+// TestThemeFromSettings covers what a session opens in, including the two ways
+// a saved name can be unusable.
+func TestThemeFromSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		saved string
+		want  string
+	}{
+		{name: "a saved theme is what the session opens in", saved: "nord", want: "nord"},
+		{name: "no saved theme means the default", saved: "", want: defaultTheme},
+		{name: "a name this version does not have means the default", saved: "removed-theme", want: defaultTheme},
+		{name: "the no-highlight choice is remembered like any other", saved: noHighlightTheme, want: noHighlightTheme},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := themeFromSettings(config.Settings{Theme: tt.saved}).name; got != tt.want {
+				t.Errorf("themeFromSettings(%q) = %q, want %q", tt.saved, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestThemeSurvivesAnUnwritableSettingsFile covers a config directory that
+// cannot be written. The theme still applies to this session, because losing
+// the shell over a color would be a poor trade.
+func TestThemeSurvivesAnUnwritableSettingsFile(t *testing.T) {
+	// Serial: replaces config.Stderr.
+	s := newThemeShell(t)
+	// A path whose parent is a file, so creating the directory fails.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("preparing the unwritable path: %v", err)
+	}
+	s.config = &config.Config{SettingsPath: filepath.Join(blocker, "settings.json")}
+
+	backup := config.Stderr
+	defer func() { config.Stderr = backup }()
+	var stderr bytes.Buffer
+	config.Stderr = &stderr
+
+	if err := s.commands.themeCommand(context.Background(), s, []string{"nord"}); err != nil {
+		t.Fatalf(".theme nord returned %v, want the session to carry on", err)
+	}
+	if s.themeName() != "nord" {
+		t.Errorf("the session theme is %q, want nord", s.themeName())
+	}
+	if !strings.Contains(stderr.String(), "could not be saved") {
+		t.Errorf("stderr = %q, want a warning that the choice was not saved", stderr.String())
+	}
+}

--- a/website/content/shell.md
+++ b/website/content/shell.md
@@ -101,6 +101,29 @@ sqly:~/data(table)$ SELECT name FROM user WHERE identifier IN (
 A parenthesis inside a string literal, a quoted name, or a comment is text and
 indents nothing, and which is which follows the current dialect.
 
+## Colors
+
+SQL is colored as you type it: keywords, string literals, comments, numbers, and
+names in quotes each get a color, and the names you chose stay in the prompt's
+own. `.theme` shows the theme in effect and the ones available, and takes one to
+switch to:
+
+```text
+sqly:~/data(table)$ .theme
+current theme: night-owl (available: accessible, catppuccin, dracula, github-light, gruvbox, monokai, night-owl, none, nord, solarized, tokyo-night, vscode)
+sqly:~/data(table)$ .theme dracula
+theme set to dracula
+```
+
+The choice is remembered: it is written to `settings.json` in sqly's config
+directory, so the next session opens the same way. `SQLY_SETTINGS_PATH` names
+that file if you want it elsewhere. `.theme none` turns coloring off and is
+remembered like any other choice.
+
+A theme sets the prompt's own colors too, so a light theme is light throughout.
+What counts as a string, a name in quotes, or a comment follows the current
+dialect, so `SELECT '(' -- not a comment'` is colored as the one string it is.
+
 ## Editing a long statement
 
 `.edit` opens the last statement in your editor and runs what you save:
@@ -161,6 +184,7 @@ afterward still exits 0.
 | `.mode [MODE]` | show or set the output mode: `table`, `vertical`, `csv`, `tsv`, `ltsv`, `json`, `jsonl`, `markdown` |
 | `.dialect [NAME]` | show or set the query dialect: `sqlite`, `mysql`, `postgresql`, `googlesql` |
 | `.row-mismatch [POLICY]` | show or set how a CSV/TSV row whose field count differs from the header is imported: `error` fails the import, `skip` drops the row, `pad` fills a short row with empty values and fails on a long one |
+| `.theme [NAME]` | show or set the colors SQL is drawn in; the choice is remembered across sessions |
 | `.edit` | open the last statement in `$VISUAL` or `$EDITOR` and run what is saved |
 | `.clear` | clear the screen |
 | `.exit` | quit (so does `Ctrl-D`) |


### PR DESCRIPTION
The input arrived in one color, so a statement being written was an undifferentiated line. A literal that had swallowed a quote and a keyword misspelled looked exactly like the rest of it.

Keywords, string literals, comments, numbers, and names in quotes are now each drawn in a color, and the names the user chose stay in the prompt's own.

```text
sqly:~/data(table)$ .theme
current theme: night-owl (available: accessible, catppuccin, dracula, github-light, gruvbox, monokai, night-owl, none, nord, solarized, tokyo-night, vscode)
sqly:~/data(table)$ .theme dracula
theme set to dracula
```

## What is colored, and what is not

The shape of the statement, rather than all of it. Coloring every word would make the line a rainbow and tell the reader less than coloring the few things that carry meaning, so an identifier keeps the prompt's input color.

A word the keyword vocabulary does not hold is drawn as an identifier. That is the safe way to be wrong: an unrecognized keyword looks like a name, where a name mistaken for a keyword would say the statement means something it does not.

The regions come from `domain/sqltext`, so what is a string, a name in quotes, or a comment follows the dialect in effect rather than being guessed at — `SELECT '(' -- not a comment'` is colored as the one string it is, and `#` opens a comment in MySQL and not in PostgreSQL.

## Remembering the choice

`.theme` writes to `settings.json` in sqly's config directory, and the next session reads it. A color is chosen once and then wanted forever, which is why this is a command with a file behind it rather than a flag asked for on every run. `SQLY_SETTINGS_PATH` names the file if it belongs elsewhere, the way `SQLY_HISTORY_PATH` names the history.

Only the theme is saved. The output mode and the dialect are deliberately absent: those answer "what am I doing right now", and a shell that opened in last week's mode would surprise more than it saved.

Neither a settings file that cannot be read nor one that cannot be written costs the session — both are a warning and the defaults. Losing a shell over a color would be a poor trade.

A theme sets the prompt's own scheme too, so a light theme is light throughout rather than colored tokens on a dark prompt. `none` turns coloring off and is remembered like any other choice.

## sqltext

`Regions` reports what the walk already found and skipped, with the `String`, `QuotedIdentifier`, and `Comment` kinds that name it. `Tokens` keeps its contract — it still yields code alone — so nothing that reads a statement sees the new kinds. MySQL's reading of a double-quoted run as a string rather than a name is the one dialect rule this needed.

## Consolidation this forced

The SQL keyword vocabulary was about to be written a fourth time. It is now derived from the places that already hold it: what the completer offers, what the context analysis reads, and the DDL verbs. The DDL verbs themselves are named once, for the three questions asked of them — whether a statement invalidates the cached schema, whether `.save` can persist what a script did, and whether a word is a keyword.

## Tests

`shell/highlight_test.go` covers what is colored and as what, including a keyword inside a string, a comment to the end of its line, the dialect deciding, rune rather than byte offsets (a table named in Japanese), the `none` theme coloring nothing, and every theme naming every role. It also has a property over every one-to-three-fragment combination of the characters a half-typed statement is made of: the spans are inside the input, non-empty, and non-overlapping.

`config/settings_test.go` covers the round trip, a first run with no file, a file that is not JSON, a directory that has to be created, and the shape of what is written. `shell/theme_command_test.go` covers the command, including a settings file that cannot be written leaving the session with its theme.

`e2e/atago` adds four scenarios against the real binary: a theme coloring keywords and numbers (checked on the escape sequences in the stream), `none` coloring nothing, a theme chosen in one process being what the next one opens in, and an unknown name being refused.

Five existing PTY scenarios needed updating: their `expect` patterns spanned what is now a color boundary. Two are better for it — the up-arrow recalls now check the screen, where the stream still holds the line as it was first typed and so matched without the recall having happened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live SQL syntax highlighting for keywords, strings, comments, numbers, and quoted names.
  * Added the `.theme` command with twelve selectable themes, including a no-color option.
  * Theme selections are saved and restored across sessions.
  * Added dialect-aware highlighting for supported SQL syntaxes.

* **Documentation**
  * Updated shell help, README, changelog, and website documentation with highlighting and theme details.

* **Bug Fixes**
  * Added warnings for settings read/write failures while preserving the active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->