### PR TITLE
test(e2e): discard the statement with Ctrl-C rather than Ctrl-U

### DIFF
--- a/e2e/atago/pty.atago.yaml
+++ b/e2e/atago/pty.atago.yaml
@@ -968,9 +968,15 @@ scenarios:
                 contains: ".help print usage, .exit exit sqly."
             - expect_screen:
                 contains: "...> FROM people"
-            # Ctrl-U clears the line so Ctrl-D is read as end of input rather
-            # than as a delete.
-            - send: { key: ctrl-u }
+            # Ctrl-C discards the whole statement, whichever of its lines the
+            # cursor is on, so Ctrl-D is read as end of input rather than as a
+            # delete. Ctrl-U was the key here, and it is the key whose scope
+            # over a multiline statement is the one thing about it worth
+            # arguing over -- readline clears the whole buffer, other line
+            # editors clear the line the cursor is on. This test does not need
+            # the answer: what it is about is the two lines above the prompt.
+            - send: { key: ctrl-c }
+            - expect: '\(table\)\$' # a fresh prompt, so the entry is gone
             - send: { key: ctrl-d }
       - assert:
           exit_code: 0


### PR DESCRIPTION
The pty scenario `editing an earlier line leaves the lines above the prompt alone` is about the two lines above the prompt: that editing a statement typed across several lines does not disturb the banner printed before it. It was ending by pressing Ctrl-U to clear the statement so that the Ctrl-D after it would be read as end of input.

That is the one key whose scope over a multiline statement is worth arguing over. readline's Ctrl-U kills the whole logical line, which for a buffer holding several is all of them; other line editors clear the line the cursor is on. nao1215/prompt#150 is that question, and this test does not need the answer.

Ctrl-C discards the statement whichever of its lines the cursor is on, and says so on screen, so the scenario now uses that and waits for the fresh prompt before the Ctrl-D that ends the session. `make test` and `make test-e2e` are green as they are, with the prompt version this repository pins: 1027 and 40 scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interactive editing behavior when canceling a buffered multi-line statement.
  - The session now confirms that the prompt returns cleanly after cancellation, ensuring discarded input does not remain pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->