### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Unreleased]
+## [v1.5.0](https://github.com/nao1215/sqly/compare/v1.4.0...v1.5.0) (2026-09-01)
 
 ### Bug Fixes
 
@@ -25,6 +25,16 @@
 * Ctrl+C while the completion menu is open no longer leaves the terminal without a cursor. sqly exits on the second Ctrl+C, and the shell it returned to had no cursor for the rest of that terminal's life.
 
 * A pasted statement longer than 64KB no longer makes the history file unreadable. sqly could not start again until the file was deleted by hand, because loading the history is part of opening the prompt.
+
+* `--dialect mysql`, `--dialect postgresql` and `--dialect googlesql` answer more of each dialect and refuse the rest by name. A GoogleSQL `SUBSTRING` or `POSITION`, a PostgreSQL `ANY_VALUE`, and a `RETURNING` clause's column names all reached SQLite in a shape it did not have, so the error named a function nobody wrote; a GoogleSQL bitwise aggregate, an `UPDATE` or `DELETE` carrying `ORDER BY` or `LIMIT`, a row-locking clause and an `ALTER TABLE` SQLite cannot make are now refused with a message saying which construct has no SQLite form and where it stands.
+
+* A file whose first line is blank loads its columns from the first line that holds something, whichever format it is. A CSV skipped the blank line, a TSV read it as a header of one empty column and refused every row after it, and a sheet whose top row was cleared or merely formatted opened as a database with no tables and no error at all.
+
+* An Excel cell loads the number the workbook stores rather than the number its format draws, so a percentage, a rounded currency figure or a value shown in scientific notation is queried and summed at full precision. `.save` to `.xlsx` keeps a column that holds whole numbers a REAL column.
+
+* A `.save` that the file's encoding cannot write names the column and the character it stopped on, and leaves the file it was going to overwrite as it was.
+
+* A completion candidate or a recalled statement holding an escape sequence is drawn rather than obeyed, the completion menu and the Ctrl+R block stay inside the terminal they are drawn on, and Ctrl+Right no longer stops between a letter and the accent on it.
 
 * The twelve themes drop the two colors the prompt never drew. `Cursor` and the completion menu's `Match` were set on every theme and had no effect on screen; the prompt has removed the fields, so `.theme` shows exactly what it changes.
 

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.28
-	github.com/nao1215/filesql v0.53.0
-	github.com/nao1215/prompt v0.0.27
+	github.com/nao1215/filesql v0.54.0
+	github.com/nao1215/prompt v0.0.28
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -58,10 +58,10 @@ github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE
 github.com/moov-io/iso4217 v0.4.0/go.mod h1:QvQE6pvu9KItHusChPLOJS10EhJnyQpcKHloIqHkQVM=
 github.com/moov-io/wire v0.16.1 h1:JbeIS8JcmJJuxkXVXG6uGt4xYfEwkYk7xKzf5VbP0yQ=
 github.com/moov-io/wire v0.16.1/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
-github.com/nao1215/filesql v0.53.0 h1:x/p015NFD7epkzxJbkc+mA/q0ZY55CtT7iPpwoCMgwU=
-github.com/nao1215/filesql v0.53.0/go.mod h1:9d2olsHF3uBjZSw/1xvIFWcAzIikcWOlVtHIWSJtTVg=
-github.com/nao1215/prompt v0.0.27 h1:gMCpPftUP4JOCnUnryq9RHoxKtuTwy8WxiPP9t1HYaM=
-github.com/nao1215/prompt v0.0.27/go.mod h1:vCduz5KRTOmRLh2ek9gb4OwZ96F28pbnky0R2QAEkHc=
+github.com/nao1215/filesql v0.54.0 h1:2K8iGd+t/GXkJvmtFplVpyMA7394aiVd8JOw0cHya6A=
+github.com/nao1215/filesql v0.54.0/go.mod h1:9d2olsHF3uBjZSw/1xvIFWcAzIikcWOlVtHIWSJtTVg=
+github.com/nao1215/prompt v0.0.28 h1:9tfdkob8Vvll+RgH5ljnFsG4267N5gw6xlpree7Ll2w=
+github.com/nao1215/prompt v0.0.28/go.mod h1:vCduz5KRTOmRLh2ek9gb4OwZ96F28pbnky0R2QAEkHc=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=


### PR DESCRIPTION
Cuts v1.5.0, taking filesql v0.54.0 and prompt v0.0.28 with it.

filesql v0.54.0 is thirty-one fixes, and what reaches a sqly user is in three places. `--dialect` answers more of each dialect and refuses the rest by name, where several constructs used to reach SQLite in a shape it did not have and fail with a message about a function nobody wrote. A file whose first line is blank loads its columns from the first line that holds something, so a CSV, a TSV and a workbook read the same bytes the same way -- a sheet whose top row was cleared used to open as a database with no tables and no error at all. An Excel cell loads the number the workbook stores rather than the number its format draws, `.save` to `.xlsx` keeps a REAL column REAL, and a save an encoding cannot write names the column and the character and leaves the file it was going to overwrite as it was.

prompt v0.0.28 covers the interactive shell: a completion candidate or a recalled statement holding an escape sequence is drawn rather than obeyed, the completion menu and the Ctrl+R block stay inside the terminal, Ctrl+Right keeps a combining mark with its letter, and the history file no longer loses entries a save did not carry.

Verified locally: build, unit tests, `make smoke`, and the atago suite -- 1027 behavior scenarios and 40 pty scenarios, all passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dialect handling for more consistent database behavior.
  - Fixed issues affecting data imports.
  - Resolved prompt-related problems for a smoother interactive experience.

- **Documentation**
  - Added release notes for version 1.5.0, documenting the latest fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->