### PR TITLE
chore(release): v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## [v1.6.2](https://github.com/nao1215/sqly/compare/v1.6.1...v1.6.2) (2026-09-02)
+
+### Bug Fixes
+
+* `CURRENT_TIMESTAMP` reads the clock under `--dialect mysql`, `postgresql` and `googlesql`. It answered the text `CURRENT_TIMESTAMP` instead, and `CURRENT_DATE` and `CURRENT_TIME` answered theirs, with no error: a query stamping rows with the current time wrote the same word into every row, and an export of that result carried the word rather than a time. Under `--dialect sqlite` it was always right.
+
+* `UTC_TIMESTAMP()`, `UTC_DATE()`, `UTC_TIME()` and `SYSDATE()` work under `--dialect mysql`, and `BINARY(x)` casts the way `BINARY x` already did. All five failed with "no such function", which reads as a typo in a query that was written correctly.
+
+* A function one of the dialects has and SQLite has not is refused by name with the reason, rather than failing as a name SQLite does not know. That covers about a hundred and fifty MySQL names and five hundred PostgreSQL ones -- the spatial functions, the data dictionary, the catalog and administration functions, sequences, large objects, XML, text search, ranges, network addresses, and the array and record functions. The message now says the function has no SQLite form here instead of saying it does not exist.
+
 ## [v1.6.1](https://github.com/nao1215/sqly/compare/v1.6.0...v1.6.1) (2026-09-02)
 
 ### Bug Fixes

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mattn/go-runewidth v0.0.28
-	github.com/nao1215/filesql v0.55.0
+	github.com/nao1215/filesql v0.56.0
 	github.com/nao1215/prompt v0.2.0
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE
 github.com/moov-io/iso4217 v0.4.0/go.mod h1:QvQE6pvu9KItHusChPLOJS10EhJnyQpcKHloIqHkQVM=
 github.com/moov-io/wire v0.16.1 h1:JbeIS8JcmJJuxkXVXG6uGt4xYfEwkYk7xKzf5VbP0yQ=
 github.com/moov-io/wire v0.16.1/go.mod h1:UQ0xtx/uE3jzokvi21n7tjLN3kEpwVJbBL0pVtxFDZs=
-github.com/nao1215/filesql v0.55.0 h1:WSWswd8DjJmF+PyVbBrUavy6ZSiosDALe6LaFktKDPk=
-github.com/nao1215/filesql v0.55.0/go.mod h1:9d2olsHF3uBjZSw/1xvIFWcAzIikcWOlVtHIWSJtTVg=
+github.com/nao1215/filesql v0.56.0 h1:tdUm1NXCtj+Y/jqfqsLYyBCS95DZQymSDKPxlxZZrPk=
+github.com/nao1215/filesql v0.56.0/go.mod h1:9d2olsHF3uBjZSw/1xvIFWcAzIikcWOlVtHIWSJtTVg=
 github.com/nao1215/prompt v0.2.0 h1:PmKD2bRF+cMlUg7QiOSEyqGoNMwRD+vJIbIO/NF/qjo=
 github.com/nao1215/prompt v0.2.0/go.mod h1:vCduz5KRTOmRLh2ek9gb4OwZ96F28pbnky0R2QAEkHc=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=


### PR DESCRIPTION
## Summary

Builds sqly on filesql v0.56.0, for one fix that is worth not waiting on: **`CURRENT_TIMESTAMP` answered the text `CURRENT_TIMESTAMP`** under `--dialect mysql`, `postgresql` and `googlesql`, and `CURRENT_DATE` and `CURRENT_TIME` answered theirs, with no error. A query stamping rows with the current time wrote the same word into every row, and an export of that result carried the word rather than a time. Under `--dialect sqlite` it was always right.

With it: `UTC_TIMESTAMP()`, `UTC_DATE()`, `UTC_TIME()`, `SYSDATE()` and `BINARY(x)` work under `--dialect mysql` where all five failed with "no such function", and about six hundred and fifty functions that one of the dialects has and SQLite has not are now refused by name with the reason instead of failing as names SQLite does not know.

sqly's own code is unchanged, so this is a patch.

## Verification

- `go test ./...` green
- `make smoke` green
- `make test-e2e` 1027 + 41 scenarios passed
- `sqly --dialect mysql --sql "SELECT CURRENT_TIMESTAMP AS t"` checked against the built binary for all three dialects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `CURRENT_TIMESTAMP` under MySQL, PostgreSQL, and GoogleSQL dialects so it returns the current time instead of literal text.
  - Fixed MySQL support for `UTC_TIMESTAMP()`, `UTC_DATE()`, `UTC_TIME()`, `SYSDATE()`, and `BINARY(x)`.
  - Improved handling of dialect-specific functions that SQLite does not support by reporting the function name and reason clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->